### PR TITLE
fix: send PostHog capture to EU after idle

### DIFF
--- a/src/components/PostHog.astro
+++ b/src/components/PostHog.astro
@@ -2,13 +2,16 @@
   import posthog from 'posthog-js';
 
   const posthogKey = import.meta.env.PUBLIC_POSTHOG_KEY;
-  const posthogHost = import.meta.env.PUBLIC_POSTHOG_HOST ?? 'https://app.posthog.com';
+  const posthogHost = import.meta.env.PUBLIC_POSTHOG_HOST || 'https://eu.i.posthog.com';
 
   function initPostHog() {
     if (!posthogKey) return;
     posthog.init(posthogKey, {
       api_host: posthogHost,
+      ui_host: 'https://eu.posthog.com',
       person_profiles: 'identified_only',
+      capture_pageview: true,
+      capture_pageleave: true,
     });
   }
 


### PR DESCRIPTION
## Summary
Capture on prod is dead. PostHog project 171414 (eu.posthog.com) has 29 all-time \`\$pageview\` events since May and 0 in the last 30 days. Snippet onboarding is incomplete.

What was wrong in code:
- Idle init defaulted \`api_host\` to **US** \`https://app.posthog.com\` when Vite env was empty. wrangler already has EU ingest (\`https://eu.i.posthog.com\`), but that var is runtime and does not reach \`import.meta.env\` on a static Workers Build.
- \`\$pageview\` is now explicit (\`capture_pageview: true\`) after the idle callback.

What this PR does not fix (needs a Cloudflare **build-time** \`PUBLIC_POSTHOG_KEY\`):
- GitHub has \`PUBLIC_POSTHOG_KEY\` as a **secret**. Workers Builds does not inlined GitHub secrets into \`import.meta.env\`. If the key is empty at build, \`initPostHog\` returns and nothing is sent, even with the EU host.
- No public visit counter.

## Test plan
- [ ] Quality honestly green
- [ ] Keep draft until Nick says auto-merge
- [ ] After a Cloudflare build env key is set (or a public project token is baked in), \`\$pageview\` lands on EU project 171414