### PR TITLE
fix: use llama-3.1-8b-instruct-fast after deprecation

### DIFF
--- a/src/__tests__/chat-api.test.ts
+++ b/src/__tests__/chat-api.test.ts
@@ -76,7 +76,7 @@ describe('chat API', () => {
       "default-src 'none'; frame-ancestors 'none';"
     );
     expect(ai.run).toHaveBeenCalledWith(
-      '@cf/meta/llama-3.1-8b-instruct',
+      '@cf/meta/llama-3.1-8b-instruct-fast',
       expect.objectContaining({
         messages: [
           expect.objectContaining({ role: 'system' }),

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -109,7 +109,7 @@ If asked to hire or meet, reply in one sentence and point to https://www.linkedi
 Keep answers brief (2-3 sentences). If asked unpublished facts, say they are not on this site.`;
 
   try {
-    const stream = await ai.run('@cf/meta/llama-3.1-8b-instruct', {
+    const stream = await ai.run('@cf/meta/llama-3.1-8b-instruct-fast', {
       messages: [{ role: 'system', content: systemPrompt }, ...prunedMessages],
       stream: true,
     });


### PR DESCRIPTION
Does not revert #451 or #453. wrangler.jsonc untouched. No Jules.

Prod after #453: GET /api/visits 200 `{"pageviews":94}`. POST /api/chat reached `ai.run` then JSON 500. `@cf/meta/llama-3.1-8b-instruct` was deprecated 30 May 2026. Switch to `@cf/meta/llama-3.1-8b-instruct-fast`. Stream stays.

#452 already merged (aurora only). This is the chat 500 fix only.