### PR TITLE
feat: first-screen 100dvh and CSS aurora wash

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -25,6 +25,10 @@ const { title, description } = Astro.props;
     <a href="#main-content" class="sr-only focus-visible">Skip to content</a>
 
     <div class="stack backgrounds">
+      <div class="aurora" aria-hidden="true">
+        <span class="aurora-wash aurora-wash-a"></span>
+        <span class="aurora-wash aurora-wash-b"></span>
+      </div>
       <Nav />
       <slot />
       <Footer />
@@ -103,6 +107,74 @@ const { title, description } = Astro.props;
         position: relative;
       }
 
+      .aurora {
+        position: absolute;
+        inset: 0;
+        z-index: -1;
+        pointer-events: none;
+        overflow: hidden;
+      }
+
+      .aurora-wash {
+        position: absolute;
+        inset: -20%;
+        pointer-events: none;
+      }
+
+      .aurora-wash-a {
+        background: radial-gradient(
+          ellipse 55% 45% at 28% 22%,
+          var(--accent-light),
+          transparent 70%
+        );
+        opacity: 0.14;
+      }
+
+      .aurora-wash-b {
+        background: radial-gradient(
+          ellipse 50% 55% at 78% 38%,
+          var(--accent-regular),
+          transparent 68%
+        );
+        opacity: 0.12;
+      }
+
+      :root.theme-dark .aurora-wash-a {
+        opacity: 0.34;
+      }
+
+      :root.theme-dark .aurora-wash-b {
+        opacity: 0.28;
+      }
+
+      @media (prefers-reduced-motion: no-preference) {
+        .aurora-wash-a {
+          animation: aurora-drift-a 45s ease-in-out infinite alternate;
+        }
+
+        .aurora-wash-b {
+          animation: aurora-drift-b 70s ease-in-out infinite alternate;
+        }
+      }
+
+      @keyframes aurora-drift-a {
+        from {
+          transform: translate3d(-3%, -2%, 0);
+        }
+        to {
+          transform: translate3d(8%, 6%, 0);
+        }
+      }
+
+      @keyframes aurora-drift-b {
+        from {
+          transform: translate3d(2%, 0, 0);
+        }
+        to {
+          transform: translate3d(-7%, 5%, 0);
+        }
+      }
+
       .backgrounds::before {
         content: '';
         position: absolute;
@@ -131,6 +203,10 @@ const { title, description } = Astro.props;
           background: none;
           background-blend-mode: none;
           --bg-gradient-size: none;
+        }
+
+        .aurora {
+          display: none;
         }
       }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -68,7 +68,7 @@ const schema = {
   description="Product Manager, Developer Experience at IFS."
 >
   <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
-  <main id="main-content" class="wrapper stack gap-16 lg:gap-24">
+  <main id="main-content" class="wrapper stack first-screen">
     <header class="hero">
       <Hero title="Product Manager, Developer Experience at IFS" align="start">
         <div class="hero-actions">
@@ -116,12 +116,21 @@ const schema = {
 </BaseLayout>
 
 <style>
+  .first-screen {
+    min-height: 100vh;
+    min-height: 100svh;
+    min-height: 100dvh;
+    justify-content: center;
+    gap: 2rem;
+    padding-block: 1rem 2rem;
+    box-sizing: border-box;
+  }
+
   .hero {
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 2rem;
-    padding-bottom: 5.5rem;
   }
 
   .hero-actions {


### PR DESCRIPTION
## Summary
- Implements Johan's aurora-first-screen spec (15 Aug): home `min-height` 100dvh / 100svh / 100vh so the footer only appears after scroll; CSS-only aurora wash sits behind content.
- Quieter home is unchanged: one H1, one proof card, one Get in touch.
- `prefers-reduced-motion: reduce` freezes the aurora; `forced-colors` hides it.
- No canvas, WebGL, new colors, extra cards, or H1 shimmer.

## Notes
- Draft, no auto-merge.
- Independent of capture PR #436.

## Test plan
- [ ] Home first screen fills the viewport; footer is below the fold until scroll.
- [ ] Aurora washes are visible (stronger in dark theme) and drift slowly.
- [ ] `prefers-reduced-motion: reduce` freezes aurora.
- [ ] Forced colors hides aurora.
- [ ] No extra cards, canvas, or color tokens.