### PR TITLE
fix: remove chat FAB idle status-dot node

### DIFF
--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -156,7 +156,6 @@
     }
   }
 
-
   /* Tooltip */
   .status-tooltip {
     position: absolute;

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -22,7 +22,6 @@
       stroke-linecap="round"
       stroke-linejoin="round"><path d="m3 21 1.9-5.7a8.5 8.5 0 1 1 3.8 3.8z"></path></svg
     >
-    <span class="status-dot" aria-hidden="true"></span>
     <span role="tooltip" id="status-tooltip" class="status-tooltip">Ask about the work</span>
   </button>
 
@@ -157,10 +156,6 @@
     }
   }
 
-  /* FAB must not read as "available to hire" */
-  .chat-toggle .status-dot {
-    display: none;
-  }
 
   /* Tooltip */
   .status-tooltip {


### PR DESCRIPTION
## Summary
Live bounce: the chat FAB still painted a green idle dot on https://me.alehar.workers.dev/ even with `display: none`. The node was still in the DOM (`span.status-dot.idle`, `rgb(34,197,94)`).

This PR **deletes** the FAB status-dot node. It does not hide it with CSS. Header status-dot stays for loading/error in the open panel. No home restyle.

## Test plan
- [ ] FAB has no `.status-dot` node
- [ ] Tooltip still **Ask about the work**
- [ ] Open chat header can still show status
- [ ] Quality honestly green (format, lint, audit)
- [ ] Keep as draft until Nick says auto-merge / UX bounce