### PR TITLE
chore: update release process to use GitHub Release API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,29 @@ jobs:
 
       - name: Increment Version & Generate Changelog
         run: node scripts/release.js
+        id: release
+
+      - name: Extract Release Info
+        run: |
+          VERSION=$(node -e "const now = new Date(); const YYYY = now.getUTCFullYear(); const MM = String(now.getUTCMonth() + 1).padStart(2, '0'); const DD = String(now.getUTCDate()).padStart(2, '0'); const HH = String(now.getUTCHours()).padStart(2, '0'); const mm = String(now.getUTCMinutes()).padStart(2, '0'); console.log(\`\${YYYY}.\${MM}.\${DD}.\${HH}\${mm}\`);")
+          echo "RELEASE_VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "RELEASE_CHANGELOG<<EOF" >> $GITHUB_ENV
+          cat CHANGELOG.md | head -50 >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Create Git Tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag ${{ env.RELEASE_VERSION }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_VERSION }}
+          body: ${{ env.RELEASE_CHANGELOG }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Project
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,8 +117,7 @@ jobs:
 
       - name: Extract Release Info
         run: |
-          VERSION=$(node -e "const now = new Date(); const YYYY = now.getUTCFullYear(); const MM = String(now.getUTCMonth() + 1).padStart(2, '0'); const DD = String(now.getUTCDate()).padStart(2, '0'); const HH = String(now.getUTCHours()).padStart(2, '0'); const mm = String(now.getUTCMinutes()).padStart(2, '0'); console.log(\`\${YYYY}.\${MM}.\${DD}.\${HH}\${mm}\`);")
-          echo "RELEASE_VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=${{ steps.release.outputs.version }}" >> $GITHUB_ENV
           echo "RELEASE_CHANGELOG<<EOF" >> $GITHUB_ENV
           cat CHANGELOG.md | head -50 >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,12 +122,6 @@ jobs:
           cat CHANGELOG.md | head -50 >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
-      - name: Create Git Tag
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag ${{ env.RELEASE_VERSION }}
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -72,6 +72,18 @@ try {
 
 fs.writeFileSync('CHANGELOG.md', changelogEntry + existingChangelog);
 
-// Output version for GitHub Release (workflow recalculates version and reads CHANGELOG.md)
+// Write outputs to GitHub Actions for workflow consumption
+const githubOutput = process.env.GITHUB_OUTPUT;
+if (githubOutput) {
+  try {
+    fs.appendFileSync(githubOutput, `version=${version}\n`);
+    fs.appendFileSync(githubOutput, `changelog=${encodeURIComponent(changelogEntry)}\n`);
+    console.log('Outputs written to GITHUB_OUTPUT');
+  } catch (e) {
+    console.warn(`Could not write to GITHUB_OUTPUT: ${e.message}`);
+  }
+}
+
+// Output version for GitHub Release
 console.log(`\n::notice title=Release Version::${version}`);
 console.log(`Successfully prepared version ${version}`);

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -72,19 +72,6 @@ try {
 
 fs.writeFileSync('CHANGELOG.md', changelogEntry + existingChangelog);
 
-// Output version and changelog for GitHub Release
-// Set output variables for workflow access using GitHub Actions format
-console.log(`\n::set-output name=version::${version}`);
-console.log(`\n::set-output name=changelog::${encodeURIComponent(changelogEntry)}`);
+// Output version for GitHub Release (workflow recalculates version and reads CHANGELOG.md)
 console.log(`\n::notice title=Release Version::${version}`);
-
-// Save changelog to a temporary file for workflow access
-const tempChangelogPath = '/tmp/changelog.txt';
-try {
-  fs.writeFileSync(tempChangelogPath, changelogEntry);
-  console.log(`Changelog saved to ${tempChangelogPath}`);
-} catch (e) {
-  console.warn(`Could not write changelog to temp file: ${e.message}`);
-}
-
 console.log(`Successfully prepared version ${version}`);

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -80,7 +80,8 @@ if (githubOutput) {
     fs.appendFileSync(githubOutput, `changelog=${encodeURIComponent(changelogEntry)}\n`);
     console.log('Outputs written to GITHUB_OUTPUT');
   } catch (e) {
-    console.warn(`Could not write to GITHUB_OUTPUT: ${e.message}`);
+    console.error(`Failed to write to GITHUB_OUTPUT: ${e.message}`);
+    process.exit(1);
   }
 }
 

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -72,31 +72,19 @@ try {
 
 fs.writeFileSync('CHANGELOG.md', changelogEntry + existingChangelog);
 
-// Git operations
+// Output version and changelog for GitHub Release
+// Set output variables for workflow access using GitHub Actions format
+console.log(`\n::set-output name=version::${version}`);
+console.log(`\n::set-output name=changelog::${encodeURIComponent(changelogEntry)}`);
+console.log(`\n::notice title=Release Version::${version}`);
+
+// Save changelog to a temporary file for workflow access
+const tempChangelogPath = '/tmp/changelog.txt';
 try {
-  execSync('git config user.name "github-actions[bot]"');
-  execSync('git config user.email "github-actions[bot]@users.noreply.github.com"');
-
-  execSync('git add CHANGELOG.md src/data/version.json');
-
-  // Only commit if there are changes
-  const status = execSync('git status --porcelain').toString().trim();
-  if (status) {
-    execSync(`git commit -m "chore: release ${version} [skip ci]"`);
-    execSync(`git tag ${version}`);
-
-    // Only push if in a CI environment to prevent accidental local pushes
-    if (process.env.GITHUB_ACTIONS) {
-      execSync('git push origin main');
-      execSync('git push origin --tags');
-      console.log(`Successfully released version ${version}`);
-    } else {
-      console.log(`Local run complete. Version ${version} prepared but not pushed.`);
-    }
-  } else {
-    console.log('No files to commit.');
-  }
-} catch (error) {
-  console.error('Error during git operations:', error.stdout ? error.stdout.toString() : error);
-  process.exit(1);
+  fs.writeFileSync(tempChangelogPath, changelogEntry);
+  console.log(`Changelog saved to ${tempChangelogPath}`);
+} catch (e) {
+  console.warn(`Could not write changelog to temp file: ${e.message}`);
 }
+
+console.log(`Successfully prepared version ${version}`);


### PR DESCRIPTION
- Simplify release.js to output version/changelog instead of handling git
- Move git tagging and release creation to CI workflow
- Extract release info in separate workflow step for clarity
- Use softprops/action-gh-release@v2 for creating GitHub Release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment pipeline now creates and publishes GitHub Releases automatically, using a generated release version and a changelog excerpt for clearer release history.
  * Local release tooling simplified to emit release metadata for the CI pipeline, reducing local-side repository changes and streamlining the release process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->