### PR TITLE
📝 Docu: Document Chat Logic Utilities

### DIFF
--- a/.Jules/docu.md
+++ b/.Jules/docu.md
@@ -3,3 +3,5 @@
 ## 2026-04-12 - [GitHub Release Utils] | **Drift Identified:** Undocumented helper functions in `src/utils/github-releases.ts` | **Action:** Added JSDoc headers to all utility functions.
 
 ## 2026-05-12 - [Chat Stream Utils] | **Drift Identified:** Undocumented helper functions in `src/utils/chat-stream.ts` | **Action:** Added JSDoc headers to all utility functions following project clarity standards.
+
+## 2026-06-12 - [Chat Logic Utils] | **Drift Identified:** Undocumented constants and schemas in `src/utils/chat-logic.ts` | **Action:** Added concise JSDoc headers to constants and schemas to match project documentation standards.

--- a/src/utils/chat-logic.ts
+++ b/src/utils/chat-logic.ts
@@ -1,11 +1,16 @@
 import { z } from 'zod';
 
+/** Maximum number of messages to keep in the conversation history. */
 export const MAX_MESSAGES = 10;
+/** Maximum character length allowed for a single message. */
 export const MAX_MESSAGE_CONTENT_LENGTH = 500;
+/** Maximum total character length allowed across all messages in a request. */
 export const MAX_TOTAL_CONTENT_LENGTH = 3000;
 
+/** Schema for valid chat participant roles. */
 export const ChatRoleSchema = z.enum(['user', 'assistant']);
 
+/** Schema for a single chat message, enforcing content length and role. */
 export const ChatMessageSchema = z.object({
   role: ChatRoleSchema,
   content: z
@@ -20,6 +25,7 @@ export const ChatMessageSchema = z.object({
 
 export type ChatMessage = z.infer<typeof ChatMessageSchema>;
 
+/** Schema for chat requests, requiring at least one message. */
 export const ChatRequestSchema = z.object({
   // Relaxed constraints: pruneMessages will handle the sliding window to fit model limits.
   messages: z.array(ChatMessageSchema).min(1, 'Expected at least one message'),


### PR DESCRIPTION
I have documented the chat logic utilities in `src/utils/chat-logic.ts`.

Key improvements:
- Added JSDoc headers to `MAX_MESSAGES`, `MAX_MESSAGE_CONTENT_LENGTH`, and `MAX_TOTAL_CONTENT_LENGTH`.
- Added JSDoc headers to `ChatRoleSchema`, `ChatMessageSchema`, and `ChatRequestSchema`.
- Updated `.Jules/docu.md` to record the drift identification and correction.

All quality gates passed:
- `npm run lint` and `npm run format` passed.
- `npm run astro check` passed (excluding pre-existing issues).
- `npm run test` passed.
- `npm run build` passed.

---
*PR created automatically by Jules for task [4034344069918095917](https://jules.google.com/task/4034344069918095917) started by @alehar9320*