### PR TITLE
Enhance About section with SEO links and consistent university mentions

### DIFF
--- a/src/content/work/master-thesis.md
+++ b/src/content/work/master-thesis.md
@@ -4,7 +4,7 @@ publishDate: 2017-06-01 00:00:00
 img: /assets/stock-1.jpg
 img_alt: Business structure concept
 description: |
-  Master Thesis @ Chalmers: A strategic exploration into the keys for digital transformation success—identifying scalable growth opportunities through data-driven innovation.
+  Master Thesis @ Chalmers University of Technology: A strategic exploration into the keys for digital transformation success—identifying scalable growth opportunities through data-driven innovation.
 tags:
   - Research
   - Digitalization
@@ -13,7 +13,7 @@ tags:
 
 Digital developments have significantly affected the market environment over the last decade. A sense of urgency has put concepts related to business transformation in high demand. Among these concepts, a popular term has been business model innovation; the strategic and innovative re-arrangement of business activities.
 
-My thesis revolved around business model innovation, and the opportunities and barriers that digitalization creates. This was done by:
+My thesis was conducted at [Chalmers University of Technology](https://www.chalmers.se/en/) and revolved around business model innovation, and the opportunities and barriers that digitalization creates. This was done by:
 
 1. Academically mapping out what it means to transform a business with the help of digitalization.
 2. Studying a specific business case where digitalization was part of changing the business model.

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -93,10 +93,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
                 target="_blank"
                 rel="noopener noreferrer">Software Engineering</a
               ></b
-            >, <a
-              href="https://www.chalmers.se/en/"
-              target="_blank"
-              rel="noopener noreferrer">Chalmers University of Technology</a
+            >, <a href="https://www.chalmers.se/en/" target="_blank" rel="noopener noreferrer"
+              >Chalmers University of Technology</a
             > (2012 - 2015)
           </p>
         </div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -26,8 +26,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <h2 class="section-title">Background</h2>
         <div class="content">
           <p>
-            I am a strategic Product Leader with a proven track record of delivering multi-million
-            dollar business value through <a
+            I am a strategic <a
+              href="https://en.wikipedia.org/wiki/Product_management"
+              target="_blank"
+              rel="noopener noreferrer">Product Leader</a
+            > with a proven track record of delivering multi-million dollar business value through <a
               href="https://en.wikipedia.org/wiki/Artificial_intelligence_in_industry"
               target="_blank"
               rel="noopener noreferrer">Industrial AI</a
@@ -35,9 +38,15 @@ import BaseLayout from '../layouts/BaseLayout.astro';
               href="https://en.wikipedia.org/wiki/Digital_transformation"
               target="_blank"
               rel="noopener noreferrer">digital transformation</a
-            >. With a unique blend of technical expertise in software engineering and strategic
-            insight in innovation management, I bridge the gap between complex technology and
-            scalable market success.
+            >. With a unique blend of technical expertise in <a
+              href="https://en.wikipedia.org/wiki/Software_engineering"
+              target="_blank"
+              rel="noopener noreferrer">software engineering</a
+            > and strategic insight in <a
+              href="https://en.wikipedia.org/wiki/Innovation_management"
+              target="_blank"
+              rel="noopener noreferrer">innovation management</a
+            >, I bridge the gap between complex technology and scalable market success.
           </p>
           <p>
             In my current role at <a
@@ -84,7 +93,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
                 target="_blank"
                 rel="noopener noreferrer">Software Engineering</a
               ></b
-            >, Chalmers University of Technology (2012 - 2015)
+            >, <a
+              href="https://www.chalmers.se/en/"
+              target="_blank"
+              rel="noopener noreferrer">Chalmers University of Technology</a
+            > (2012 - 2015)
           </p>
         </div>
       </section>
@@ -92,8 +105,35 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         <h2 class="section-title">Skills</h2>
         <div class="content">
           <p>
-            Product Management, Software Development, Design Thinking, Strategic Thinking,
-            Technological Innovation, Developer Experience, Business Analysis
+            <a
+              href="https://en.wikipedia.org/wiki/Product_management"
+              target="_blank"
+              rel="noopener noreferrer">Product Management</a
+            >, <a
+              href="https://en.wikipedia.org/wiki/Software_development"
+              target="_blank"
+              rel="noopener noreferrer">Software Development</a
+            >, <a
+              href="https://en.wikipedia.org/wiki/Design_thinking"
+              target="_blank"
+              rel="noopener noreferrer">Design Thinking</a
+            >, <a
+              href="https://en.wikipedia.org/wiki/Strategic_thinking"
+              target="_blank"
+              rel="noopener noreferrer">Strategic Thinking</a
+            >, <a
+              href="https://en.wikipedia.org/wiki/Innovation_management"
+              target="_blank"
+              rel="noopener noreferrer">Technological Innovation</a
+            >, <a
+              href="https://en.wikipedia.org/wiki/Developer_experience"
+              target="_blank"
+              rel="noopener noreferrer">Developer Experience</a
+            >, <a
+              href="https://en.wikipedia.org/wiki/Business_analysis"
+              target="_blank"
+              rel="noopener noreferrer">Business Analysis</a
+            >
           </p>
         </div>
       </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -95,8 +95,8 @@ const projects = (await getCollection('work'))
               >
             </li>
             <li class="mention-card">
-              <a href="https://www.chalmers.se/" target="_blank" rel="noopener noreferrer"
-                >Chalmers University</a
+              <a href="https://www.chalmers.se/en/" target="_blank" rel="noopener noreferrer"
+                >Chalmers University of Technology</a
               >
             </li>
             <li class="mention-card">


### PR DESCRIPTION
I have enhanced the About section of the website by adding relevant outbound links to professional terms (e.g., Product Management, Software Engineering, Design Thinking) to improve SEO. Additionally, I standardized all references to 'Chalmers University of Technology' across the site (including the homepage and project pages) to ensure they consistently use the full name and link to the official English website (https://www.chalmers.se/en/). I also ensured that content metadata (description field) remains plain text to prevent broken Markdown from appearing in HTML meta tags, while keeping the corresponding links in the visible body content. All changes were verified via local development server, screenshots, and existing unit tests.

---
*PR created automatically by Jules for task [4496651093508119774](https://jules.google.com/task/4496651093508119774) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added external hyperlinks for educational institutions, professional roles, and skills to improve navigation and context.
  * Standardized naming to "Chalmers University of Technology" across the site for consistency.
  * Refined thesis and About page copy for clearer phrasing and updated the site mention/link in the Mentions section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->