### PR TITLE
feat: finish the digital twin chat

### DIFF
--- a/src/__tests__/chat-api.test.ts
+++ b/src/__tests__/chat-api.test.ts
@@ -79,6 +79,19 @@ describe('chat API', () => {
         stream: true,
       })
     );
+
+    const firstCall = ai.run.mock.calls[0][1] as {
+      messages: Array<{ role: string; content: string }>;
+    };
+    const systemPrompt = firstCall.messages[0].content;
+    expect(systemPrompt).toContain('Product Manager');
+    expect(systemPrompt).toContain('Developer Experience');
+    expect(systemPrompt).toContain('2x');
+    expect(systemPrompt).toContain('30x');
+    expect(systemPrompt).toContain('Zeroheight');
+    expect(systemPrompt).toContain('linkedin.com/in/alehar');
+    expect(systemPrompt).not.toContain('Strategic Product Leader');
+    expect(systemPrompt).not.toContain('Available');
   });
 
   it('returns 503 when the AI binding is missing', async () => {

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -27,10 +27,13 @@
 
   <div id="chat-window" class="chat-window hidden">
     <div class="chat-header">
-      <span class="chat-header-title">
-        <span class="status-dot" aria-hidden="true"></span>
-        Chat with Alexander's AI
-      </span>
+      <div class="chat-identity">
+        <img class="chat-portrait" src="/assets/portrait.png" width="40" height="40" alt="" />
+        <div class="chat-identity-text">
+          <p class="chat-name">Alexander Härenstam</p>
+          <p class="chat-role">Digital twin</p>
+        </div>
+      </div>
       <button id="chat-close" class="chat-close" aria-label="Close chat">
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -56,6 +59,11 @@
           helpful starting point, not a verified source of truth.
         </p>
       </section>
+      <div id="chat-suggestions" class="chat-suggestions">
+        <button type="button" class="chat-suggestion">IFS Design System</button>
+        <button type="button" class="chat-suggestion">DevEx at IFS</button>
+        <button type="button" class="chat-suggestion">How to get in touch</button>
+      </div>
     </div>
     <div id="typing-indicator" class="typing-indicator hidden">Alexander is typing...</div>
     <form id="chat-form" class="chat-form">
@@ -115,47 +123,6 @@
     outline-offset: 4px;
   }
 
-  /* Status dot shared styles */
-  .status-dot {
-    display: inline-block;
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    flex-shrink: 0;
-    background-color: var(--status-idle);
-    box-shadow: 0 0 6px var(--status-idle);
-    transition:
-      background-color 0.3s ease,
-      box-shadow 0.3s ease;
-  }
-
-  .status-dot.loading {
-    background-color: var(--status-loading);
-    box-shadow: 0 0 6px var(--status-loading);
-    animation: status-pulse 1.2s ease-in-out infinite;
-  }
-
-  .status-dot.error {
-    background-color: var(--status-error);
-    box-shadow: 0 0 6px var(--status-error);
-  }
-
-  @keyframes status-pulse {
-    0%,
-    100% {
-      opacity: 1;
-    }
-    50% {
-      opacity: 0.4;
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .status-dot.loading {
-      animation: none;
-    }
-  }
-
   /* Tooltip */
   .status-tooltip {
     position: absolute;
@@ -179,12 +146,39 @@
     opacity: 1;
   }
 
-  /* Header layout */
-  .chat-header-title {
+  /* Header identity */
+  .chat-identity {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.75rem;
+    min-width: 0;
+  }
+
+  .chat-portrait {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+  }
+
+  .chat-identity-text {
+    min-width: 0;
+  }
+
+  .chat-name {
+    margin: 0;
     font-size: 0.875rem;
+    font-weight: 600;
+    line-height: 1.2;
+    color: var(--gray-0);
+  }
+
+  .chat-role {
+    margin: 0;
+    font-size: 0.75rem;
+    line-height: 1.3;
+    color: var(--gray-400);
   }
 
   .chat-window {
@@ -277,6 +271,35 @@
     color: var(--gray-200);
   }
 
+  .chat-suggestions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    max-width: 100%;
+  }
+
+  .chat-suggestions.hidden {
+    display: none;
+  }
+
+  .chat-suggestion {
+    background: transparent;
+    border: 1px solid var(--gray-800);
+    color: var(--gray-100);
+    border-radius: 999px;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.75rem;
+    font-family: inherit;
+    cursor: pointer;
+  }
+
+  .chat-suggestion:hover,
+  .chat-suggestion:focus-visible {
+    border-color: var(--accent-regular);
+    outline: 2px solid var(--accent-regular);
+    outline-offset: 2px;
+  }
+
   .typing-indicator {
     padding: 0.5rem 1rem;
     font-size: 0.75rem;
@@ -358,6 +381,15 @@
   setStatus('idle');
 
   const messages = JSON.parse(sessionStorage.getItem('chat-history') || '[]');
+  const chatSuggestions = document.getElementById('chat-suggestions');
+
+  function hideSuggestions() {
+    chatSuggestions?.classList.add('hidden');
+  }
+
+  if (messages.length > 0) {
+    hideSuggestions();
+  }
 
   function saveMessages() {
     sessionStorage.setItem('chat-history', JSON.stringify(messages));
@@ -429,11 +461,20 @@
     }
   });
 
+  chatSuggestions?.querySelectorAll('.chat-suggestion').forEach((button) => {
+    button.addEventListener('click', () => {
+      if (!(chatForm instanceof HTMLFormElement) || !chatInput) return;
+      chatInput.value = button.textContent?.trim() ?? '';
+      chatForm.requestSubmit();
+    });
+  });
+
   chatForm?.addEventListener('submit', async (e) => {
     e.preventDefault();
     const content = chatInput.value.trim();
     if (!content) return;
 
+    hideSuggestions();
     chatInput.value = '';
     appendMessage('user', content);
     messages.push({ role: 'user', content });

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -86,11 +86,12 @@ export const POST: APIRoute = async ({ request, locals }) => {
 
   const prunedMessages = pruneMessages(result.data.messages as ChatMessage[]);
 
-  const systemPrompt = `You are Alexander Härenstam, a strategic Product Leader at IFS.
-You are based in Nacka/Stockholm.
-Your tone is professional, insightful, and empathetic.
-You have a background in Software Engineering and Innovation Management.
-Keep your responses brief, typically 2-3 sentences.`;
+  const systemPrompt = `You are the digital twin of Alexander Härenstam, Product Manager, Developer Experience at IFS.
+Answer only from these published facts: DevEx PM at IFS; IFS Design System scaled from inception to IFS Cloud; 2x faster feature delivery; 30x ROI; Zeroheight Design System Awards runner-up.
+Do not invent metrics, quotes, team sizes, or consultant copy.
+If asked for unpublished numbers, say they are not on this site.
+Keep answers brief (2-3 sentences).
+When asked how to get in touch, point to https://www.linkedin.com/in/alehar/.`;
 
   try {
     const stream = await ai.run('@cf/meta/llama-3.1-8b-instruct', {


### PR DESCRIPTION
## Summary

Finishes the digital twin chat panel and grounding. **Draft. No auto-merge. Independent of #439.** No homepage, hire-path, hero, nav, CallToAction, or `/contact` changes. Does not touch `src/pages/index.astro` or `src/layouts/BaseLayout.astro`.

## Ship list

1. **Panel header:** portrait (`/assets/portrait.png`) + name exactly `Alexander Härenstam` + subtitle exactly `Digital twin`. Never the word Available. Green hire status-dot node **deleted** from the panel header (not `display:none`). FAB stays a button with no status-dot. Idle tooltip remains `Ask about the work` (loading/error may stay Thinking... / Connection issue).
2. **Empty state:** existing disclaimer kept (“I'm still an AI... not a verified source of truth”). Input kept. Added suggested-question buttons:
   - IFS Design System
   - DevEx at IFS
   - How to get in touch
   Clicking a suggestion fills the input and submits the existing form. Suggestions hide after the user sends a message, and on reload if session history exists.
3. **Grounded system prompt** in `src/pages/api/chat.ts`: digital twin of Alexander Härenstam, Product Manager, Developer Experience at IFS. Published facts only (DevEx PM at IFS; IFS Design System scaled from inception to IFS Cloud; 2x faster feature delivery; 30x ROI; Zeroheight Design System Awards runner-up). No invented metrics/quotes/team sizes/consultant copy. No “Strategic Product Leader” or “Available”. Answers stay brief (2–3 sentences). Unpublished numbers → not on this site.
4. **Get in touch** answers point to https://www.linkedin.com/in/alehar/ via the system prompt. CallToAction, Nav, index hero, and `/contact` are unchanged.
5. Quieter home + #439 stay untouched.
6. Disclaimer stays. Tooltip stays “Ask about the work”.

## Test plan

- [ ] Open the chat panel: header shows portrait, **Alexander Härenstam**, **Digital twin**; no hire status-dot; no “Available”
- [ ] FAB remains a button; idle tooltip is **Ask about the work**
- [ ] Empty state shows the existing AI disclaimer plus the three suggestion buttons
- [ ] Clicking a suggestion sends that question; suggestions hide after send and after reload with session history
- [ ] Chat API system prompt includes Product Manager, Developer Experience, 2x, 30x, Zeroheight, linkedin.com/in/alehar; does not include “Strategic Product Leader” or “Available”
- [ ] Get-in-touch answers point to LinkedIn; homepage/#439 files are not in this diff