### PR TITLE
fix: read AI and visit secrets from cloudflare:workers

### DIFF
--- a/src/__tests__/chat-api.test.ts
+++ b/src/__tests__/chat-api.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi, type Mock } from 'vitest';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 
+import { env as workerEnv } from 'cloudflare:workers';
 import { POST, type ChatEnv } from '../pages/api/chat';
 
 const endpoint = 'https://example.com/api/chat';
@@ -19,13 +20,13 @@ function createRequest(body: unknown, headers?: HeadersInit) {
 }
 
 function createContext(request: Request, runtimeEnv: unknown = {}) {
+  const bindings = workerEnv as ChatEnv;
+  delete bindings.AI;
+  delete bindings.CHAT_STORE;
+  Object.assign(bindings, runtimeEnv as ChatEnv);
   return {
     request,
-    locals: {
-      runtime: {
-        env: runtimeEnv as ChatEnv,
-      },
-    },
+    locals: {},
   } as unknown as ChatPostContext;
 }
 
@@ -45,6 +46,12 @@ function createAi(stream = new ReadableStream()): MockAi {
 }
 
 describe('chat API', () => {
+  beforeEach(() => {
+    const bindings = workerEnv as ChatEnv;
+    delete bindings.AI;
+    delete bindings.CHAT_STORE;
+  });
+
   it('sanitizes valid messages and forwards them with the local system prompt', async () => {
     const ai = createAi();
 

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from 'astro';
+import { env } from 'cloudflare:workers';
 import { ChatRequestSchema, pruneMessages, type ChatMessage } from '../../utils/chat-logic';
 
 const jsonHeaders = {
@@ -25,22 +26,21 @@ function jsonError(error: string, status: number) {
   });
 }
 
-function readChatEnv(locals: unknown): ChatEnv {
+function readChatEnv(): ChatEnv {
   try {
-    const env = (locals as { runtime?: { env?: ChatEnv } } | null)?.runtime?.env;
-    if (env && typeof env === 'object') return env;
+    if (env && typeof env === 'object') return env as ChatEnv;
   } catch {
-    // Workers have no process.env without nodejs_compat.
+    // cloudflare:workers env is the only binding surface after adapter v13.
   }
   return {};
 }
 
 const UNAVAILABLE = 'Chat is currently unavailable. Please try again later.';
 
-export const POST: APIRoute = async ({ request, locals }) => {
+export const POST: APIRoute = async ({ request }) => {
   let bindings: ChatEnv;
   try {
-    bindings = readChatEnv(locals);
+    bindings = readChatEnv();
   } catch {
     return jsonError(UNAVAILABLE, 503);
   }

--- a/src/pages/api/visits.ts
+++ b/src/pages/api/visits.ts
@@ -1,4 +1,5 @@
 import type { APIRoute } from 'astro';
+import { env } from 'cloudflare:workers';
 import { shouldShowVisitCount } from '../../utils/visit-stats';
 
 const securityHeaders = {
@@ -63,19 +64,18 @@ function parsePageviews(payload: unknown): number | null {
   return null;
 }
 
-function readVisitEnv(locals: unknown): VisitEnv {
+function readVisitEnv(): VisitEnv {
   try {
-    const env = (locals as { runtime?: { env?: VisitEnv } } | null)?.runtime?.env;
-    if (env && typeof env === 'object') return env;
+    if (env && typeof env === 'object') return env as VisitEnv;
   } catch {
-    // Workers have no process.env without nodejs_compat; missing runtime is fail-open.
+    // cloudflare:workers env is the only binding surface after adapter v13.
   }
   return {};
 }
 
-export const GET: APIRoute = async ({ locals }) => {
+export const GET: APIRoute = async () => {
   try {
-    const bindings = readVisitEnv(locals);
+    const bindings = readVisitEnv();
     const personalKey = bindings.POSTHOG_PERSONAL_API_KEY?.trim();
     if (!personalKey) {
       console.error({ event: 'visits_key_missing' });


### PR DESCRIPTION
Root cause: Astro 7.2 + @astrojs/cloudflare 14 removed `locals.runtime.env`. Dashboard AI binding and POSTHOG_PERSONAL_API_KEY are already on Worker `me`; the handlers never saw them.

- `chat.ts` and `visits.ts` use `import { env } from 'cloudflare:workers'`
- Missing `env.AI` → JSON 503
- Missing `env.POSTHOG_PERSONAL_API_KEY` → 204 fail-open (no fake count)
- wrangler.jsonc already has `"ai": { "binding": "AI" }`
- Does not revert #451. Does not touch aurora #452. Not Jules.

Rick: POST prod `/api/chat` after deploy. Expect 200 SSE if AI is bound.