### PR TITLE
Enable auto-merge for green PRs, not only Dependabot

### DIFF
--- a/.github/workflows/enable-automerge.yml
+++ b/.github/workflows/enable-automerge.yml
@@ -1,0 +1,29 @@
+name: Enable Auto-Merge
+
+# Opt new PRs into GitHub auto-merge. Dependabot keeps using
+# dependabot-automerge.yml (including the major-version skip).
+# Trigger only on opened / ready_for_review / reopened so Mergify
+# synchronize events on the existing open-PR pile do not mass-merge.
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
+    steps:
+      - name: Enable squash auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,11 +15,11 @@ pull_request_rules:
     actions:
       merge:
   - name: Make sure PR are update before merging with rebase
-    description: This automatically rebases PRs when they are out-of-date with the
-      base branch to avoid semantic conflicts (next step us switch to merge
-      queue).
+    description: Rebase automerge-labeled PRs that are far behind. Restricted so
+      the rest of the open-PR pile is not constantly rebased.
     conditions:
       - -closed
+      - label = automerge
       - '#commits-behind >= 10'
     actions:
       rebase:
@@ -34,11 +34,11 @@ pull_request_rules:
         toggle:
           - size/L
   - name: Make sure PR are up to date before merging
-    description: This automatically updates PRs when they are out-of-date with the
-      base branch to avoid semantic conflicts (next step is using a merge
-      queue).
+    description: Update automerge-labeled PRs when they are slightly behind.
+      Restricted so the rest of the open-PR pile is not constantly updated.
     conditions:
       - -closed
+      - label = automerge
       - '#commits-behind > 0'
       - '#commits-behind < 10'
     actions:


### PR DESCRIPTION
## Why
Green PRs were not auto-merging because auto-merge was only wired for Dependabot.

- Repo `allow_auto_merge` is already on
- `.github/workflows/dependabot-automerge.yml` runs `gh pr merge --auto --squash` only when `github.actor == 'dependabot[bot]'` (and skips majors)
- Mergify's merge rule only fires with the `automerge` label
- Mergify was also updating/rebasing **every** open PR, which is why CI keeps thrashing on the ~169-PR pile

## What changed
1. New workflow `.github/workflows/enable-automerge.yml` enables squash auto-merge on **opened / ready_for_review / reopened** for non-draft, same-repo PRs into `main`. Dependabot is left to the existing workflow (majors still skip). Trigger types are intentionally narrow so Mergify `synchronize` events on old PRs do not mass-merge the pile.
2. Mergify `update` / `rebase` rules now require the `automerge` label. Conflict labels and t-shirt sizes are unchanged. Existing PRs can still opt in by adding `automerge`.

## Not in this PR
Does not close or merge the existing open PRs. After this lands, new PRs auto-merge once required checks pass.
