### PR TITLE
fix: add pages_build_output_dir and project name to Cloudflare Pages …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,8 +133,8 @@ jobs:
       - name: Build Project
         run: npm run build
 
-      - name: Deploy to Cloudflare
-        run: npx wrangler pages deploy ./dist
+      - name: Deploy to Cloudflare Pages
+        run: npx wrangler pages deploy ./dist --project-name ${{ secrets.CLOUDFLARE_PAGES_PROJECT }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -10,4 +10,5 @@
   "observability": {
     "enabled": true,
   },
+  "pages_build_output_dir": "./dist",
 }


### PR DESCRIPTION
…deployment

- Add pages_build_output_dir to wrangler.jsonc to tell Wrangler where static files are
- Update CI workflow to pass --project-name via CLOUDFLARE_PAGES_PROJECT secret
- Fixes 'Must specify a project name' error in wrangler pages deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment and build configuration for the application's deployment pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->