### PR TITLE
Add SSE stream parser for AI chatbot responses

### DIFF
--- a/.wrangler/deploy/config.json
+++ b/.wrangler/deploy/config.json
@@ -1,5 +1,1 @@
-{
-  "configPath": "../../dist/server/wrangler.json",
-  "auxiliaryWorkers": [],
-  "prerenderWorkerConfigPath": "../../dist/server/.prerender/wrangler.json"
-}
+{"configPath":"../../dist/server/wrangler.json","auxiliaryWorkers":[]}

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -238,6 +238,8 @@
 </style>
 
 <script>
+  import { createChatStreamParser, extractAssistantTextFromSse } from '../utils/chat-stream';
+
   const chatToggle = document.getElementById('chat-toggle');
   const chatWindow = document.getElementById('chat-window');
   const chatClose = document.getElementById('chat-close');
@@ -257,6 +259,23 @@
     content: string;
   }
 
+  function normalizeMessage(message: Message): Message {
+    if (message.role !== 'assistant') {
+      return message;
+    }
+
+    const normalizedContent = extractAssistantTextFromSse(message.content);
+
+    if (normalizedContent.length === 0) {
+      return message;
+    }
+
+    return {
+      ...message,
+      content: normalizedContent,
+    };
+  }
+
   function appendMessage(role: string, content: string) {
     const messageDiv = document.createElement('div');
     messageDiv.className = `message ${role}-message`;
@@ -267,7 +286,7 @@
   }
 
   // Load history
-  messages.forEach((msg: Message) => {
+  messages.map(normalizeMessage).forEach((msg: Message) => {
     const displayRole = msg.role === 'ai' ? 'assistant' : msg.role;
     appendMessage(displayRole, msg.content);
   });
@@ -304,6 +323,7 @@
       typingIndicator?.classList.add('hidden');
       const aiMessageDiv = appendMessage('assistant', '');
       let aiContent = '';
+      const streamParser = createChatStreamParser();
 
       const reader = response.body?.getReader();
       const decoder = new TextDecoder();
@@ -312,11 +332,20 @@
         while (true) {
           const { done, value } = await reader.read();
           if (done) break;
-          const chunk = decoder.decode(value);
-          aiContent += chunk;
-          aiMessageDiv.textContent = aiContent;
+          const chunk = decoder.decode(value, { stream: true });
+          const parsedChunk = streamParser.push(chunk);
+          if (parsedChunk) {
+            aiContent += parsedChunk;
+            aiMessageDiv.textContent = aiContent;
+          }
           chatMessages?.scrollTo(0, chatMessages.scrollHeight);
         }
+      }
+
+      const remainingContent = streamParser.flush();
+      if (remainingContent) {
+        aiContent += remainingContent;
+        aiMessageDiv.textContent = aiContent;
       }
 
       messages.push({ role: 'assistant', content: aiContent });

--- a/src/utils/chat-stream.test.ts
+++ b/src/utils/chat-stream.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { createChatStreamParser, extractAssistantTextFromSse } from './chat-stream';
+
+function event(response: string) {
+  return `data: ${JSON.stringify({ response, p: 'abc' })}\n\n`;
+}
+
+describe('chat stream parser', () => {
+  it('extracts readable text from a complete SSE transcript', () => {
+    const raw = `${event('As')}${event(' a')}${event(' strategic Product Leader')}${event(' at IFS')}${'data: [DONE]\n\n'}`;
+
+    expect(extractAssistantTextFromSse(raw)).toBe('As a strategic Product Leader at IFS');
+  });
+
+  it('buffers partial chunks until a full event arrives', () => {
+    const parser = createChatStreamParser();
+
+    expect(parser.push('data: {"response":"As","p":"abc"}')).toBe('');
+    expect(parser.push('\n\ndata: {"response":" a","p":"abc"}\n\n')).toBe('As a');
+    expect(parser.flush()).toBe('');
+  });
+
+  it('flushes a trailing event that ends without a terminating newline', () => {
+    const parser = createChatStreamParser();
+
+    expect(parser.push('data: {"response":"End","p":"abc"}')).toBe('');
+    expect(parser.flush()).toBe('End');
+  });
+
+  it('ignores invalid and metadata-only SSE payloads', () => {
+    const raw =
+      'data: {"response":null,"usage":{"prompt_tokens":1}}\n\n' +
+      'data: {"response":"Hello"}\n\n' +
+      'data: not-json\n\n';
+
+    expect(extractAssistantTextFromSse(raw)).toBe('Hello');
+  });
+
+  it('returns an empty string for SSE-shaped payloads without assistant text', () => {
+    expect(extractAssistantTextFromSse('data: not-json\n\n')).toBe('');
+  });
+
+  it('treats event-only payloads as SSE and ignores them when they have no response text', () => {
+    expect(extractAssistantTextFromSse('event: message\n\n')).toBe('');
+  });
+
+  it('falls back to plain text when the input is not SSE', () => {
+    expect(extractAssistantTextFromSse('Hello world')).toBe('Hello world');
+  });
+});

--- a/src/utils/chat-stream.ts
+++ b/src/utils/chat-stream.ts
@@ -1,0 +1,94 @@
+const DATA_PREFIX = 'data:';
+const DONE_MARKER = '[DONE]';
+
+interface SseParserState {
+  currentEventLines: string[];
+  partialLine: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function looksLikeSsePayload(raw: string): boolean {
+  return raw.includes(DATA_PREFIX) || raw.includes(DONE_MARKER) || raw.includes('event:');
+}
+
+function extractResponseFromPayload(payload: string): string {
+  if (!payload || payload === DONE_MARKER) {
+    return '';
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(payload);
+
+    if (isRecord(parsed) && typeof parsed.response === 'string') {
+      return parsed.response;
+    }
+  } catch {
+    return '';
+  }
+
+  return '';
+}
+
+function consumeLine(state: SseParserState, line: string): string {
+  if (line === '') {
+    const payload = state.currentEventLines.join('\n').trim();
+    state.currentEventLines = [];
+    return extractResponseFromPayload(payload);
+  }
+
+  if (line.startsWith(DATA_PREFIX)) {
+    state.currentEventLines.push(line.slice(DATA_PREFIX.length).trimStart());
+  }
+
+  return '';
+}
+
+function processBufferedText(state: SseParserState, input: string, isFinalChunk: boolean): string {
+  const normalizedInput = `${state.partialLine}${input}`.replaceAll('\r\n', '\n');
+  const lines = normalizedInput.split('\n');
+  const lastIndex = isFinalChunk ? lines.length : Math.max(lines.length - 1, 0);
+  let parsedText = '';
+
+  for (let index = 0; index < lastIndex; index += 1) {
+    parsedText += consumeLine(state, lines[index]);
+  }
+
+  state.partialLine = isFinalChunk ? '' : lines[lines.length - 1];
+
+  if (isFinalChunk && state.currentEventLines.length > 0) {
+    parsedText += extractResponseFromPayload(state.currentEventLines.join('\n').trim());
+    state.currentEventLines = [];
+  }
+
+  return parsedText;
+}
+
+export function createChatStreamParser() {
+  const state: SseParserState = {
+    currentEventLines: [],
+    partialLine: '',
+  };
+
+  return {
+    push(chunk: string) {
+      return processBufferedText(state, chunk, false);
+    },
+    flush() {
+      return processBufferedText(state, '', true);
+    },
+  };
+}
+
+export function extractAssistantTextFromSse(raw: string) {
+  const parser = createChatStreamParser();
+  const text = parser.push(raw) + parser.flush();
+
+  if (text.trim().length > 0) {
+    return text;
+  }
+
+  return looksLikeSsePayload(raw) ? '' : raw;
+}


### PR DESCRIPTION
Implement a robust Server-Sent Events (SSE) parser to extract and normalize assistant messages from streaming chat responses. The parser handles partial chunks, buffers incomplete events, and gracefully falls back to plain text for non-SSE payloads. This enhancement ensures clean message display by stripping SSE protocol artifacts from chat history and real-time streaming content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved chat response streaming for enhanced reliability and performance
  * Enhanced chat history preprocessing to ensure consistent message display

* **Tests**
  * Added comprehensive test suite for chat stream parsing utilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alehar9320/astro-cloudflare-personal-website/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->