### PR TITLE
🔍 Vantage: Document RENDER environment variable

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -51,3 +51,12 @@ SENTRY_AUTH_TOKEN=your-sentry-auth-token-for-source-map-uploads
 #   (miniflare reads these during npm run dev for local server code)
 # - Variables prefixed with PUBLIC_* are exposed to the browser (available as import.meta.env.PUBLIC_*)
 # - For production secrets, use: wrangler secret:bulk < secrets.json
+
+# Multi-Environment Deployment (Render.com vs Cloudflare)
+# Render.com automatically sets RENDER=true in its environment.
+# In astro.config.mjs, the constant 'isRender' (process.env.RENDER === 'true')
+# is used to toggle between the @astrojs/node adapter (for Render) and the
+# @astrojs/cloudflare adapter (for Cloudflare Pages).
+#
+# To test the Render/Node configuration locally:
+# RENDER=true npm run dev


### PR DESCRIPTION
This change adds documentation for the `RENDER` environment variable to `.dev.vars.example`. It explains how the variable is used in `astro.config.mjs` to switch between the `@astrojs/node` adapter (used for Render.com) and the `@astrojs/cloudflare` adapter. It also provides a command-line example for testing the Render configuration locally.

---
*PR created automatically by Jules for task [16619722201357393674](https://jules.google.com/task/16619722201357393674) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded environment configuration documentation with guidance for deploying to Render.com and Cloudflare Pages, including setup instructions and procedures for locally testing platform-specific configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->