### PR TITLE
Add Render MCP server documentation and configuration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,7 +70,8 @@ Notes: npm scripts forward arguments after `--` to the underlying command.
 
 ## MCP servers
 
-- This repo contains mcp_config.json with an `astro-docs` MCP server configured. See `mcp_config.json` at project root.
+- This repo contains `mcp_config.json` with `astro-docs` and `render` MCP servers configured.
+- See `mcp_config.json` at project root and [docs/mcp.md](docs/mcp.md) for detailed setup instructions for Cursor, Antigravity, Codex, and Claude Desktop.
 
 ---
 
@@ -135,12 +136,6 @@ Before submitting code for a pull request:
 - ✅ `npm run build` succeeds without warnings
 
 **If any formatting issues remain after `npm run format`, they will block the CI quality gate.**
-
----
-
-## MCP servers
-
-- This repo contains mcp_config.json with an `astro-docs` MCP server configured. See `mcp_config.json` at project root.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@
   - PascalCase for Astro components (`MyComponent.astro`).
   - kebab-case for other files (`my-script.ts`).
 - **Icons:** Phosphor Icons adapted in `src/components/IconPaths.ts`.
+- **MCP Servers:** Configured in `mcp_config.json` (root) and documented in `docs/mcp.md`. Includes `astro-docs` and `render` servers.
 
 ## 3. Development Workflow
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,101 @@
+# Model Context Protocol (MCP) Setup
+
+This project supports MCP servers to provide AI agents with real-time context and tools for development and deployment.
+
+## Render MCP Server
+
+The Render MCP server allows AI agents to manage Cloud Services and debug applications directly from your editor.
+
+### 1. Cursor Setup
+
+Add the following configuration to `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "render": {
+      "url": "https://mcp.render.com/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_API_KEY>"
+      }
+    }
+  }
+}
+```
+
+Replace `<YOUR_API_KEY>` with your Render API key. For more details, see the [Cursor MCP documentation](https://docs.cursor.com/context/model-context-protocol).
+
+### 2. Antigravity Setup
+
+1. Open the MCP store via the "..." dropdown at the top of the editor's agent panel.
+2. Click on "Manage MCP Servers" -> "View raw config".
+3. Modify the `mcp_config.json` (located at `~/.gemini/antigravity/mcp_config.json`) with the following:
+
+```json
+{
+  "mcpServers": {
+    "render": {
+      "url": "https://mcp.render.com/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_API_KEY>"
+      }
+    }
+  }
+}
+```
+
+### 3. Codex / Cline Setup
+
+If you are using the Cline (formerly Claude Dev) extension in VS Code:
+
+1. Open the Cline MCP settings file:
+   - macOS: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
+   - Windows: `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\settings\cline_mcp_settings.json`
+2. Add the "render" entry to the `mcpServers` object:
+
+```json
+{
+  "mcpServers": {
+    "render": {
+      "url": "https://mcp.render.com/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_API_KEY>"
+      }
+    }
+  }
+}
+```
+
+### 4. Claude Desktop Setup
+
+1. Open your Claude Desktop configuration file:
+   - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+   - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+2. Add the following to the `mcpServers` object:
+
+```json
+{
+  "mcpServers": {
+    "render": {
+      "url": "https://mcp.render.com/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_API_KEY>"
+      }
+    }
+  }
+}
+```
+
+## Astro Docs MCP Server
+
+This repo also references the Astro Docs MCP server in `mcp_config.json`:
+
+```json
+{
+  "astro-docs": {
+    "url": "https://mcp.docs.astro.build/mcp"
+  }
+}
+```
+
+You can add this to your preferred editor's MCP configuration to give the AI access to the latest Astro documentation.

--- a/mcp_config.json
+++ b/mcp_config.json
@@ -1,7 +1,13 @@
 {
   "mcpServers": {
     "astro-docs": {
-      "serverUrl": "https://mcp.docs.astro.build/mcp"
+      "url": "https://mcp.docs.astro.build/mcp"
+    },
+    "render": {
+      "url": "https://mcp.render.com/mcp",
+      "headers": {
+        "Authorization": "Bearer <YOUR_API_KEY>"
+      }
     }
   }
 }


### PR DESCRIPTION
This change adds comprehensive documentation and configuration for the Render MCP (Model Context Protocol) server. 

Key changes:
- Created `docs/mcp.md` containing detailed setup steps for Cursor, Antigravity, Codex (Cline), and Claude Desktop.
- Updated `mcp_config.json` at the root to include the Render MCP server as a reference for agents and users.
- Updated `AGENTS.md` and `.github/copilot-instructions.md` to point users and AI agents to the new documentation.
- Standardized the `mcp_config.json` format by using the `url` key for all server entries, ensuring compatibility with various MCP-enabled editors.

---
*PR created automatically by Jules for task [13757320756843622481](https://jules.google.com/task/13757320756843622481) started by @alehar9320*