### PR TITLE
🎨 Palette: [UX improvement] Add glassmorphic Skip to Content link

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,5 +1,5 @@
 ## 2026-04-10 - Skip to Content Accessibility
 
-**Learning:** Adding a "Skip to Content" link is a fundamental accessibility requirement for keyboard users. Using `tabindex="-1"` on the target `<main>` element ensures focus is correctly managed across all browsers without adding the element to the natural tab order. For glassmorphic designs, the link should use `backdrop-filter: blur(10px)` and a high `z-index` to remain visible and readable over dynamic aurora backgrounds when focused.
+**Learning:** Adding a "Skip to Content" link is a fundamental accessibility requirement for keyboard users. Using `tabindex="-1"` on the target `<main>` element ensures focus is correctly managed across all browsers without adding the element to the natural tab order. For glassmorphic designs, the link should use a subtle backdrop-filter blur for legibility and a high `z-index` to remain visible and readable over dynamic aurora backgrounds when focused.
 
 **Action:** Standardized all page-level components with `<main id="main-content" tabindex="-1">` to support the global skip-link defined in `BaseLayout.astro`.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+## 2026-04-10 - Skip to Content Accessibility
+
+**Learning:** Adding a "Skip to Content" link is a fundamental accessibility requirement for keyboard users. Using `tabindex="-1"` on the target `<main>` element ensures focus is correctly managed across all browsers without adding the element to the natural tab order. For glassmorphic designs, the link should use `backdrop-filter: blur(10px)` and a high `z-index` to remain visible and readable over dynamic aurora backgrounds when focused.
+
+**Action:** Standardized all page-level components with `<main id="main-content" tabindex="-1">` to support the global skip-link defined in `BaseLayout.astro`.

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -21,7 +21,7 @@ const { title, description } = Astro.props;
   </head>
   <body>
     <!-- Skip to content link for accessibility -->
-    <a href="#main-content" class="sr-only focus-visible">Skip to content</a>
+    <a href="#main-content" class="skip-to-content">Skip to content</a>
 
     <div class="stack backgrounds">
       <Nav />
@@ -130,32 +130,28 @@ const { title, description } = Astro.props;
       }
 
       /* Accessibility Styles */
-      .sr-only {
-        border: 0;
-        clip: rect(0, 0, 0, 0);
-        height: 1px;
-        margin: -1px;
-        overflow: hidden;
-        padding: 0;
-        position: absolute;
-        width: 1px;
-        white-space: nowrap;
+      .skip-to-content {
+        position: fixed;
+        top: -100%;
+        left: 50%;
+        transform: translateX(-50%);
+        padding: 0.75rem 1.5rem;
+        background: hsla(var(--gray-999-basis), 0.85);
+        backdrop-filter: blur(16px);
+        -webkit-backdrop-filter: blur(16px);
+        border: 1px solid var(--accent-regular);
+        border-top: 0;
+        border-radius: 0 0 0.75rem 0.75rem;
+        color: var(--gray-0);
+        font-weight: 500;
+        text-decoration: none;
+        z-index: 10000;
+        transition: top var(--theme-transition);
+        box-shadow: var(--shadow-lg);
       }
 
-      .sr-only.focus-visible:focus {
-        clip: auto;
-        height: auto;
-        margin: auto;
-        overflow: visible;
-        position: static;
-        width: auto;
-        white-space: normal;
-        padding: 1rem;
-        background: var(--gray-900);
-        color: var(--gray-0);
-        display: block;
-        text-align: center;
-        z-index: 9999;
+      .skip-to-content:focus-visible {
+        top: 0;
       }
     </style>
   </body>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -4,8 +4,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout title="Not Found" description="404 Error — this page was not found">
-  <Hero
-    title="Page Not Found"
-    tagline="The page you're looking for doesn't exist or has moved. Let's get you back on track."
-  />
+  <main id="main-content" tabindex="-1">
+    <Hero
+      title="Page Not Found"
+      tagline="The page you're looking for doesn't exist or has moved. Let's get you back on track."
+    />
+  </main>
 </BaseLayout>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -46,7 +46,7 @@ const schema = {
   <script type="application/ld+json" set:html={JSON.stringify(schema)} />
 
   <div class="stack gap-20">
-    <main id="main-content" class="wrapper about">
+    <main id="main-content" tabindex="-1" class="wrapper about">
       <Hero
         title="About"
         tagline="Bridging the gap between software engineering and strategic innovation to drive market success."

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -49,7 +49,7 @@ const projects = (await getCollection('work'))
       <Skills />
     </div>
 
-    <main id="main-content" class="wrapper stack gap-20 lg:gap-48">
+    <main id="main-content" tabindex="-1" class="wrapper stack gap-20 lg:gap-48">
       <section class="section with-background with-cta">
         <header class="section-header stack gap-2 lg:gap-4">
           <h2>Strategic Impact</h2>

--- a/src/pages/whats-new.astro
+++ b/src/pages/whats-new.astro
@@ -6,7 +6,7 @@ import Hero from '../components/Hero.astro';
 
 <BaseLayout title="What's New | Alexander Härenstam" description="Changelog and recent updates">
   <div class="stack gap-20">
-    <main class="wrapper stack gap-8">
+    <main id="main-content" tabindex="-1" class="wrapper stack gap-8">
       <Hero
         title="What's New"
         tagline="A continuously updated release log of improvements, tweaks, and new features."

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -16,7 +16,7 @@ const projects = (await getCollection('work')).sort(
   description="Explore Alexander Härenstam's strategic product portfolio and recent initiatives."
 >
   <div class="stack gap-20">
-    <main id="main-content" class="wrapper stack gap-8">
+    <main id="main-content" tabindex="-1" class="wrapper stack gap-8">
       <Hero
         title="Strategic Portfolio"
         tagline="A curated selection of initiatives transforming complex enterprise challenges into scalable product solutions."

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -58,7 +58,7 @@ const schema = {
           </Hero>
         </div>
       </header>
-      <main class="wrapper">
+      <main id="main-content" tabindex="-1" class="wrapper">
         <div class="stack gap-10 content">
           {entry.data.img && <img src={entry.data.img} alt={entry.data.img_alt || ''} />}
           <div class="content">


### PR DESCRIPTION
### 🎨 Palette: [UX improvement] 
 
**Mission:** Improve keyboard accessibility while maintaining the "Northern Lights" glassmorphic aesthetic. 
 
**Changes:** 
- **Accessibility:** Added a global "Skip to Content" link in `BaseLayout.astro`. This allows keyboard users to bypass navigation and jump directly to the primary content. 
- **Structure:** Standardized the use of `<main id="main-content" tabindex="-1">` across all site pages (`index`, `about`, `work`, `whats-new`, `404`, and dynamic project pages). The `tabindex="-1"` ensures focus is shifted correctly without adding the main element to the natural tab order. 
- **Design:** Styled the skip link with glassmorphism (backdrop-filter: blur, translucent background) to align with the portfolio's visual language. The link remains hidden until it receives focus. 
- **Documentation:** Recorded learnings regarding Astro-specific accessibility patterns and focus management in `.Jules/palette.md`. 
 
**Verification:** 
- Passed `npm run format`, `lint`, `test`, and `astro check`. 
- Verified with Playwright: simulated 'Tab' navigation and confirmed the skip link focus and jump functionality. 
- Visual check: Confirmed the skip link appears correctly at the top of the viewport when focused.

---
*PR created automatically by Jules for task [8133425841221259767](https://jules.google.com/task/8133425841221259767) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Redesigned skip-to-content link with a visible, focus-first glassmorphic control for clearer keyboard access.
  * Standardized main content regions across pages to be programmatically focusable, improving skip-link behavior and keyboard navigation consistency.

* **Documentation**
  * Added a pattern document describing focus-management best practices and styling guidelines for implementing the skip-to-content control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->