### PR TITLE
🛡️ Sentinel: Refactor Hero component to remove set:html

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,1 @@
+## 2025-05-14 - Removed set:html from Hero component | **Vulnerability:** Use of `set:html` in reusable components like `Hero.astro` can lead to XSS if prop content is not strictly sanitized. | **Prevention:** Migrated rich content to named slots, allowing Astro to handle standard props with automatic escaping and providing a secure boundary for HTML injection.

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -11,8 +11,9 @@ const { align = 'center', tagline, title } = Astro.props;
 <div class:list={['hero stack gap-4', align]}>
   <div class="stack gap-2">
     <h1 class="title">{title}</h1>
-    {tagline && <p class="tagline">{tagline}</p>}
-    <slot name="tagline" />
+    <slot name="tagline">
+      {tagline && <p class="tagline">{tagline}</p>}
+    </slot>
   </div>
   <slot />
 </div>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -11,7 +11,8 @@ const { align = 'center', tagline, title } = Astro.props;
 <div class:list={['hero stack gap-4', align]}>
   <div class="stack gap-2">
     <h1 class="title">{title}</h1>
-    {tagline && <p class="tagline" set:html={tagline} />}
+    {tagline && <p class="tagline">{tagline}</p>}
+    <slot name="tagline" />
   </div>
   <slot />
 </div>
@@ -23,7 +24,8 @@ const { align = 'center', tagline, title } = Astro.props;
   }
 
   .title,
-  .tagline {
+  .tagline,
+  :global(.hero .tagline) {
     max-width: 37ch;
     margin-inline: auto;
   }
@@ -43,7 +45,8 @@ const { align = 'center', tagline, title } = Astro.props;
     }
 
     .start .title,
-    .start .tagline {
+    .start .tagline,
+    :global(.hero.start .tagline) {
       margin-inline: unset;
     }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,11 +26,15 @@ const projects = (await getCollection('work'))
   <div class="stack gap-20 lg:gap-48">
     <div class="wrapper stack gap-8 lg:gap-20">
       <header class="hero">
-        <Hero
-          title="Elevating Developer Experience & Product Strategy"
-          tagline="I am <strong>Alexander Härenstam</strong>, a Strategic Product Leader championing enterprise-scale Industrial AI at <a href='https://www.ifs.com/' target='_blank' rel='noopener noreferrer'>IFS</a>."
-          align="start"
-        >
+        <Hero title="Elevating Developer Experience & Product Strategy" align="start">
+          <p slot="tagline" class="tagline">
+            I am <strong>Alexander Härenstam</strong>, a Strategic Product Leader championing
+            enterprise-scale Industrial AI at <a
+              href="https://www.ifs.com/"
+              target="_blank"
+              rel="noopener noreferrer">IFS</a
+            >.
+          </p>
           <div class="roles">
             <Pill><Icon icon="strategy" size="1.33em" /> Technical Product Management</Pill>
             <Pill><Icon icon="terminal-window" size="1.33em" /> Developer Experience (DevEx)</Pill>


### PR DESCRIPTION
I have refactored the `Hero.astro` component to remove the `set:html` directive, replacing it with a named slot for rich HTML content. This aligns with the project's security standards and prevents potential XSS vulnerabilities in reusable components. I also updated the homepage to use this new pattern and verified the visual consistency with Playwright screenshots.

---
*PR created automatically by Jules for task [12453494772490012745](https://jules.google.com/task/12453494772490012745) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unsafe HTML injection for taglines and now rely on standard escaping to prevent potential XSS; styling adjusted so layout and spacing remain consistent.

* **New Features**
  * Hero accepts named-slot content for richer, safer tagline markup.

* **Documentation**
  * Added a changelog entry documenting the security and rendering change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->