### PR TITLE
Fix Snyk badge 404 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Code Style: Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=for-the-badge&logo=prettier)](https://github.com/prettier/prettier)
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/alehar9320/astro-cloudflare-personal-website/ci.yml?style=for-the-badge&logo=githubactions&logoColor=white)](https://github.com/alehar9320/astro-cloudflare-personal-website/actions)
 [![Codecov](https://img.shields.io/codecov/c/github/alehar9320/astro-cloudflare-personal-website?style=for-the-badge&logo=codecov)](https://codecov.io/gh/alehar9320/astro-cloudflare-personal-website)
-[![Snyk Vulnerabilities](https://img.shields.io/snyk/vulnerabilities/github/alehar9320/astro-cloudflare-personal-website?style=for-the-badge&logo=snyk&logoColor=white)](https://app.snyk.io/org/alehar9320/projects)
+[![Snyk Security](https://img.shields.io/badge/Snyk-security-9043C6?style=for-the-badge&logo=snyk&logoColor=white)](https://snyk.io/test/github/alehar9320/astro-cloudflare-personal-website)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Code Style: Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=for-the-badge&logo=prettier)](https://github.com/prettier/prettier)
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/alehar9320/astro-cloudflare-personal-website/ci.yml?style=for-the-badge&logo=githubactions&logoColor=white)](https://github.com/alehar9320/astro-cloudflare-personal-website/actions)
 [![Codecov](https://img.shields.io/codecov/c/github/alehar9320/astro-cloudflare-personal-website?style=for-the-badge&logo=codecov)](https://codecov.io/gh/alehar9320/astro-cloudflare-personal-website)
-[![Snyk Security](https://img.shields.io/badge/Snyk-security-9043C6?style=for-the-badge&logo=snyk&logoColor=white)](https://snyk.io/test/github/alehar9320/astro-cloudflare-personal-website)
+[![Snyk Security](https://snyk.io/test/github/alehar9320/astro-cloudflare-personal-website/badge.svg)](https://snyk.io/test/github/alehar9320/astro-cloudflare-personal-website)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
 
 </div>


### PR DESCRIPTION
The Snyk badge in the README was showing a 404 error because Shields.io has deprecated its direct integration with Snyk. I've replaced it with a static Shields.io badge that maintains the visual style of the project and links to the correct Snyk project test page for this repository. Verified the Snyk project is public and monitored.

---
*PR created automatically by Jules for task [11562703395251417930](https://jules.google.com/task/11562703395251417930) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README security badge: replaced the previous Snyk badge with a “Snyk Security” badge and updated its destination to the Snyk test page so users land on the latest security test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->