### PR TITLE
feat: ensure home first viewport fills screen above fold

### DIFF
--- a/.Jules/jules.md
+++ b/.Jules/jules.md
@@ -9,3 +9,9 @@
 - [Insight 1: Shimmer micro-interactions provide high-quality visual feedback without increasing JS bundle size.]
 - [Insight 2: Using `translateX` for the shimmer sweep is more performant than animating `background-position` as it avoids layout repaints.]
 - [Delta: 18 lines. Guardrails: All passed autonomously.]
+
+## 2026-05-28 - Quieter Home First Viewport | Signal: Product/UX | Lean Implementation: Full Viewport Height Adjustment
+
+- [Insight 1: Setting dynamic viewport units (`min-height: calc(100dvh - header_height)`) on the `.hero` container reliably pushes secondary cards and the site footer below the initial fold on both mobile and desktop screens.]
+- [Insight 2: Centering hero flex content vertically within `100dvh` creates a balanced, quieter initial view without requiring structural DOM changes.]
+- [Delta: ~12 lines modified in `src/pages/index.astro`. Guardrails: All passed.]

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -120,8 +120,10 @@ const schema = {
     display: flex;
     flex-direction: column;
     align-items: center;
+    justify-content: center;
     gap: 2rem;
-    padding-bottom: 5.5rem;
+    padding-bottom: 2rem;
+    min-height: calc(100dvh - 7rem);
   }
 
   .hero-actions {
@@ -238,9 +240,11 @@ const schema = {
     .hero {
       display: grid;
       grid-template-columns: 6fr 4fr;
+      align-content: center;
       padding-inline: 2.5rem;
       gap: 3.75rem;
-      padding-bottom: 0;
+      padding-bottom: 2rem;
+      min-height: calc(100dvh - 9rem);
     }
 
     .hero-actions {


### PR DESCRIPTION
Adjust home hero min-height and flex alignment so the first viewport fills the screen with navigation and hero section on mobile and desktop viewports, pushing the proof card and footer below the fold.

Fixes #438

---
*PR created automatically by Jules for task [17853442875882778676](https://jules.google.com/task/17853442875882778676) started by @alehar9320*