### PR TITLE
fix: chat JSON 503 when AI unbound, readable CSS aurora

### DIFF
--- a/src/__tests__/chat-api.test.ts
+++ b/src/__tests__/chat-api.test.ts
@@ -411,19 +411,24 @@ describe('chat API', () => {
     const originalEnv = process.env;
     process.env = { ...originalEnv, AI: ai as unknown as (typeof process.env)['AI'] };
 
-    const request = createRequest({ messages: [{ role: 'user', content: 'Hello' }] });
-    const context = {
-      request,
-      locals: {
-        runtime: {} as { env: ChatEnv },
-      },
-    } as unknown as ChatPostContext;
+    try {
+      const request = createRequest({ messages: [{ role: 'user', content: 'Hello' }] });
+      const context = {
+        request,
+        locals: {
+          runtime: {} as { env: ChatEnv },
+        },
+      } as unknown as ChatPostContext;
 
-    const response = await POST(context);
-    expect(response.status).toBe(200);
-    expect(ai.run).toHaveBeenCalled();
-
-    process.env = originalEnv;
+      const response = await POST(context);
+      expect(response.status).toBe(503);
+      await expect(readJson(response)).resolves.toEqual({
+        error: 'Chat is currently unavailable. Please try again later.',
+      });
+      expect(ai.run).not.toHaveBeenCalled();
+    } finally {
+      process.env = originalEnv;
+    }
   });
 
   it('handles rate limit count being an empty string', async () => {
@@ -488,19 +493,23 @@ describe('chat API', () => {
     expect(loggedError.error).toContain('AI unavailable');
   });
 
-  it('falls back to process.env when locals.runtime.env is missing', async () => {
+  it('does not fall back to process.env when locals.runtime.env is missing', async () => {
     const ai = createAi();
     const originalEnv = process.env;
     process.env = { ...originalEnv, AI: ai as unknown as (typeof process.env)['AI'] };
 
-    const request = createRequest({ messages: [{ role: 'user', content: 'Hello' }] });
-    const context = { request, locals: {} } as unknown as ChatPostContext;
+    try {
+      const request = createRequest({ messages: [{ role: 'user', content: 'Hello' }] });
+      const context = { request, locals: {} } as unknown as ChatPostContext;
 
-    const response = await POST(context);
-
-    expect(response.status).toBe(200);
-    expect(ai.run).toHaveBeenCalled();
-
-    process.env = originalEnv;
+      const response = await POST(context);
+      expect(response.status).toBe(503);
+      await expect(readJson(response)).resolves.toEqual({
+        error: 'Chat is currently unavailable. Please try again later.',
+      });
+      expect(ai.run).not.toHaveBeenCalled();
+    } finally {
+      process.env = originalEnv;
+    }
   });
 });

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -509,7 +509,27 @@
         body: JSON.stringify({ messages }),
       });
 
-      if (!response.ok) throw new Error('Failed to fetch');
+      if (!response.ok) {
+        let errorText = 'Chat is currently unavailable. Please try again later.';
+        try {
+          const data: unknown = await response.json();
+          if (
+            data &&
+            typeof data === 'object' &&
+            'error' in data &&
+            typeof (data as { error: unknown }).error === 'string' &&
+            (data as { error: string }).error.trim()
+          ) {
+            errorText = (data as { error: string }).error.trim();
+          }
+        } catch {
+          // empty 500/body: keep the honest unavailable line
+        }
+        typingIndicator?.classList.add('hidden');
+        appendMessage('assistant', errorText);
+        setStatus('error');
+        return;
+      }
 
       typingIndicator?.classList.add('hidden');
       const aiMessageDiv = appendMessage('assistant', '');
@@ -546,7 +566,7 @@
       const message = error instanceof Error ? error.message : String(error);
       console.error({ event: 'chat_client_error', error: message });
       typingIndicator?.classList.add('hidden');
-      appendMessage('assistant', 'Sorry, something went wrong. Please try again.');
+      appendMessage('assistant', 'Chat is currently unavailable. Please try again later.');
       setStatus('error');
     }
   });

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -117,9 +117,9 @@ const { title, description } = Astro.props;
 
       .aurora-wash {
         position: absolute;
-        inset: -20%;
+        inset: -12%;
         pointer-events: none;
-        filter: blur(80px);
+        filter: blur(24px);
       }
 
       .aurora-wash-a {
@@ -128,7 +128,7 @@ const { title, description } = Astro.props;
           var(--accent-light),
           transparent 70%
         );
-        opacity: 0.14;
+        opacity: 0.28;
       }
 
       .aurora-wash-b {
@@ -137,15 +137,15 @@ const { title, description } = Astro.props;
           var(--accent-regular),
           transparent 68%
         );
-        opacity: 0.12;
+        opacity: 0.22;
       }
 
       :root.theme-dark .aurora-wash-a {
-        opacity: 0.34;
+        opacity: 0.55;
       }
 
       :root.theme-dark .aurora-wash-b {
-        opacity: 0.28;
+        opacity: 0.45;
       }
 
       @media (prefers-reduced-motion: no-preference) {
@@ -160,19 +160,19 @@ const { title, description } = Astro.props;
 
       @keyframes aurora-drift-a {
         from {
-          transform: translate3d(-3%, -2%, 0);
+          transform: translate3d(-10%, -8%, 0);
         }
         to {
-          transform: translate3d(8%, 6%, 0);
+          transform: translate3d(16%, 12%, 0);
         }
       }
 
       @keyframes aurora-drift-b {
         from {
-          transform: translate3d(2%, 0, 0);
+          transform: translate3d(8%, 0, 0);
         }
         to {
-          transform: translate3d(-7%, 5%, 0);
+          transform: translate3d(-14%, 10%, 0);
         }
       }
 

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -25,16 +25,31 @@ function jsonError(error: string, status: number) {
   });
 }
 
+function readChatEnv(locals: unknown): ChatEnv {
+  try {
+    const env = (locals as { runtime?: { env?: ChatEnv } } | null)?.runtime?.env;
+    if (env && typeof env === 'object') return env;
+  } catch {
+    // Workers have no process.env without nodejs_compat.
+  }
+  return {};
+}
+
+const UNAVAILABLE = 'Chat is currently unavailable. Please try again later.';
+
 export const POST: APIRoute = async ({ request, locals }) => {
-  // Access bindings through locals.runtime.env or process.env (fallback for non-Cloudflare)
-  const bindings = ((locals as unknown as { runtime?: { env: ChatEnv } }).runtime?.env ||
-    process.env) as unknown as ChatEnv;
+  let bindings: ChatEnv;
+  try {
+    bindings = readChatEnv(locals);
+  } catch {
+    return jsonError(UNAVAILABLE, 503);
+  }
 
   const ai = bindings.AI;
   const store = bindings.CHAT_STORE;
 
   if (!ai) {
-    return jsonError('Chat is currently unavailable. Please try again later.', 503);
+    return jsonError(UNAVAILABLE, 503);
   }
 
   // Basic Security: Client IP-based rate limiting


### PR DESCRIPTION
P0 live: POST `/api/chat` was HTTP 500 empty body because `runtime.env || process.env` throws on Workers (no nodejs_compat). Same landmine as #449 / #450.

- Read `locals.runtime.env` only. Missing AI → JSON 503 `{ error }`. No empty 500.
- UI shows that honest error. Does not persist a fake twin answer.
- wrangler.jsonc already declares `ai.binding: AI` on Worker `me`. If 503 remains after this, the production Worker does not have Workers AI enabled (Rick).
- Aurora: drop wash blur 80px → 24px, raise dark opacity, larger CSS travel. Still CSS-only, freeze unless `prefers-reduced-motion: no-preference`. No canvas.

Not Jules. Quieter home and hire path unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat error handling with clearer service-unavailable messages for API and network failures.
  * Chat now stops loading indicators and avoids attempting to stream responses when the service is unavailable.
  * Added a consistent response when the chat service configuration is unavailable.

* **Style**
  * Refined aurora background effects with adjusted opacity, blur, and animation movement for a more polished appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->