### PR TITLE
Add Snyk badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Code Style: Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=for-the-badge&logo=prettier)](https://github.com/prettier/prettier)
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/alehar9320/astro-cloudflare-personal-website/ci.yml?style=for-the-badge&logo=githubactions&logoColor=white)](https://github.com/alehar9320/astro-cloudflare-personal-website/actions)
 [![Codecov](https://img.shields.io/codecov/c/github/alehar9320/astro-cloudflare-personal-website?style=for-the-badge&logo=codecov)](https://codecov.io/gh/alehar9320/astro-cloudflare-personal-website)
+[![Snyk Vulnerabilities](https://img.shields.io/snyk/vulnerabilities/github/alehar9320/astro-cloudflare-personal-website?style=for-the-badge&logo=snyk&logoColor=white)](https://app.snyk.io/org/alehar9320/projects)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
 
 </div>


### PR DESCRIPTION
This change adds a Shields.io-style Snyk badge to the README.md file. The badge reflects the vulnerability status of the repository and links to the Snyk organization's project dashboard. It is styled to match the existing badges in the README.

---
*PR created automatically by Jules for task [8278795361627278833](https://jules.google.com/task/8278795361627278833) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Snyk Vulnerabilities status badge to the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->