### PR TITLE
fix: aurora wash meets the portrait card

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -152,11 +152,58 @@ const schema = {
   }
 
   .portrait {
+    position: relative;
+    isolation: isolate;
     border-radius: 1.5rem;
     box-shadow: var(--shadow-md);
   }
 
+  .portrait::before,
+  .portrait::after {
+    content: '';
+    position: absolute;
+    z-index: -1;
+    pointer-events: none;
+    border-radius: inherit;
+    filter: blur(24px);
+    /* Phone: no upward overflow into Get in touch. */
+    inset: 8% -12% -12% -12%;
+  }
+
+  .portrait::before {
+    background: radial-gradient(
+      ellipse 70% 60% at 28% 22%,
+      var(--accent-light),
+      transparent 70%
+    );
+    opacity: 0.28;
+  }
+
+  .portrait::after {
+    background: radial-gradient(
+      ellipse 60% 70% at 78% 68%,
+      var(--accent-regular),
+      transparent 68%
+    );
+    opacity: 0.22;
+  }
+
+  :global(:root.theme-dark) .portrait::before,
+  :global(:root.theme-dark) .portrait::after {
+    mix-blend-mode: screen;
+  }
+
+  :global(:root.theme-dark) .portrait::before {
+    opacity: 0.55;
+  }
+
+  :global(:root.theme-dark) .portrait::after {
+    opacity: 0.45;
+  }
+
   .portrait img {
+    position: relative;
+    z-index: 1;
     display: block;
     width: 100%;
     aspect-ratio: 5 / 4;
@@ -218,6 +265,14 @@ const schema = {
   }
 
   @media (prefers-reduced-motion: no-preference) {
+    .portrait::before {
+      animation: portrait-aurora-a 12s ease-in-out infinite alternate;
+    }
+
+    .portrait::after {
+      animation: portrait-aurora-b 20s ease-in-out infinite alternate;
+    }
+
     .portrait {
       transition:
         transform 0.3s ease,
@@ -244,6 +299,31 @@ const schema = {
     }
   }
 
+  @media (prefers-reduced-motion: reduce) {
+    .portrait::before,
+    .portrait::after {
+      animation: none;
+    }
+  }
+
+  @keyframes portrait-aurora-a {
+    from {
+      transform: translate3d(-10%, -8%, 0);
+    }
+    to {
+      transform: translate3d(16%, 12%, 0);
+    }
+  }
+
+  @keyframes portrait-aurora-b {
+    from {
+      transform: translate3d(8%, 0, 0);
+    }
+    to {
+      transform: translate3d(-14%, 10%, 0);
+    }
+  }
+
   @media (min-width: 50em) {
     .hero {
       display: grid;
@@ -260,6 +340,11 @@ const schema = {
 
     .portrait {
       border-radius: 4.5rem;
+    }
+
+    .portrait::before,
+    .portrait::after {
+      inset: -12%;
     }
 
     .portrait img {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -152,45 +152,54 @@ const schema = {
   }
 
   .portrait {
+    --portrait-aurora:
+      0 0 20px 4px color-mix(in srgb, var(--accent-light) 55%, transparent),
+      0 0 48px 10px color-mix(in srgb, var(--accent-regular) 40%, transparent);
     position: relative;
-    isolation: isolate;
     border-radius: 1.5rem;
-    box-shadow: var(--shadow-md);
+    margin-inline: 1.25rem;
+    max-width: calc(100% - 2.5rem);
+    box-shadow: var(--portrait-aurora), var(--shadow-md);
+  }
+
+  :global(:root.theme-dark) .portrait {
+    --portrait-aurora:
+      0 0 22px 5px color-mix(in srgb, var(--accent-light) 70%, transparent),
+      0 0 56px 14px color-mix(in srgb, var(--accent-regular) 50%, transparent);
   }
 
   .portrait::before,
   .portrait::after {
     content: '';
     position: absolute;
-    z-index: -1;
+    z-index: 0;
     pointer-events: none;
     border-radius: inherit;
     filter: blur(24px);
-    /* Phone: no upward overflow into Get in touch. */
-    inset: 8% -12% -12% -12%;
+    /* Phone: stay in the side gutter; do not grow into Get in touch. */
+    inset: 12% -10% -16% -10%;
   }
 
   .portrait::before {
-    background: radial-gradient(ellipse 70% 60% at 28% 22%, var(--accent-light), transparent 70%);
-    opacity: 0.28;
+    background: radial-gradient(ellipse 45% 85% at 0% 50%, var(--accent-light), transparent 72%);
+    opacity: 0.4;
   }
 
   .portrait::after {
-    background: radial-gradient(ellipse 60% 70% at 78% 68%, var(--accent-regular), transparent 68%);
-    opacity: 0.22;
-  }
-
-  :global(:root.theme-dark) .portrait::before,
-  :global(:root.theme-dark) .portrait::after {
-    mix-blend-mode: screen;
+    background: radial-gradient(
+      ellipse 45% 85% at 100% 50%,
+      var(--accent-regular),
+      transparent 72%
+    );
+    opacity: 0.34;
   }
 
   :global(:root.theme-dark) .portrait::before {
-    opacity: 0.55;
+    opacity: 0.7;
   }
 
   :global(:root.theme-dark) .portrait::after {
-    opacity: 0.45;
+    opacity: 0.58;
   }
 
   .portrait img {
@@ -274,7 +283,7 @@ const schema = {
     .portrait:hover,
     .portrait:focus-visible {
       transform: translateY(-2px);
-      box-shadow: var(--shadow-md);
+      box-shadow: var(--portrait-aurora), var(--shadow-md);
     }
 
     .proof-card {
@@ -331,12 +340,14 @@ const schema = {
     }
 
     .portrait {
+      margin-inline: 0;
+      max-width: none;
       border-radius: 4.5rem;
     }
 
     .portrait::before,
     .portrait::after {
-      inset: -12%;
+      inset: -16%;
     }
 
     .portrait img {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -172,26 +172,29 @@ const schema = {
   .portrait::after {
     content: '';
     position: absolute;
-    z-index: 0;
     pointer-events: none;
     border-radius: inherit;
-    filter: blur(24px);
-    /* Phone: stay in the side gutter; do not grow into Get in touch. */
-    inset: 12% -10% -16% -10%;
   }
 
   .portrait::before {
-    background: radial-gradient(ellipse 45% 85% at 0% 50%, var(--accent-light), transparent 72%);
-    opacity: 0.4;
+    z-index: 0;
+    filter: blur(24px);
+    /* Phone: stay in the side gutter; do not grow into Get in touch. */
+    inset: 12% -10% -16% -10%;
+    background:
+      radial-gradient(ellipse 45% 85% at 0% 50%, var(--accent-light), transparent 72%),
+      radial-gradient(ellipse 45% 85% at 100% 50%, var(--accent-regular), transparent 72%);
+    opacity: 0.45;
   }
 
+  /* Rim sits ON the rounded edge so a 2px crop reads as a kiss, not a white slab. */
   .portrait::after {
-    background: radial-gradient(
-      ellipse 45% 85% at 100% 50%,
-      var(--accent-regular),
-      transparent 72%
-    );
-    opacity: 0.34;
+    z-index: 2;
+    inset: 0;
+    background: none;
+    box-shadow:
+      inset 0 0 0 2px color-mix(in srgb, var(--accent-light) 80%, transparent),
+      inset 0 0 16px 6px color-mix(in srgb, var(--accent-regular) 50%, transparent);
   }
 
   :global(:root.theme-dark) .portrait::before {
@@ -199,7 +202,9 @@ const schema = {
   }
 
   :global(:root.theme-dark) .portrait::after {
-    opacity: 0.58;
+    box-shadow:
+      inset 0 0 0 2px color-mix(in srgb, var(--accent-light) 90%, transparent),
+      inset 0 0 18px 7px color-mix(in srgb, var(--accent-regular) 60%, transparent);
   }
 
   .portrait img {
@@ -270,10 +275,6 @@ const schema = {
       animation: portrait-aurora-a 12s ease-in-out infinite alternate;
     }
 
-    .portrait::after {
-      animation: portrait-aurora-b 20s ease-in-out infinite alternate;
-    }
-
     .portrait {
       transition:
         transform 0.3s ease,
@@ -301,8 +302,7 @@ const schema = {
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .portrait::before,
-    .portrait::after {
+    .portrait::before {
       animation: none;
     }
   }
@@ -345,8 +345,7 @@ const schema = {
       border-radius: 4.5rem;
     }
 
-    .portrait::before,
-    .portrait::after {
+    .portrait::before {
       inset: -16%;
     }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -171,20 +171,12 @@ const schema = {
   }
 
   .portrait::before {
-    background: radial-gradient(
-      ellipse 70% 60% at 28% 22%,
-      var(--accent-light),
-      transparent 70%
-    );
+    background: radial-gradient(ellipse 70% 60% at 28% 22%, var(--accent-light), transparent 70%);
     opacity: 0.28;
   }
 
   .portrait::after {
-    background: radial-gradient(
-      ellipse 60% 70% at 78% 68%,
-      var(--accent-regular),
-      transparent 68%
-    );
+    background: radial-gradient(ellipse 60% 70% at 78% 68%, var(--accent-regular), transparent 68%);
     opacity: 0.22;
   }
 


### PR DESCRIPTION
Motion PASS on live aurora stands. Portrait PNG is opaque white, so the page wash never sat on the photo.

CSS-only halo on the portrait card:
- Meets the rounded card; photo stays on top (face unpainted)
- Phone: no upward overflow into Get in touch
- Same 12s / 20s travel; freeze on \`prefers-reduced-motion: reduce\`
- Dark \`mix-blend-mode: screen\`

Title, LinkedIn, and colophon unchanged. No Jules.