### PR TITLE
fix: small-hero padding and aurora wash blur

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -119,6 +119,7 @@ const { title, description } = Astro.props;
         position: absolute;
         inset: -20%;
         pointer-events: none;
+        filter: blur(80px);
       }
 
       .aurora-wash-a {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -131,6 +131,7 @@ const schema = {
     flex-direction: column;
     align-items: center;
     gap: 2rem;
+    padding-bottom: 5.5rem;
   }
 
   .hero-actions {


### PR DESCRIPTION
Follow-up to merged #439. Johan pass nits: restore padding-bottom 5.5rem on small hero; blur aurora washes. One commit. Does not hold #439 (already merged).