### PR TITLE
feat: honest PostHog pageview count (fail-open)

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -33,6 +33,7 @@ const currentYear = new Date().getFullYear();
       Human + AI Collaboration. Optimized for humans & agents. Content may have flaws; verify for
       accuracy.
     </p>
+    <p class="visit-stats" data-visit-stats hidden></p>
   </div>
   <p class="socials">
     <a href="https://www.linkedin.com/in/alehar/"> LinkedIn</a>
@@ -53,6 +54,7 @@ const currentYear = new Date().getFullYear();
 
 <script>
   import { fetchGitHubReleases } from '../utils/github-releases';
+  import { formatPageviewCount, shouldShowVisitCount } from '../utils/visit-stats';
 
   const versionLink = document.querySelector('[data-latest-version]');
 
@@ -65,6 +67,35 @@ const currentYear = new Date().getFullYear();
 
       versionLink.textContent = 'Latest Updates';
     });
+  }
+
+  const visitStats = document.querySelector('[data-visit-stats]');
+
+  if (visitStats instanceof HTMLElement) {
+    fetch('/api/visits')
+      .then(async (response) => {
+        if (response.status === 204 || !response.ok) return;
+
+        let data: unknown;
+        try {
+          data = await response.json();
+        } catch {
+          return;
+        }
+
+        const pageviews =
+          data && typeof data === 'object' && 'pageviews' in data
+            ? (data as { pageviews: unknown }).pageviews
+            : undefined;
+
+        if (!shouldShowVisitCount(pageviews)) return;
+
+        visitStats.textContent = formatPageviewCount(pageviews);
+        visitStats.hidden = false;
+      })
+      .catch(() => {
+        // Fail-open: keep the count hidden.
+      });
   }
 </script>
 
@@ -140,6 +171,11 @@ const currentYear = new Date().getFullYear();
     font-size: 0.75rem;
     color: var(--gray-600);
     line-height: 1.5;
+  }
+
+  .visit-stats {
+    color: var(--gray-400);
+    font-size: var(--text-sm);
   }
 
   /* Source icon link styling: keep visual weight minimal */

--- a/src/pages/api/visits.ts
+++ b/src/pages/api/visits.ts
@@ -1,0 +1,142 @@
+import type { APIRoute } from 'astro';
+import { shouldShowVisitCount } from '../../utils/visit-stats';
+
+const securityHeaders = {
+  'X-Content-Type-Options': 'nosniff',
+  'X-Frame-Options': 'DENY',
+  'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
+  'Content-Security-Policy': "default-src 'none'; frame-ancestors 'none';",
+} as const;
+
+const jsonHeaders = {
+  'content-type': 'application/json',
+  'Cache-Control': 'public, max-age=300',
+  ...securityHeaders,
+} as const;
+
+const emptyHeaders = {
+  'Cache-Control': 'no-store',
+  ...securityHeaders,
+} as const;
+
+export const prerender = false;
+
+interface VisitEnv {
+  POSTHOG_PERSONAL_API_KEY?: string;
+  POSTHOG_PROJECT_ID?: string;
+  POSTHOG_QUERY_HOST?: string;
+}
+
+const DEFAULT_PROJECT_ID = '171414';
+const DEFAULT_QUERY_HOST = 'https://eu.posthog.com';
+const QUERY_TIMEOUT_MS = 5000;
+const HOGQL = "SELECT count() AS pageviews FROM events WHERE event = '$pageview'";
+
+function empty204() {
+  return new Response(null, { status: 204, headers: emptyHeaders });
+}
+
+function parsePageviews(payload: unknown): number | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const results = (payload as { results?: unknown }).results;
+  if (!Array.isArray(results) || results.length === 0) return null;
+
+  const row = results[0];
+  let raw: unknown;
+
+  if (typeof row === 'number' || typeof row === 'string') {
+    raw = row;
+  } else if (Array.isArray(row)) {
+    raw = row[0];
+  } else if (row && typeof row === 'object' && 'pageviews' in row) {
+    raw = (row as { pageviews: unknown }).pageviews;
+  } else {
+    return null;
+  }
+
+  if (typeof raw === 'number') return raw;
+  if (typeof raw === 'string' && raw.trim() !== '') {
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+export const GET: APIRoute = async ({ locals }) => {
+  const bindings = ((locals as unknown as { runtime?: { env: VisitEnv } }).runtime?.env ||
+    process.env) as unknown as VisitEnv;
+
+  const personalKey = bindings.POSTHOG_PERSONAL_API_KEY?.trim();
+  if (!personalKey) {
+    console.error({ event: 'visits_key_missing' });
+    return empty204();
+  }
+
+  const projectId = (bindings.POSTHOG_PROJECT_ID || DEFAULT_PROJECT_ID).trim();
+  if (!/^\d+$/.test(projectId)) {
+    console.error({ event: 'visits_invalid_project_id' });
+    return empty204();
+  }
+
+  let host: string;
+  try {
+    const parsed = new URL((bindings.POSTHOG_QUERY_HOST || DEFAULT_QUERY_HOST).trim());
+    if (parsed.protocol !== 'https:') {
+      console.error({ event: 'visits_invalid_host' });
+      return empty204();
+    }
+    host = parsed.origin;
+  } catch {
+    console.error({ event: 'visits_invalid_host' });
+    return empty204();
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), QUERY_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${host}/api/projects/${projectId}/query/`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${personalKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: {
+          kind: 'HogQLQuery',
+          query: HOGQL,
+        },
+      }),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      console.error({ event: 'visits_query_failed' });
+      return empty204();
+    }
+
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch {
+      console.error({ event: 'visits_query_invalid' });
+      return empty204();
+    }
+
+    const count = parsePageviews(payload);
+    if (!shouldShowVisitCount(count)) {
+      console.error({ event: 'visits_count_hidden' });
+      return empty204();
+    }
+
+    return new Response(JSON.stringify({ pageviews: count }), {
+      status: 200,
+      headers: jsonHeaders,
+    });
+  } catch {
+    console.error({ event: 'visits_query_failed' });
+    return empty204();
+  } finally {
+    clearTimeout(timeout);
+  }
+};

--- a/src/pages/api/visits.ts
+++ b/src/pages/api/visits.ts
@@ -30,7 +30,8 @@ interface VisitEnv {
 const DEFAULT_PROJECT_ID = '171414';
 const DEFAULT_QUERY_HOST = 'https://eu.posthog.com';
 const QUERY_TIMEOUT_MS = 5000;
-const HOGQL = "SELECT count() AS pageviews FROM events WHERE event = '$pageview'";
+const HOGQL =
+  "SELECT count() AS pageviews FROM events WHERE event = '$pageview' AND timestamp >= toDateTime('1970-01-01 00:00:00')";
 
 function empty204() {
   return new Response(null, { status: 204, headers: emptyHeaders });

--- a/src/utils/visit-stats.test.ts
+++ b/src/utils/visit-stats.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { formatPageviewCount, shouldShowVisitCount } from './visit-stats';
+
+describe('shouldShowVisitCount', () => {
+  it('hides 0', () => {
+    expect(shouldShowVisitCount(0)).toBe(false);
+  });
+
+  it('hides negative numbers', () => {
+    expect(shouldShowVisitCount(-1)).toBe(false);
+  });
+
+  it('hides NaN', () => {
+    expect(shouldShowVisitCount(Number.NaN)).toBe(false);
+  });
+
+  it('hides undefined', () => {
+    expect(shouldShowVisitCount(undefined)).toBe(false);
+  });
+
+  it('shows 1', () => {
+    expect(shouldShowVisitCount(1)).toBe(true);
+  });
+
+  it('shows 29', () => {
+    expect(shouldShowVisitCount(29)).toBe(true);
+  });
+});
+
+describe('formatPageviewCount', () => {
+  it('uses singular for 1', () => {
+    expect(formatPageviewCount(1)).toBe('1 pageview');
+  });
+
+  it('uses plural for 29', () => {
+    expect(formatPageviewCount(29)).toBe('29 pageviews');
+  });
+});

--- a/src/utils/visit-stats.ts
+++ b/src/utils/visit-stats.ts
@@ -1,0 +1,7 @@
+export function shouldShowVisitCount(count: unknown): count is number {
+  return typeof count === 'number' && Number.isFinite(count) && count > 0;
+}
+
+export function formatPageviewCount(count: number): string {
+  return `${count} pageview${count === 1 ? '' : 's'}`;
+}


### PR DESCRIPTION
Honest $pageview count in the footer. Fail-open: never show a fake 0.

**Blocked on Cloudflare Worker secret `POSTHOG_PERSONAL_API_KEY`** (Rick). Query-only personal API key, not wrangler vars, not the public project token, not in the repo. Until that secret exists, `/api/visits` returns 204 and the footer stays hidden. That is intended. Do not fake a count.

HogQL is all-time `$pageview` with a timestamp bound so the scan is not unbounded.

Draft. No Jules. No auto-merge. Separate from #439 and #448.