### PR TITLE
🎨 Palette: Improve Keyboard Navigation & Focus States

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,9 @@
 **Learning:** When implementing a glassmorphic design with subtle backgrounds and lift effects (like `translateY`), standard focus outlines can feel disconnected or get lost in the translucency. Using `:focus-visible` specifically allows for high-visibility outlines that only appear for keyboard users, avoiding visual noise for mouse users. Combining the focus state with the same "lift" effect used on hover provides a consistent spatial mental model for the interface.
 
 **Action:** Consistently use `:focus-visible` with `outline: 2px solid var(--accent-regular)` and `outline-offset: 4px` on interactive cards and buttons. For components that lift on hover (e.g., `PortfolioPreview` cards), apply the same transformation to the focus state to ensure keyboard users experience the same interactive polish as mouse users.
+
+## 2025-05-16 - Glassmorphic Accessibility and Inset Focus Rings
+
+**Learning:** Accessibility elements like "Skip to Content" links should share the design language of the site. A glassmorphic focus state (translucent background, backdrop-filter, and border) ensures these elements feel like a core part of the UI rather than an afterthought. For rounded interactive elements in tight layouts (like mobile menu buttons), an inset focus ring (`outline-offset: -0.5rem`) prevents the outline from being clipped or clashing with nearby elements while remaining highly visible.
+
+**Action:** Implement glassmorphism for critical accessibility overlays and use negative `outline-offset` for pill-shaped buttons in header/footer contexts to maintain a clean, professional aesthetic without sacrificing keyboard discoverability.

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -184,6 +184,13 @@ const isCurrentPage = (href: string) => {
     line-height: 1.1;
     color: var(--gray-0);
     text-decoration: none;
+    border-radius: 0.5rem;
+    transition: outline-offset var(--theme-transition);
+  }
+
+  .site-title:focus-visible {
+    outline: 2px solid var(--accent-regular);
+    outline-offset: 4px;
   }
 
   .menu-button {
@@ -198,6 +205,12 @@ const isCurrentPage = (href: string) => {
     backdrop-filter: blur(16px);
     -webkit-backdrop-filter: blur(16px);
     box-shadow: var(--shadow-md);
+    transition: outline-offset var(--theme-transition);
+  }
+
+  .menu-button:focus-visible {
+    outline: 2px solid var(--accent-regular);
+    outline-offset: -0.5rem;
   }
 
   .menu-button[aria-expanded='true'] {
@@ -281,12 +294,20 @@ const isCurrentPage = (href: string) => {
     padding: var(--icon-padding);
     text-decoration: none;
     color: var(--accent-dark);
-    transition: color var(--theme-transition);
+    transition:
+      color var(--theme-transition),
+      outline-offset var(--theme-transition);
+    border-radius: 0.5rem;
   }
 
   .social:hover,
-  .social:focus {
+  .social:focus-visible {
     color: var(--accent-text-over);
+  }
+
+  .social:focus-visible {
+    outline: 2px solid var(--accent-regular);
+    outline-offset: 4px;
   }
 
   .theme-toggle {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -147,15 +147,26 @@ const { title, description } = Astro.props;
         height: auto;
         margin: auto;
         overflow: visible;
-        position: static;
+        position: fixed;
+        top: 1rem;
+        left: 50%;
+        transform: translateX(-50%);
         width: auto;
         white-space: normal;
-        padding: 1rem;
-        background: var(--gray-900);
+        padding: 1rem 2rem;
+        background: hsla(var(--gray-999-basis), 0.7);
+        backdrop-filter: blur(12px);
+        -webkit-backdrop-filter: blur(12px);
         color: var(--gray-0);
+        border: 1px solid hsla(var(--gray-999-basis), 0.2);
+        border-radius: 999rem;
         display: block;
         text-align: center;
         z-index: 9999;
+        text-decoration: none;
+        font-family: var(--font-brand);
+        font-weight: 500;
+        box-shadow: var(--shadow-lg);
       }
     </style>
   </body>


### PR DESCRIPTION
This PR implements a series of micro-UX and accessibility improvements focused on keyboard navigation and focus visibility.

### 💡 What
- **Polished Skip-Link**: Transformed the hidden "Skip to content" link into a centered, glassmorphic pill that appears on focus.
- **Refined Focus States**: Implemented `:focus-visible` for the site title and navigation elements, replacing default browser outlines with a style-matched cyan ring.
- **Inset Focus Rings**: Specifically addressed the "clipping" issue on the mobile menu button by using an `inset` focus ring (`outline-offset: -0.5rem`), ensuring full visibility even at viewport edges.

### 🎯 Why
- Improved accessibility for keyboard-only users.
- Maintained "Northern Lights" aesthetic during interactive states.
- Standardized a design pattern for accessible glassmorphism.

### ✅ Verification
- Ran `npm run lint`, `npm run test`, and `npm run astro check`.
- Performed visual audit via Playwright (screenshots generated for skip-link and mobile menu states).
- Verified production build with `npm run build`.

---
*PR created automatically by Jules for task [9015691841557104573](https://jules.google.com/task/9015691841557104573) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced keyboard navigation with clearer and more visible focus indicators throughout the interface
  * Redesigned the skip-to-content link as a centered pill button with glassmorphic styling for improved accessibility
  * Updated focus-state styling across navigation components with smooth transitions and distinct visual feedback for keyboard users

<!-- end of auto-generated comment: release notes by coderabbit.ai -->