### PR TITLE
🎨 Palette: Synchronize hover lift and focus-visible states

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+## 2025-02-12 - Synchronize hover lift and focus-visible states
+
+**Learning:** For interactive components that 'lift' on hover (using `transform: translateY`), the `:focus-visible` state should include the same transformation to maintain a consistent spatial mental model for keyboard users.
+**Action:** Always apply the Focus Animation Standard when implementing hover lift effects, ensuring `:focus-visible` matches the transformation and provides a standardized accessible outline.

--- a/src/components/CallToAction.astro
+++ b/src/components/CallToAction.astro
@@ -40,13 +40,18 @@ const { href, target, rel } = Astro.props;
     }
   }
 
-  a:focus,
-  a:hover {
+  a:hover,
+  a:focus-visible {
     background-position: 100% 50%;
     transform: translateY(-3px) scale(1.02);
     box-shadow:
       0 12px 30px -5px hsla(210, 100%, 50%, 0.6),
       var(--shadow-md);
+  }
+
+  a:focus-visible {
+    outline: 2px solid var(--accent-regular);
+    outline-offset: 4px;
   }
 
   a:active {

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -280,8 +280,14 @@ const isCurrentPage = (href: string) => {
   }
 
   .social:hover,
-  .social:focus {
+  .social:focus-visible {
     color: var(--accent-text-over);
+  }
+
+  .social:focus-visible {
+    outline: 2px solid var(--accent-regular);
+    outline-offset: 4px;
+    border-radius: 0.375rem;
   }
 
   .theme-toggle {
@@ -342,9 +348,14 @@ const isCurrentPage = (href: string) => {
     }
 
     .link:hover,
-    .link:focus {
+    .link:focus-visible {
       color: var(--gray-100);
       background-color: var(--accent-subtle-overlay);
+    }
+
+    .link:focus-visible {
+      outline: 2px solid var(--accent-regular);
+      outline-offset: 4px;
     }
 
     .link[aria-current='page'] {

--- a/src/components/PortfolioPreview.astro
+++ b/src/components/PortfolioPreview.astro
@@ -35,12 +35,18 @@ const { data, id } = Astro.props.project;
       border-color 0.4s ease;
   }
 
-  .card:hover {
+  .card:hover,
+  .card:focus-within {
     transform: translateY(-6px);
     box-shadow:
       0 15px 35px -5px hsla(210, 100%, 45%, 0.4),
       var(--shadow-lg);
     border-color: hsla(var(--gray-999-basis), 0.5);
+  }
+
+  .card:focus-visible {
+    outline: 2px solid var(--accent-regular);
+    outline-offset: 4px;
   }
 
   .title {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -281,7 +281,6 @@ const projects = (await getCollection('work'))
   }
 
   .mention-card a:focus-visible {
-    transform: translateY(-2px);
     outline: 2px solid var(--accent-regular);
     outline-offset: 4px;
     border-radius: 1.25rem;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -281,8 +281,9 @@ const projects = (await getCollection('work'))
   }
 
   .mention-card a:focus-visible {
+    transform: translateY(-2px);
     outline: 2px solid var(--accent-regular);
-    outline-offset: 3px;
+    outline-offset: 4px;
     border-radius: 1.25rem;
   }
 


### PR DESCRIPTION
This PR implements a micro-UX improvement to synchronize hover lift effects with focus states. 

Key improvements:
- **Accessibility:** Keyboard users now receive the same spatial feedback ("lift") as mouse users when navigating interactive elements.
- **Consistency:** Focus indicators are standardized to `2px solid var(--accent-regular)` with a `4px` offset across the site.
- **Polish:** Replaced generic `:focus` with `:focus-visible` to prevent focus rings from appearing on mouse clicks, maintaining a clean glassmorphic aesthetic while ensuring accessibility.

Verified with Playwright screenshots and existing project quality checks.

---
*PR created automatically by Jules for task [4031325357735071922](https://jules.google.com/task/4031325357735071922) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an accessibility note describing that hover "lift" animations should also apply to focus-visible to maintain spatial consistency.

* **Style**
  * Enhanced keyboard focus indicators (outline + offset) across interactive elements for clearer visibility.
  * Aligned focus-visible states with hover effects so keyboard users see the same visual feedback as pointer users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->