### PR TITLE
Wire PostHog public env into the production build

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,7 +15,7 @@ const isAstroCheck = process.argv.includes('check');
 // PostHog never initialized on prod (key missing → PostHog.astro no-ops).
 try {
   const wranglerConfig = JSON.parse(
-    readFileSync(new URL('./wrangler.jsonc', import.meta.url), 'utf8'),
+    readFileSync(new URL('./wrangler.jsonc', import.meta.url), 'utf8')
   );
   for (const [key, value] of Object.entries(wranglerConfig.vars ?? {})) {
     if (process.env[key] === undefined && value != null) {

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,5 @@
 // @ts-check
+import { readFileSync } from 'node:fs';
 import { defineConfig } from 'astro/config';
 import { codecovVitePlugin } from '@codecov/vite-plugin';
 
@@ -8,6 +9,22 @@ import sentry from '@sentry/astro';
 
 const isRender = process.env.RENDER === 'true';
 const isAstroCheck = process.argv.includes('check');
+
+// Vite inlines PUBLIC_* from process.env at build time. Cloudflare Workers
+// Builds does not inject wrangler.jsonc vars into that env, which is why
+// PostHog never initialized on prod (key missing → PostHog.astro no-ops).
+try {
+  const wranglerConfig = JSON.parse(
+    readFileSync(new URL('./wrangler.jsonc', import.meta.url), 'utf8'),
+  );
+  for (const [key, value] of Object.entries(wranglerConfig.vars ?? {})) {
+    if (process.env[key] === undefined && value != null) {
+      process.env[key] = String(value);
+    }
+  }
+} catch {
+  // wrangler.jsonc is optional for `astro check` / local without the file.
+}
 
 const codecovPlugin = /** @type {import('vite').PluginOption} */ (
   codecovVitePlugin({

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -20,6 +20,7 @@
     }
   ],
   "vars": {
-    "PUBLIC_POSTHOG_HOST": "https://eu.i.posthog.com"
+    "PUBLIC_POSTHOG_HOST": "https://eu.i.posthog.com",
+    "PUBLIC_POSTHOG_KEY": "phc_sMWrvgXAzhmDbkdmngsr3W7ZgJ4UdRTpzM2an8H2NUN7"
   }
 }


### PR DESCRIPTION
## Why
Prod analytics is silent (0 pageviews / 30 days). `src/components/PostHog.astro` reads `import.meta.env.PUBLIC_POSTHOG_KEY` at Vite build time and returns immediately if it is missing.

Cloudflare Workers Builds does not inject GitHub secrets into that env. `wrangler.jsonc` had the EU host as a **runtime** Worker var only, which never reaches `import.meta.env`. The prod client bundle has the PostHog SDK and no project key, so init never runs.

## What changed
- Add the public PostHog project key next to the existing EU host in `wrangler.jsonc` `vars` (this is a client ingest token, same class as a GA measurement ID).
- At `astro.config.mjs` load, copy `wrangler.jsonc` `vars` into `process.env` so Vite inlines `PUBLIC_*` during `npm run build`.

After this deploys, a hard refresh of https://me.alehar.workers.dev/ should start sending `$pageview` to the EU project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the public PostHog key through Wrangler settings.
  * Automatically uses optional local configuration values when available during build setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->