### PR TITLE
🎨 Palette: Enhance Focus States and Refine Pill Interactivity

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,5 +1,11 @@
 # Palette 🎨 - UX & Accessibility Journal
 
+## 2025-05-17 - Avoiding Deceptive Interactivity and Unifying Focus States
+
+**Learning:** "Deceptive interactivity" (e.g., using `cursor: pointer` or "lift" effects on non-clickable elements like badges) creates a broken promise to the user, leading to frustration when clicking doesn't trigger an action. Additionally, links with custom classes often miss the global focus indicator styles, creating an inconsistent experience for keyboard users.
+
+**Action:** Removed pointer cursors and interactive transformations from the `Pill` component to better reflect its status as a static badge. Unified focus states by explicitly adding `:focus-visible` outlines to navigational links with classes (`.back-link`, `.version-link`), ensuring a consistent 2px accent outline with 4px offset across the site.
+
 ## 2025-05-15 - Improving Keyboard Accessibility with Enhanced Focus States
 
 **Learning:** When implementing a glassmorphic design with subtle backgrounds and lift effects (like `translateY`), standard focus outlines can feel disconnected or get lost in the translucency. Using `:focus-visible` specifically allows for high-visibility outlines that only appear for keyboard users, avoiding visual noise for mouse users. Combining the focus state with the same "lift" effect used on hover provides a consistent spatial mental model for the interface.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -106,6 +106,12 @@ const currentYear = new Date().getFullYear();
     color: var(--gray-200);
   }
 
+  .version-link:focus-visible {
+    outline: 2px solid var(--accent-regular);
+    outline-offset: 4px;
+    border-radius: 0.25rem;
+  }
+
   .separator {
     padding: 0 0.5rem;
     color: var(--gray-600);

--- a/src/components/Pill.astro
+++ b/src/components/Pill.astro
@@ -28,20 +28,12 @@
       transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
       box-shadow 0.3s ease,
       border-color 0.3s ease;
-    cursor: pointer;
     user-select: none;
   }
 
   .pill:hover {
     background-position: 100% 50%;
-    transform: translateY(-4px) scale(1.02);
     box-shadow: var(--shadow-md);
     border-color: transparent;
-  }
-
-  .pill:active {
-    transform: translateY(-1px) scale(0.96);
-    background-position: 50% 50%;
-    box-shadow: var(--shadow-sm);
   }
 </style>

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -148,6 +148,12 @@ const schema = {
     text-decoration-color: currentColor;
   }
 
+  .back-link:focus-visible {
+    outline: 2px solid var(--accent-regular);
+    outline-offset: 4px;
+    border-radius: 0.25rem;
+  }
+
   @media (min-width: 50em) {
     .back-link {
       display: block;


### PR DESCRIPTION
This PR implements a micro-UX and accessibility improvement by unifying focus states for navigational links with custom classes and refining the `Pill` component to avoid "deceptive interactivity." 

Specifically, it:
1.  **Enhances Keyboard Accessibility:** Adds standard `:focus-visible` outlines (2px solid accent, 4px offset) to the "Back to Work" link in project pages and the version/issue links in the footer, which previously lacked prominent focus indicators.
2.  **Refines Interaction Models:** Removes `cursor: pointer`, the vertical "lift" hover effect, and the scale-down active effect from the `Pill` component. These elements are non-interactive badges, and their previous styling falsely suggested they were clickable buttons.
3.  **Documents UX Best Practices:** Adds a new entry to the Palette journal explaining the logic behind these changes and the importance of honest interaction design.

These changes ensure a more consistent and accessible experience while maintaining the site's minimalist, glassmorphic aesthetic.

---
*PR created automatically by Jules for task [18366102551687203537](https://jules.google.com/task/18366102551687203537) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added explicit keyboard focus outlines to navigation links for improved keyboard accessibility
  * Removed pointer cursor styling from interactive pill components
  * Simplified hover state effects by removing transform animations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->