### PR TITLE
perf: defer PostHog init until idle

### DIFF
--- a/src/components/PostHog.astro
+++ b/src/components/PostHog.astro
@@ -4,10 +4,18 @@
   const posthogKey = import.meta.env.PUBLIC_POSTHOG_KEY;
   const posthogHost = import.meta.env.PUBLIC_POSTHOG_HOST ?? 'https://app.posthog.com';
 
-  if (posthogKey) {
+  function initPostHog() {
+    if (!posthogKey) return;
     posthog.init(posthogKey, {
       api_host: posthogHost,
       person_profiles: 'identified_only',
     });
   }
+
+  const scheduleIdle =
+    typeof requestIdleCallback === 'function'
+      ? (cb: () => void) => requestIdleCallback(cb)
+      : (cb: () => void) => setTimeout(cb, 1);
+
+  scheduleIdle(initPostHog);
 </script>


### PR DESCRIPTION
## Summary
Defer `posthog.init` until the browser is idle via `requestIdleCallback`, with a `setTimeout` fallback. First paint is not blocked by analytics.

- Touches only `src/components/PostHog.astro`
- No lockfile, no Astro bump
- Does not copy #285 (that branch stays draft)

## Test plan
- [ ] Quality honestly green (format, lint, audit)
- [ ] PostHog still inits when `PUBLIC_POSTHOG_KEY` is set
- [ ] Keep as draft until Nick says auto-merge