### PR TITLE
🎨 Palette: Standardize Skip-to-Content and Glassmorphic Focus States

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-09 - Standardized Skip-to-Content and Glassmorphic Focus States
+**Learning:** Standardizing accessibility targets (`id="main-content"`, `tabindex="-1"`) across all page layouts ensures a consistent UX for keyboard and screen reader users. In a glassmorphic design system, focus states should mirror the visual weight of hover effects to maintain aesthetic coherence.
+**Action:** Always include `#main-content` targets in new Astro page templates and utilize `:focus-visible` to deliver high-visibility, glassmorphic feedback without cluttering the UI for mouse users.

--- a/src/components/PortfolioPreview.astro
+++ b/src/components/PortfolioPreview.astro
@@ -35,12 +35,15 @@ const { data, id } = Astro.props.project;
       border-color 0.4s ease;
   }
 
-  .card:hover {
+  .card:hover,
+  .card:focus-visible {
     transform: translateY(-6px);
     box-shadow:
       0 15px 35px -5px hsla(210, 100%, 45%, 0.4),
       var(--shadow-lg);
     border-color: hsla(var(--gray-999-basis), 0.5);
+    outline: 2px solid var(--accent-regular);
+    outline-offset: 4px;
   }
 
   .title {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -142,20 +142,30 @@ const { title, description } = Astro.props;
         white-space: nowrap;
       }
 
-      .sr-only.focus-visible:focus {
+      .sr-only.focus-visible:focus-visible {
         clip: auto;
         height: auto;
         margin: auto;
         overflow: visible;
-        position: static;
+        position: fixed;
+        top: 1rem;
+        left: 1rem;
         width: auto;
         white-space: normal;
-        padding: 1rem;
-        background: var(--gray-900);
+        padding: 0.75rem 1.5rem;
+        background: hsla(var(--gray-999-basis), 0.7);
+        backdrop-filter: blur(12px);
+        -webkit-backdrop-filter: blur(12px);
         color: var(--gray-0);
+        border: 1px solid var(--accent-regular);
+        border-radius: 999rem;
         display: block;
         text-align: center;
-        z-index: 9999;
+        z-index: 99999;
+        text-decoration: none;
+        font-family: var(--font-brand);
+        font-weight: 600;
+        box-shadow: var(--shadow-lg);
       }
     </style>
   </body>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -4,8 +4,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="Not Found" description="404 Error — this page was not found">
-  <Hero
-    title="Page Not Found"
-    tagline="The page you're looking for doesn't exist or has moved. Let's get you back on track."
-  />
+  <main id="main-content" tabindex="-1">
+    <Hero
+      title="Page Not Found"
+      tagline="The page you're looking for doesn't exist or has moved. Let's get you back on track."
+    />
+  </main>
 </BaseLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -46,7 +46,7 @@ const schema = {
   <script type="application/ld+json" set:html={JSON.stringify(schema)} />
 
   <div class="stack gap-20">
-    <main id="main-content" class="wrapper about">
+    <main id="main-content" tabindex="-1" class="wrapper about">
       <Hero
         title="About"
         tagline="Bridging the gap between software engineering and strategic innovation to drive market success."

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -49,7 +49,7 @@ const projects = (await getCollection('work'))
       <Skills />
     </div>
 
-    <main id="main-content" class="wrapper stack gap-20 lg:gap-48">
+    <main id="main-content" tabindex="-1" class="wrapper stack gap-20 lg:gap-48">
       <section class="section with-background with-cta">
         <header class="section-header stack gap-2 lg:gap-4">
           <h2>Strategic Impact</h2>

--- a/src/pages/whats-new.astro
+++ b/src/pages/whats-new.astro
@@ -6,7 +6,7 @@ import Hero from '../components/Hero.astro';
 
 <BaseLayout title="What's New | Alexander Härenstam" description="Changelog and recent updates">
   <div class="stack gap-20">
-    <main class="wrapper stack gap-8">
+    <main id="main-content" tabindex="-1" class="wrapper stack gap-8">
       <Hero
         title="What's New"
         tagline="A continuously updated release log of improvements, tweaks, and new features."

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -16,7 +16,7 @@ const projects = (await getCollection('work')).sort(
   description="Explore Alexander Härenstam's strategic product portfolio and recent initiatives."
 >
   <div class="stack gap-20">
-    <main id="main-content" class="wrapper stack gap-8">
+    <main id="main-content" tabindex="-1" class="wrapper stack gap-8">
       <Hero
         title="Strategic Portfolio"
         tagline="A curated selection of initiatives transforming complex enterprise challenges into scalable product solutions."

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -42,7 +42,7 @@ const { Content } = await render(entry);
           </Hero>
         </div>
       </header>
-      <main class="wrapper">
+      <main id="main-content" tabindex="-1" class="wrapper">
         <div class="stack gap-10 content">
           {entry.data.img && <img src={entry.data.img} alt={entry.data.img_alt || ''} />}
           <div class="content">


### PR DESCRIPTION
This PR implements a high-impact micro-UX and accessibility improvement for Alexander Härenstam's portfolio. 

### Changes:
- **Accessibility Standardization:** Added `id="main-content"` and `tabindex="-1"` to the `<main>` element of all page-level Astro components (`index.astro`, `about.astro`, `work.astro`, `whats-new.astro`, `[...slug].astro`, and `404.astro`) to ensure the global skip-link functions correctly.
- **Glassmorphic Skip Link:** Redesigned the "Skip to Content" link in `BaseLayout.astro` using the "Northern Lights" palette (Marine blue and cyan) and glassmorphism (translucent background, blur, and accent borders). It is only visible to keyboard users via `:focus-visible`.
- **Enhanced Focus States:** Improved the keyboard navigation experience for portfolio cards in `PortfolioPreview.astro` by adding high-visibility focus rings and shadows that mirror the hover interaction.
- **Quality Assurance:** All 22 tests passed. Verified the visual and functional changes using a custom Playwright script and a production build (`npm run preview`) to bypass local dev middleware issues.

This change adheres to the project's minimalist aesthetic and Vanilla CSS constraints while significantly improving the experience for assistive technology users.

---
*PR created automatically by Jules for task [18285806884899101566](https://jules.google.com/task/18285806884899101566) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved keyboard focus visibility with enhanced outlines across the site.
  * Enhanced "Skip to content" link with better contrast, positioning, and glassmorphic styling.
  * Better keyboard navigation support for accessing main content regions on all pages.

* **Documentation**
  * Added accessibility guidelines for consistent focus states and keyboard navigation patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->