### PR TITLE
feat: ground the twin and count questions after a successful run

### DIFF
--- a/src/__tests__/chat-api.test.ts
+++ b/src/__tests__/chat-api.test.ts
@@ -99,12 +99,13 @@ describe('chat API', () => {
     expect(systemMessage.role).toBe('system');
     expect(systemMessage.content).toContain('Product Manager, Developer Experience');
     expect(systemMessage.content).toContain('linkedin.com/in/alehar');
-    expect(systemMessage.content).toContain('Greater Stockholm');
+    expect(systemMessage.content).toContain('Hire path is LinkedIn only');
     expect(systemMessage.content).toContain('Chalmers B.Sc. Software Engineering');
     expect(systemMessage.content).toContain(
       'Chalmers M.Sc. Management and Economics of Innovation'
     );
-    expect(systemMessage.content).toContain('Hire path is LinkedIn only');
+    expect(systemMessage.content).toContain('Greater Stockholm');
+    expect(systemMessage.content).toContain('Eight years at IFS');
     expect(systemMessage.content).toContain('AI coding copilots is current DevEx work');
     expect(systemMessage.content).toContain('2x faster delivery');
     expect(systemMessage.content).toContain('30x ROI');
@@ -129,6 +130,23 @@ describe('chat API', () => {
     expect(body).toContain('30x ROI');
     expect(body).toContain('Zeroheight runner-up');
     expect(body).toContain(DESIGN_SYSTEM_PROOF);
+  });
+
+  it('returns the exact 2x/30x proof for any IFS design-system question', async () => {
+    const ai = createAi();
+    const response = await postChat(
+      { messages: [{ role: 'user', content: 'Tell me about the IFS design system' }] },
+      ai
+    );
+
+    expect(response.status).toBe(200);
+    expect(ai.run).not.toHaveBeenCalled();
+    const body = await response.text();
+    expect(body).toContain('2x');
+    expect(body).toContain('30x');
+    expect(body).toContain('2x faster delivery');
+    expect(body).toContain('30x ROI');
+    expect(body).toContain('Zeroheight runner-up');
   });
 
   it('returns 503 when the AI binding is missing', async () => {
@@ -293,12 +311,14 @@ describe('chat API', () => {
     await expect(readJson(response)).resolves.toEqual({
       error: 'Rate limit exceeded. Try again in an hour.',
     });
-    expect(get).toHaveBeenCalledWith('chat-limit:203.0.113.1');
+    expect(get).toHaveBeenCalledWith('chat-hourly:203.0.113.1');
     expect(put).not.toHaveBeenCalled();
     expect(ai.run).not.toHaveBeenCalled();
+    expect(response.headers.get('X-Chat-Hourly-Remaining')).toBe('0');
+    expect(response.headers.get('X-Chat-Hourly-Limit')).toBe('20');
   });
 
-  it('increments the rate limit counter before running AI', async () => {
+  it('increments hourly and daily counters only after a successful AI run', async () => {
     const ai = createAi();
     const get = vi.fn().mockResolvedValue('2');
     const put = vi.fn();
@@ -316,10 +336,20 @@ describe('chat API', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(put).toHaveBeenCalledWith('chat-limit:203.0.113.2', '3', {
+    expect(ai.run.mock.calls.length).toBe(1);
+    expect(put).toHaveBeenCalledWith('chat-hourly:203.0.113.2', '3', {
       expirationTtl: 3600,
     });
-    expect(ai.run.mock.calls.length).toBe(1);
+    expect(put).toHaveBeenCalledWith(
+      expect.stringMatching(/^chat-daily:\d{4}-\d{2}-\d{2}$/),
+      '3',
+      expect.objectContaining({ expiration: expect.any(Number) })
+    );
+    expect(response.headers.get('X-Chat-Hourly-Limit')).toBe('20');
+    expect(response.headers.get('X-Chat-Hourly-Remaining')).toBe('17');
+    expect(response.headers.get('X-Chat-Daily-Limit')).toBe('500');
+    expect(response.headers.get('X-Chat-Daily-Remaining')).toBe('497');
+    expect(ai.run.mock.invocationCallOrder[0]).toBeLessThan(put.mock.invocationCallOrder[0]);
   });
 
   it('resets and starts the rate limit counter at one when a malformed count (NaN) exists', async () => {
@@ -340,7 +370,7 @@ describe('chat API', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(put).toHaveBeenCalledWith('chat-limit:203.0.113.4', '1', {
+    expect(put).toHaveBeenCalledWith('chat-hourly:203.0.113.4', '1', {
       expirationTtl: 3600,
     });
     expect(ai.run.mock.calls.length).toBe(1);
@@ -364,7 +394,7 @@ describe('chat API', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(put).toHaveBeenCalledWith('chat-limit:203.0.113.3', '1', {
+    expect(put).toHaveBeenCalledWith('chat-hourly:203.0.113.3', '1', {
       expirationTtl: 3600,
     });
     expect(ai.run.mock.calls.length).toBe(1);
@@ -437,7 +467,7 @@ describe('chat API', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(get).toHaveBeenCalledWith('chat-limit:anonymous');
+    expect(get).toHaveBeenCalledWith('chat-hourly:anonymous');
   });
 
   it('handles locals.runtime being defined but env missing', async () => {
@@ -479,7 +509,11 @@ describe('chat API', () => {
     const response = await POST(context);
 
     expect(response.status).toBe(200);
-    expect(put).toHaveBeenCalledWith(expect.stringContaining('chat-limit'), '1', expect.anything());
+    expect(put).toHaveBeenCalledWith(
+      expect.stringContaining('chat-hourly'),
+      '1',
+      expect.anything()
+    );
   });
 
   it('returns a generic 500 error when AI execution fails', async () => {
@@ -545,5 +579,65 @@ describe('chat API', () => {
     } finally {
       process.env = originalEnv;
     }
+  });
+
+  it('does not increment on invalid JSON', async () => {
+    const ai = createAi();
+    const get = vi.fn();
+    const put = vi.fn();
+    const store = { get, put } as unknown as KVNamespace;
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const response = await POST(
+      createContext(createRequest('{invalid json'), { AI: ai, CHAT_STORE: store })
+    );
+
+    expect(response.status).toBe(400);
+    expect(put).not.toHaveBeenCalled();
+    expect(get).not.toHaveBeenCalled();
+    expect(ai.run).not.toHaveBeenCalled();
+  });
+
+  it('does not increment when AI execution fails', async () => {
+    const ai = { run: vi.fn().mockRejectedValue(new Error('AI unavailable')) };
+    const get = vi.fn().mockResolvedValue('4');
+    const put = vi.fn();
+    const store = { get, put } as unknown as KVNamespace;
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const response = await POST(
+      createContext(createRequest({ messages: [{ role: 'user', content: 'Hello' }] }), {
+        AI: ai,
+        CHAT_STORE: store,
+      })
+    );
+
+    expect(response.status).toBe(500);
+    expect(ai.run).toHaveBeenCalled();
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  it('returns 429 and skips AI when the site-wide daily cap is reached', async () => {
+    const ai = createAi();
+    const get = vi.fn().mockImplementation(async (key: string) => {
+      if (key.startsWith('chat-daily:')) return '500';
+      return '1';
+    });
+    const put = vi.fn();
+    const store = { get, put } as unknown as KVNamespace;
+    const env = { AI: ai, CHAT_STORE: store };
+
+    const response = await POST(
+      createContext(createRequest({ messages: [{ role: 'user', content: 'Hello' }] }), env)
+    );
+
+    expect(response.status).toBe(429);
+    await expect(readJson(response)).resolves.toEqual({
+      error: 'Site-wide daily chat limit reached. Try again tomorrow.',
+    });
+    expect(put).not.toHaveBeenCalled();
+    expect(ai.run).not.toHaveBeenCalled();
+    expect(response.headers.get('X-Chat-Daily-Remaining')).toBe('0');
+    expect(response.headers.get('X-Chat-Hourly-Remaining')).toBe('19');
   });
 });

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -53,6 +53,7 @@
       </section>
     </div>
     <div id="typing-indicator" class="typing-indicator hidden">Alexander is typing...</div>
+    <p id="chat-remaining" class="chat-remaining" aria-live="polite" hidden></p>
     <form id="chat-form" class="chat-form">
       <input
         type="text"
@@ -315,9 +316,16 @@
     display: none;
   }
 
-  .chat-form {
-    padding: 1rem;
+  .chat-remaining {
+    margin: 0;
+    padding: 0.75rem 1rem 0;
+    font-size: 0.75rem;
+    color: var(--gray-400);
     border-top: 1px solid var(--gray-800);
+  }
+
+  .chat-form {
+    padding: 0.5rem 1rem 1rem;
     display: flex;
     gap: 0.5rem;
   }
@@ -363,6 +371,7 @@
   const chatMessages = document.getElementById('chat-messages');
   const typingIndicator = document.getElementById('typing-indicator');
   const chatSuggestions = document.getElementById('chat-suggestions');
+  const chatRemaining = document.getElementById('chat-remaining');
 
   const statusTooltip = document.getElementById('status-tooltip');
   const statusAnnouncer = document.getElementById('status-announcer');
@@ -371,11 +380,21 @@
     idle: 'Ask about the work',
     loading: 'Thinking...',
     error: 'Connection issue',
+    limited: 'Hourly limit reached',
   };
 
-  function setStatus(state: 'idle' | 'loading' | 'error') {
+  function setStatus(state: 'idle' | 'loading' | 'error' | 'limited') {
     if (statusTooltip) statusTooltip.textContent = statusLabels[state];
     if (statusAnnouncer) statusAnnouncer.textContent = statusLabels[state];
+  }
+
+  function applyRemaining(response: Response) {
+    const raw = response.headers.get('X-Chat-Hourly-Remaining');
+    if (raw === null || !chatRemaining) return;
+    const left = parseInt(raw, 10);
+    if (Number.isNaN(left)) return;
+    chatRemaining.hidden = false;
+    chatRemaining.textContent = `${Math.max(0, left)} of 20 questions left this hour`;
   }
 
   setStatus('idle');
@@ -509,6 +528,8 @@
         body: JSON.stringify({ messages }),
       });
 
+      applyRemaining(response);
+
       if (!response.ok) {
         let errorText = 'Chat is currently unavailable. Please try again later.';
         try {
@@ -527,7 +548,13 @@
         }
         typingIndicator?.classList.add('hidden');
         appendMessage('assistant', errorText);
-        setStatus('error');
+        if (response.status === 429) {
+          setStatus('limited');
+          if (statusTooltip) statusTooltip.textContent = errorText;
+          if (statusAnnouncer) statusAnnouncer.textContent = errorText;
+        } else {
+          setStatus('error');
+        }
         return;
       }
 

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -17,7 +17,19 @@ const jsonHeaders = {
   'Content-Security-Policy': "default-src 'none'; frame-ancestors 'none';",
 } as const;
 
+const sseHeaders = {
+  'content-type': 'text/event-stream',
+  'Cache-Control': 'no-store',
+  'X-Content-Type-Options': 'nosniff',
+  'X-Frame-Options': 'DENY',
+  'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
+  'Content-Security-Policy': "default-src 'none'; frame-ancestors 'none';",
+} as const;
+
 export const prerender = false;
+
+export const HOURLY_LIMIT = 20;
+export const DAILY_LIMIT = 500;
 
 export interface ChatEnv {
   AI?: {
@@ -26,10 +38,19 @@ export interface ChatEnv {
   CHAT_STORE?: KVNamespace;
 }
 
-function jsonError(error: string, status: number) {
+function remainingHeaders(hourlyRemaining: number, dailyRemaining: number) {
+  return {
+    'X-Chat-Hourly-Limit': String(HOURLY_LIMIT),
+    'X-Chat-Hourly-Remaining': String(Math.max(0, hourlyRemaining)),
+    'X-Chat-Daily-Limit': String(DAILY_LIMIT),
+    'X-Chat-Daily-Remaining': String(Math.max(0, dailyRemaining)),
+  };
+}
+
+function jsonError(error: string, status: number, extraHeaders: Record<string, string> = {}) {
   return new Response(JSON.stringify({ error }), {
     status,
-    headers: jsonHeaders,
+    headers: { ...jsonHeaders, ...extraHeaders },
   });
 }
 
@@ -42,7 +63,43 @@ function readChatEnv(): ChatEnv {
   return {};
 }
 
+function parseCount(raw: string | null): number {
+  const parsed = parseInt(raw || '0', 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function utcDateKey(now = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}
+
+function nextUtcMidnightUnix(now = new Date()): number {
+  return Math.floor(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1, 0, 0, 0) / 1000
+  );
+}
+
+function dailyPutOptions(now = new Date()): { expiration: number } | { expirationTtl: number } {
+  const expiration = nextUtcMidnightUnix(now);
+  const secondsUntilMidnight = expiration - Math.floor(now.getTime() / 1000);
+  if (secondsUntilMidnight >= 60) {
+    return { expiration };
+  }
+  return { expirationTtl: 86400 };
+}
+
 const UNAVAILABLE = 'Chat is currently unavailable. Please try again later.';
+
+const systemPrompt = `You are Alexander Härenstam's digital twin. Speak in the first person as his twin.
+Current title: Product Manager, Developer Experience at IFS (Feb 2025-present, Greater Stockholm).
+Education: Chalmers B.Sc. Software Engineering; Chalmers M.Sc. Management and Economics of Innovation. Eight years at IFS.
+The IFS Design System case is the only numbered proof. When asked about it, answer with this exact proof: 2x faster delivery, 30x ROI, Zeroheight runner-up.
+Write the digits 2 and 30. Say twice as fast (2x) and thirty times ROI (30x). Never say "x faster" or "x ROI". Do not mint new ROI.
+AI coding copilots is current DevEx work with no numbered proof. Do not invent copilots metrics.
+Hire path is LinkedIn only: https://www.linkedin.com/in/alehar/. Do not invent email, a résumé, or availability. Do not tell the UI to add a Get in touch button.
+Recruiter keywords (not a fake title): Product Management, Developer Experience, DevEx, AI coding copilots, design systems, Industrial AI, IFS Cloud, platform, product strategy.
+Keep answers brief (2-3 sentences). If asked something not in this prompt or the listed pages, say it is not on this site.
+
+${llmsTxt}`;
 
 export const POST: APIRoute = async ({ request }) => {
   let bindings: ChatEnv;
@@ -57,26 +114,6 @@ export const POST: APIRoute = async ({ request }) => {
 
   if (!ai) {
     return jsonError(UNAVAILABLE, 503);
-  }
-
-  // Basic Security: Client IP-based rate limiting
-  const ip = request.headers.get('cf-connecting-ip') || 'anonymous';
-  const rateLimitKey = `chat-limit:${ip}`;
-
-  if (store) {
-    const rawCount = await store.get(rateLimitKey);
-    // biome-ignore lint/style/noNonNullAssertion: rate limit check is inside store guard
-    let currentCount = parseInt(rawCount || '0');
-    if (Number.isNaN(currentCount)) {
-      currentCount = 0;
-    }
-
-    if (currentCount >= 20) {
-      // 20 requests per hour limit
-      return jsonError('Rate limit exceeded. Try again in an hour.', 429);
-    }
-    // Increment counter with 1 hour expiration
-    await store.put(rateLimitKey, (currentCount + 1).toString(), { expirationTtl: 3600 });
   }
 
   let body: unknown;
@@ -106,21 +143,38 @@ export const POST: APIRoute = async ({ request }) => {
     return jsonError(result.error.issues[0].message, 400);
   }
 
+  const ip = request.headers.get('cf-connecting-ip') || 'anonymous';
+  const hourlyKey = `chat-hourly:${ip}`;
+  const dailyKey = `chat-daily:${utcDateKey()}`;
+
+  let hourlyCount = 0;
+  let dailyCount = 0;
+
+  if (store) {
+    const [hourlyRaw, dailyRaw] = await Promise.all([store.get(hourlyKey), store.get(dailyKey)]);
+    hourlyCount = parseCount(hourlyRaw);
+    dailyCount = parseCount(dailyRaw);
+
+    if (hourlyCount >= HOURLY_LIMIT) {
+      return jsonError(
+        'Rate limit exceeded. Try again in an hour.',
+        429,
+        remainingHeaders(0, DAILY_LIMIT - dailyCount)
+      );
+    }
+
+    if (dailyCount >= DAILY_LIMIT) {
+      return jsonError(
+        'Site-wide daily chat limit reached. Try again tomorrow.',
+        429,
+        remainingHeaders(HOURLY_LIMIT - hourlyCount, 0)
+      );
+    }
+  }
+
   const prunedMessages = pruneMessages(result.data.messages as ChatMessage[]);
   const lastUser = [...prunedMessages].reverse().find((message) => message.role === 'user');
   const canned = lastUser ? groundedDesignSystemAnswer(lastUser.content) : null;
-
-  const systemPrompt = `You are Alexander Härenstam's digital twin. Speak in the first person as his twin.
-Current title: Product Manager, Developer Experience at IFS (Feb 2025-present, Greater Stockholm).
-Education: Chalmers B.Sc. Software Engineering; Chalmers M.Sc. Management and Economics of Innovation. Eight years at IFS.
-The IFS Design System case is the only numbered proof. When asked about it, answer with this exact proof: 2x faster delivery, 30x ROI, Zeroheight runner-up.
-Write the digits 2 and 30. Say twice as fast (2x) and thirty times ROI (30x). Never say "x faster" or "x ROI". Do not mint new ROI.
-AI coding copilots is current DevEx work with no numbered proof. Do not invent copilots metrics.
-Hire path is LinkedIn only: https://www.linkedin.com/in/alehar/. Do not invent email, a résumé, or availability. Do not tell the UI to add a Get in touch button.
-Recruiter keywords (not a fake title): Product Management, Developer Experience, DevEx, AI coding copilots, design systems, Industrial AI, IFS Cloud, platform, product strategy.
-Keep answers brief (2-3 sentences). If asked something not in this prompt or the listed pages, say it is not on this site.
-
-${llmsTxt}`;
 
   try {
     const stream = canned
@@ -130,19 +184,31 @@ ${llmsTxt}`;
           stream: true,
         });
 
+    if (store) {
+      hourlyCount += 1;
+      dailyCount += 1;
+      await Promise.all([
+        store.put(hourlyKey, hourlyCount.toString(), { expirationTtl: 3600 }),
+        store.put(dailyKey, dailyCount.toString(), dailyPutOptions()),
+      ]);
+    }
+
     return new Response(stream, {
       headers: {
-        'content-type': 'text/event-stream',
-        'Cache-Control': 'no-store',
-        'X-Content-Type-Options': 'nosniff',
-        'X-Frame-Options': 'DENY',
-        'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
-        'Content-Security-Policy': "default-src 'none'; frame-ancestors 'none';",
+        ...sseHeaders,
+        ...remainingHeaders(
+          store ? HOURLY_LIMIT - hourlyCount : HOURLY_LIMIT,
+          store ? DAILY_LIMIT - dailyCount : DAILY_LIMIT
+        ),
       },
     });
   } catch (error: unknown) {
     console.error({ event: 'chat_api_run_error', error: String(error) });
     // Defense in Depth: Never expose raw error messages to the UI for server-side failures
-    return jsonError('An internal error occurred. Please try again later.', 500);
+    return jsonError(
+      'An internal error occurred. Please try again later.',
+      500,
+      store ? remainingHeaders(HOURLY_LIMIT - hourlyCount, DAILY_LIMIT - dailyCount) : {}
+    );
   }
 };

--- a/src/utils/chat-logic.ts
+++ b/src/utils/chat-logic.ts
@@ -51,7 +51,11 @@ export const DESIGN_SYSTEM_PROOF =
 
 export function groundedDesignSystemAnswer(lastUserMessage: string): string | null {
   const question = lastUserMessage.trim().toLowerCase();
-  if (question === DESIGN_SYSTEM_CHIP.toLowerCase()) {
+  if (
+    question === DESIGN_SYSTEM_CHIP.toLowerCase() ||
+    (question.includes('design system') &&
+      (question.includes('ifs') || question.includes('change') || question.includes('roi')))
+  ) {
     return DESIGN_SYSTEM_PROOF;
   }
   return null;


### PR DESCRIPTION
## Summary
- Build-time inject `public/llms.txt` plus biography already on the site: Chalmers B.Sc. Software Engineering, M.Sc. Management and Economics of Innovation, 8 years IFS (design system / DevEx / Industrial AI). Title stays Product Manager, Developer Experience at IFS. Hire path LinkedIn only. Do not invent email, CV, résumé, availability, or new ROI. Not Strategic Product Leader.
- Count a question only after a successful `ai.run`. Junk POSTs (400) and 500s do not burn the hour.
- Site-wide daily cap of 500 on existing `CHAT_STORE` (`chat-daily:YYYY-MM-DD`). No wrangler change, no new KV namespace.
- Response headers: `X-Chat-Hourly-Limit` / `X-Chat-Hourly-Remaining`, `X-Chat-Daily-Limit` / `X-Chat-Daily-Remaining`. Panel shows remaining of 20 this hour. 429 is the API error as-is, not “something went wrong.”
- Stream + `@cf/meta/llama-3.1-8b-instruct-fast` unchanged. Aurora / #457 untouched. No Jules.

## Test plan
- [ ] 20 of 20 in the panel; after a successful answer it ticks down
- [ ] Invalid JSON / validation errors do not decrement remaining
- [ ] 429 hourly: “Rate limit exceeded. Try again in an hour.” Tooltip is not “Connection issue”
- [ ] Twin answers from llms.txt + Chalmers/IFS facts; hire → LinkedIn; no invented email/CV/ROI
- [ ] Stay draft. Auto-merge off. Dan will not merge.