### PR TITLE
Hire path: Get in touch one-click to LinkedIn

### DIFF
--- a/src/components/ContactCTA.astro
+++ b/src/components/ContactCTA.astro
@@ -6,19 +6,16 @@ import Icon from './Icon.astro';
 <aside>
   <h2>Ready to collaborate on high-impact initiatives?</h2>
   <div class="cta-stack">
-    <CallToAction href="/contact/" data-hire-event="hire_cta_click" data-hire-surface="contact_cta">
-      Get in touch
-      <Icon icon="paper-plane-tilt" size="1.2em" />
-    </CallToAction>
-    <a
+    <CallToAction
       href="https://www.linkedin.com/in/alehar/"
       target="_blank"
       rel="noopener noreferrer"
-      data-hire-event="linkedin_click"
+      data-hire-event="hire_cta_click"
       data-hire-surface="contact_cta"
     >
-      LinkedIn
-    </a>
+      Message on LinkedIn
+      <Icon icon="paper-plane-tilt" size="1.2em" />
+    </CallToAction>
   </div>
 </aside>
 

--- a/src/components/ContactCTA.astro
+++ b/src/components/ContactCTA.astro
@@ -13,9 +13,10 @@ import Icon from './Icon.astro';
       data-hire-event="hire_cta_click"
       data-hire-surface="contact_cta"
     >
-      Message on LinkedIn
+      Get in touch
       <Icon icon="paper-plane-tilt" size="1.2em" />
     </CallToAction>
+    <p class="cta-hint">LinkedIn · replies from me</p>
   </div>
 </aside>
 
@@ -44,7 +45,14 @@ import Icon from './Icon.astro';
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 1rem;
+    gap: 0.4rem;
+  }
+
+  .cta-hint {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--gray-300);
+    font-weight: 400;
   }
 
   @media (min-width: 50em) {

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -23,8 +23,9 @@ const linkedinHref = 'https://www.linkedin.com/in/alehar/';
           data-hire-event="linkedin_click"
           data-hire-surface="contact_page"
         >
-          Message on LinkedIn
+          Get in touch
         </CallToAction>
+        <p class="cta-hint">LinkedIn · replies from me</p>
       </div>
     </Hero>
   </main>
@@ -45,7 +46,14 @@ const linkedinHref = 'https://www.linkedin.com/in/alehar/';
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 1rem;
+    gap: 0.4rem;
     margin-top: 0.5rem;
+  }
+
+  .cta-hint {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--gray-300);
+    font-weight: 400;
   }
 </style>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -23,7 +23,7 @@ const linkedinHref = 'https://www.linkedin.com/in/alehar/';
           data-hire-event="linkedin_click"
           data-hire-surface="contact_page"
         >
-          LinkedIn
+          Message on LinkedIn
         </CallToAction>
       </div>
     </Hero>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -105,11 +105,13 @@ const schema = {
           </p>
           <div class="hero-actions">
             <CallToAction
-              href="/contact/"
+              href="https://www.linkedin.com/in/alehar/"
+              target="_blank"
+              rel="noopener noreferrer"
               data-hire-event="hire_cta_click"
               data-hire-surface="hero"
             >
-              Get in touch
+              Message on LinkedIn
             </CallToAction>
           </div>
           <div class="roles">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -111,8 +111,9 @@ const schema = {
               data-hire-event="hire_cta_click"
               data-hire-surface="hero"
             >
-              Message on LinkedIn
+              Get in touch
             </CallToAction>
+            <p class="cta-hint">LinkedIn · replies from me</p>
           </div>
           <div class="roles">
             <Pill><Icon icon="strategy" size="1.33em" /> Technical Product Management</Pill>
@@ -232,9 +233,18 @@ const schema = {
   .hero-actions {
     margin-top: 0.75rem;
     display: flex;
+    flex-direction: column;
     flex-wrap: wrap;
-    gap: 0.75rem;
+    gap: 0.4rem;
+    align-items: center;
     justify-content: center;
+  }
+
+  .cta-hint {
+    margin: 0;
+    font-size: var(--text-sm);
+    color: var(--gray-300);
+    font-weight: 400;
   }
 
   .hero img {
@@ -262,6 +272,7 @@ const schema = {
 
     .hero-actions {
       justify-content: flex-start;
+      align-items: flex-start;
     }
 
     .hero img {


### PR DESCRIPTION
## Summary
Get in touch was two clicks (home → /contact → LinkedIn). Recruiter/collab outcome is a conversation. Until there is a real inbox or CV, LinkedIn is the only honest completion.

Quieter-home CTA only (no H1 retitle, no killing TL;DR/cards):

- Hero, ContactCTA, and `/contact` button label: **Get in touch**
- href `https://www.linkedin.com/in/alehar/` in a new tab (`noopener noreferrer`)
- Quiet helper under the button, not a second pill: **LinkedIn · replies from me**
- Nav Contact still goes to `/contact/`
- No mailto. No placeholder CV. Chat unchanged and is not the hire path.
- Named hire events kept. Surfaces: hero / contact_cta / contact_page.

## Test plan
- [ ] Quality (format, lint, audit) green
- [ ] Hero and footer CTA say Get in touch and open LinkedIn in a new tab
- [ ] Quiet hint is text under the button, not a second pill
- [ ] Nav Contact still opens `/contact/`
- [ ] `/contact/` has the same button + hint
- [ ] Chat tooltip unchanged