### PR TITLE
fix: contain CSS aurora to the first viewport

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -109,8 +109,13 @@ const { title, description } = Astro.props;
 
       .aurora {
         position: absolute;
-        inset: 0;
+        top: 0;
+        right: 0;
+        left: 0;
         z-index: 0;
+        height: 100vh;
+        height: 100svh;
+        height: 100dvh;
         pointer-events: none;
         overflow: hidden;
       }
@@ -128,7 +133,6 @@ const { title, description } = Astro.props;
         position: absolute;
         inset: -12%;
         pointer-events: none;
-        filter: blur(24px);
       }
 
       .aurora-wash-a {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -178,7 +178,6 @@ const schema = {
 
   .portrait::before {
     z-index: 0;
-    filter: blur(24px);
     /* Phone: stay in the side gutter; do not grow into Get in touch. */
     inset: 12% -10% -16% -10%;
     background:


### PR DESCRIPTION
## Summary
- Live scrolling on https://me.alehar.workers.dev/ was janking because `.aurora` was `position:absolute; inset:0` on the full page, with two washes animating **transform while `filter: blur(24px)`**, plus dark `mix-blend-mode: screen` on that full-height layer.
- Contain `.aurora` to the first viewport (`100vh` / `100svh` / `100dvh`), not the full scroll. Washes animate transform/opacity only (no blur on the animated nodes). Radial gradients already fade to transparent.
- Portrait kiss from #456 stays (inset rim + outer halo). Dropped `filter: blur` from `.portrait::before` so that halo is transform-only too. Reduced-motion still freezes both.
- Left `.backgrounds::before { filter: hue-rotate(-70deg) }` alone — static, not the animated path.
- CSS-only. Title, LinkedIn, colophon unchanged. No Jules.

## Test plan
- [ ] Preview: https://feat-aurora-first-viewport-me.alehar.workers.dev/
- [ ] Dark ~375 and ~1440: first-screen aurora kiss still visible; face and Get in touch clear
- [ ] Scroll the page: no jank / compositor hitch vs live
- [ ] `prefers-reduced-motion: reduce`: washes freeze
- [ ] Johan bounce before merge. Stay draft. Auto-merge off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the visual presentation of the aurora background with more consistent viewport coverage.
  - Removed blur effects from background washes and the portrait accent for a sharper, cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->