### PR TITLE
Enhance vitest coverage to measure all source files

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,7 +18,12 @@ export default defineConfig({
       reporter: ['text', 'lcov'],
       reportsDirectory: './coverage',
       all: true,
-      include: ['src/**/*', 'sentry.server.config.ts', 'sentry.client.config.ts', 'scripts/release.js'],
+      include: [
+        'src/**/*',
+        'sentry.server.config.ts',
+        'sentry.client.config.ts',
+        'scripts/release.js',
+      ],
       exclude: ['src/**/*.d.ts', 'src/content/**', 'src/data/**', 'src/styles/**'],
     },
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,16 +18,8 @@ export default defineConfig({
       reporter: ['text', 'lcov'],
       reportsDirectory: './coverage',
       all: true,
-      include: ['src/**/*', 'sentry.server.config.ts', 'scripts/release.js'],
-      exclude: [
-        'src/**/*.d.ts',
-        'src/**/*.{test,spec}.{ts,tsx,js,jsx,mjs,cjs,astro}',
-        'src/**/__tests__/**',
-        'src/**/*.astro',
-        'src/content/**',
-        'src/data/**',
-        'src/styles/**',
-      ],
+      include: ['src/**/*', 'sentry.server.config.ts', 'sentry.client.config.ts', 'scripts/release.js'],
+      exclude: ['src/**/*.d.ts', 'src/content/**', 'src/data/**', 'src/styles/**'],
     },
   },
 });


### PR DESCRIPTION
As requested by the Principal Software Architect, I have updated the `vitest.config.ts` to provide a more accurate and comprehensive measurement of test coverage.

The key changes include:
- Removing exclusions for `.astro` files, layouts, and pages.
- Removing exclusions for test files and directories (`src/**/__tests__/**` and `src/**/*.{test,spec}.*`).
- Adding `sentry.client.config.ts` to the coverage inclusion list.
- Maintaining exclusions only for static/non-source directories (`src/content`, `src/data`, `src/styles`) and `.d.ts` files.

While `.astro` files currently report parse errors in the V8 coverage provider, they are now correctly included in the configuration as per the requirement to measure all source files.

---
*PR created automatically by Jules for task [18266002003423714287](https://jules.google.com/task/18266002003423714287) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved interactive styling for mention cards and plain links: smoother transitions, lifted hover effect, clearer focus outlines for keyboard users, visible underlines on hover/focus, and reduced-motion respect.
* **Chores**
  * Updated test coverage configuration to broaden which client/config and template files are included in reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->