### PR TITLE
🛡️ Sentinel: Mitigate PostCSS XSS vulnerability

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -4,6 +4,8 @@ Security-focused logs and critical learnings for the Alexander Härenstam's port
 
 Format: ## YYYY-MM-DD - [Title] | **Vulnerability:** [Insight] | **Prevention:** [Action]
 
+## 2026-04-25 - Resolve PostCSS XSS vulnerability | **Vulnerability:** PostCSS (versions < 8.5.10) had a moderate severity XSS vulnerability via unescaped `</style>` in its CSS stringify output (GHSA-qx2v-qp2m-jg93). | **Prevention:** Implemented a dependency override in `package.json` to force `postcss` version `^8.5.10`.
+
 ## 2026-04-10 - Mitigate XSS in Hero component | **Vulnerability:** Use of `set:html` with the `tagline` prop in `Hero.astro` allowed potential XSS if unvalidated input were passed to the component. While current usage was safe, it posed a risk for future changes. | **Prevention:** Replaced `set:html` with a named slot `<slot name="tagline" />` for rich content injection. The `tagline` prop now defaults to auto-escaped plain text.
 
 ## 2026-04-11 - Resolve yaml vulnerability | **Vulnerability:** Moderate risk vulnerability in transitive dependency `yaml` (v2.0.0-2.8.2) through `@astrojs/check`, susceptible to Stack Overflow via deeply nested YAML collections (GHSA-48c2-rrv3-qjmp). | **Prevention:** Implemented a dependency override in `package.json` to force `yaml` version `^2.8.3`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9497,9 +9497,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "overrides": {
     "brace-expansion": "^5.0.5",
+    "postcss": "^8.5.10",
     "yaml": "^2.8.3",
     "@actions/github": {
       "undici": "7.24.7"


### PR DESCRIPTION
Implemented a security fix to address GHSA-qx2v-qp2m-jg93 by overriding the PostCSS version to 8.5.10. Verified with npm audit and documented in the Sentinel journal.

---
*PR created automatically by Jules for task [3727020026899710332](https://jules.google.com/task/3727020026899710332) started by @alehar9320*