### PR TITLE
fix: use PM/DevEx identity and ground the twin

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,10 +1,14 @@
 # Alexander Härenstam
 
-> Product Manager, Developer Experience at IFS. Personal site for design systems, DevEx, and Industrial AI.
+> Product Manager, Developer Experience at IFS (Feb 2025–present, Greater Stockholm). Personal site for design systems, DevEx, and Industrial AI.
 
 Title on this site is Product Manager, Developer Experience at IFS. Do not inflate it. Hire path is LinkedIn only (https://www.linkedin.com/in/alehar/). Do not invent an email, a CV, a résumé, or availability beyond that.
 
-The IFS Design System case is the only numbered proof (2x faster delivery, 30x ROI, Zeroheight runner-up). Other work pages are narrative; do not mint new metrics.
+Education: Chalmers B.Sc. Software Engineering (2012–2015); Chalmers M.Sc. Management and Economics of Innovation (2015–2017). Eight years at IFS.
+
+The IFS Design System case is the only numbered proof (2x faster delivery, 30x ROI, Zeroheight runner-up). AI coding copilots is current DevEx work with no numbered proof. Other work pages are narrative; do not mint new metrics.
+
+Recruiter keywords (not a fake title): Product Management, Developer Experience, DevEx, AI coding copilots, design systems, Industrial AI, IFS Cloud, platform, product strategy.
 
 ## Pages
 

--- a/src/__tests__/chat-api.test.ts
+++ b/src/__tests__/chat-api.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 
 import { env as workerEnv } from 'cloudflare:workers';
 import { POST, type ChatEnv } from '../pages/api/chat';
+import { DESIGN_SYSTEM_CHIP, DESIGN_SYSTEM_PROOF } from '../utils/chat-logic';
 
 const endpoint = 'https://example.com/api/chat';
 
@@ -112,6 +113,22 @@ describe('chat API', () => {
     expect(systemMessage.content).not.toContain('Strategic Product Leader');
     expect(systemMessage.content).not.toContain('Available');
     expect(systemMessage.content).not.toContain('mailto');
+  });
+
+  it('returns the exact 2x/30x proof for the design-system chip without calling the model', async () => {
+    const ai = createAi();
+    const response = await postChat(
+      { messages: [{ role: 'user', content: DESIGN_SYSTEM_CHIP }] },
+      ai
+    );
+
+    expect(response.status).toBe(200);
+    expect(ai.run).not.toHaveBeenCalled();
+    const body = await response.text();
+    expect(body).toContain('2x faster delivery');
+    expect(body).toContain('30x ROI');
+    expect(body).toContain('Zeroheight runner-up');
+    expect(body).toContain(DESIGN_SYSTEM_PROOF);
   });
 
   it('returns 503 when the AI binding is missing', async () => {

--- a/src/__tests__/chat-api.test.ts
+++ b/src/__tests__/chat-api.test.ts
@@ -98,10 +98,16 @@ describe('chat API', () => {
     expect(systemMessage.role).toBe('system');
     expect(systemMessage.content).toContain('Product Manager, Developer Experience');
     expect(systemMessage.content).toContain('linkedin.com/in/alehar');
+    expect(systemMessage.content).toContain('Greater Stockholm');
+    expect(systemMessage.content).toContain('Chalmers B.Sc. Software Engineering');
+    expect(systemMessage.content).toContain(
+      'Chalmers M.Sc. Management and Economics of Innovation'
+    );
+    expect(systemMessage.content).toContain('Hire path is LinkedIn only');
+    expect(systemMessage.content).toContain('AI coding copilots is current DevEx work');
     expect(systemMessage.content).not.toContain('Strategic Product Leader');
     expect(systemMessage.content).not.toContain('Available');
     expect(systemMessage.content).not.toContain('mailto');
-    expect(systemMessage.content).not.toContain('CV');
   });
 
   it('returns 503 when the AI binding is missing', async () => {

--- a/src/__tests__/chat-api.test.ts
+++ b/src/__tests__/chat-api.test.ts
@@ -105,6 +105,10 @@ describe('chat API', () => {
     );
     expect(systemMessage.content).toContain('Hire path is LinkedIn only');
     expect(systemMessage.content).toContain('AI coding copilots is current DevEx work');
+    expect(systemMessage.content).toContain('2x faster delivery');
+    expect(systemMessage.content).toContain('30x ROI');
+    expect(systemMessage.content).toContain('Zeroheight runner-up');
+    expect(systemMessage.content).toContain('Write the digits 2 and 30');
     expect(systemMessage.content).not.toContain('Strategic Product Leader');
     expect(systemMessage.content).not.toContain('Available');
     expect(systemMessage.content).not.toContain('mailto');

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -15,7 +15,8 @@ describe('identity copy', () => {
 
   it('does not use Strategic Product Leader in about, biography, meta, llms.txt, or the twin prompt', () => {
     for (const { path, text } of sources) {
-      expect(text, path).not.toContain('Strategic Product Leader');
+      expect(text.toLowerCase(), path).not.toContain('strategic product leader');
+      expect(text.toLowerCase(), path).not.toContain('strategic product leadership');
     }
   });
 
@@ -38,6 +39,10 @@ describe('identity copy', () => {
     expect(about).not.toContain('30x ROI');
     expect(about).toContain('/work/ifs-design-system/');
     expect(work).toContain('Product Manager, Developer Experience');
+    const bio = sources.find((s) => s.path.endsWith('biography.astro'))!.text;
+    expect(bio).toContain(
+      'Explore the professional journey of Alexander Härenstam, Product Manager, Developer Experience at IFS.'
+    );
     expect(twin).toContain('2x faster delivery');
     expect(twin).toContain('30x ROI');
   });

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 const files = [
   'src/pages/about.astro',
   'src/pages/biography.astro',
+  'src/pages/work.astro',
   'src/components/MainHead.astro',
   'public/llms.txt',
   'src/pages/api/chat.ts',
@@ -24,13 +25,21 @@ describe('identity copy', () => {
     }
   });
 
-  it('does not mint unverifiable About metrics', () => {
+  it('does not mint unverifiable metrics on About, Work, or the twin', () => {
     const about = sources.find((s) => s.path.endsWith('about.astro'))!.text;
-    expect(about).not.toContain('multi-million');
+    const work = sources.find((s) => s.path.endsWith('work.astro'))!.text;
+    const twin = sources.find((s) => s.path.endsWith('chat.ts'))!.text;
+    for (const { path, text } of sources) {
+      expect(text, path).not.toContain('multi-million');
+      expect(text, path).not.toContain('several millions');
+      expect(text, path).not.toContain('Strategic Product Management');
+    }
     expect(about).not.toContain('autonomous industrial AI');
-    expect(about).toContain('2x faster delivery');
-    expect(about).toContain('30x ROI');
-    expect(about).toContain('Zeroheight');
+    expect(about).not.toContain('30x ROI');
+    expect(about).toContain('/work/ifs-design-system/');
+    expect(work).toContain('Product Manager, Developer Experience');
+    expect(twin).toContain('2x faster delivery');
+    expect(twin).toContain('30x ROI');
   });
 
   it('grounds llms.txt with Chalmers education and recruiter keywords', () => {

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const files = [
+  'src/pages/about.astro',
+  'src/pages/biography.astro',
+  'src/components/MainHead.astro',
+  'public/llms.txt',
+  'src/pages/api/chat.ts',
+];
+
+describe('identity copy', () => {
+  const sources = files.map((path) => ({ path, text: readFileSync(path, 'utf8') }));
+
+  it('does not use Strategic Product Leader in about, biography, meta, llms.txt, or the twin prompt', () => {
+    for (const { path, text } of sources) {
+      expect(text, path).not.toContain('Strategic Product Leader');
+    }
+  });
+
+  it('uses Product Manager, Developer Experience as the title', () => {
+    for (const { path, text } of sources) {
+      expect(text, path).toContain('Product Manager, Developer Experience');
+    }
+  });
+
+  it('does not mint unverifiable About metrics', () => {
+    const about = sources.find((s) => s.path.endsWith('about.astro'))!.text;
+    expect(about).not.toContain('multi-million');
+    expect(about).not.toContain('autonomous industrial AI');
+    expect(about).toContain('2x faster delivery');
+    expect(about).toContain('30x ROI');
+    expect(about).toContain('Zeroheight');
+  });
+
+  it('grounds llms.txt with Chalmers education and recruiter keywords', () => {
+    const llms = sources.find((s) => s.path.endsWith('llms.txt'))!.text;
+    expect(llms).toContain('Chalmers B.Sc. Software Engineering');
+    expect(llms).toContain('Management and Economics of Innovation');
+    expect(llms).toContain('Greater Stockholm');
+    expect(llms).toContain('AI coding copilots');
+    expect(llms).toContain('IFS Cloud');
+  });
+});

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -42,6 +42,15 @@ describe('identity copy', () => {
     expect(twin).toContain('30x ROI');
   });
 
+  it('keeps spaces around TL;DR strong terms (Astro drops newline-only spaces)', () => {
+    const about = sources.find((s) => s.path.endsWith('about.astro'))!.text;
+    const work = sources.find((s) => s.path.endsWith('work.astro'))!.text;
+    const bio = sources.find((s) => s.path.endsWith('biography.astro'))!.text;
+    expect(about).toContain("{' '}with");
+    expect(about).toContain("{' '}<strong>AI coding copilots</strong>");
+    expect(work).toContain("{' '}<strong>IFS</strong>");
+    expect(bio).toContain("{' '}<strong>Innovation Management</strong>");
+  });
   it('grounds llms.txt with Chalmers education and recruiter keywords', () => {
     const llms = sources.find((s) => s.path.endsWith('llms.txt'))!.text;
     expect(llms).toContain('Chalmers B.Sc. Software Engineering');

--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -8,8 +8,8 @@ interface Props {
 }
 
 const {
-  title = 'Alexander Härenstam | Product Leader & Innovator in AI',
-  description = 'Alexander Härenstam is a Strategic Product Leader driving high-impact innovation, Industrial AI, and Developer Experience (DevEx) at IFS.',
+  title = 'Alexander Härenstam | Product Manager, Developer Experience',
+  description = 'Product Manager, Developer Experience at IFS. Design systems, DevEx, and Industrial AI.',
 } = Astro.props;
 ---
 

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -14,3 +14,8 @@ interface Env {
   };
   CHAT_STORE: KVNamespace;
 }
+
+declare module '*.txt?raw' {
+  const content: string;
+  export default content;
+}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -10,11 +10,11 @@ const schema = {
       '@type': 'Person',
       '@id': 'https://harenstam.com/#person',
       name: 'Alexander Härenstam',
-      jobTitle: 'Strategic Product Leader',
+      jobTitle: 'Product Manager, Developer Experience',
       description:
-        'Strategic Product Leader specializing in Developer Experience (DevEx) and Industrial AI at IFS.',
+        'Product Manager, Developer Experience at IFS. Design systems, DevEx, and Industrial AI.',
       url: 'https://harenstam.com/',
-      sameAs: ['https://www.linkedin.com/in/alehar'],
+      sameAs: ['https://www.linkedin.com/in/alehar/'],
       worksFor: {
         '@type': 'Organization',
         name: 'IFS',
@@ -33,7 +33,7 @@ const schema = {
       name: 'About | Alexander Härenstam',
       about: { '@id': 'https://harenstam.com/#person' },
       description:
-        "Learn about Alexander Härenstam's background, education, and skills as a Strategic Product Leader at IFS.",
+        "Learn about Alexander Härenstam's background, education, and skills as Product Manager, Developer Experience at IFS.",
       breadcrumb: {
         '@type': 'BreadcrumbList',
         itemListElement: [
@@ -58,7 +58,7 @@ const schema = {
 
 <BaseLayout
   title="About | Alexander Härenstam"
-  description="Learn about Alexander Härenstam's background, education, and skills as a Strategic Product Leader at IFS."
+  description="Learn about Alexander Härenstam's background, education, and skills as Product Manager, Developer Experience at IFS."
 >
   <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
 
@@ -81,55 +81,49 @@ const schema = {
         <div class="content">
           <div class="tldr-box">
             <p>
-              <strong>🎯 TL;DR:</strong> Strategic Product Leader at <strong>IFS</strong> with an M.Sc.
-              from
-              <strong>Chalmers</strong>. I specialize in <strong>Industrial AI</strong>, <strong
-                >Developer Experience (DevEx)</strong
-              >, and <strong>Design Systems</strong>, delivering multi-million dollar ROI through
-              technological innovation.
+              <strong>🎯 TL;DR:</strong> Product Manager, Developer Experience at <strong
+                >IFS</strong
+              >
+              with an M.Sc. from <strong>Chalmers</strong>. I work on <strong>Industrial AI</strong
+              >,
+              <strong>Developer Experience (DevEx)</strong>, <strong>design systems</strong>, and
+              <strong>AI coding copilots</strong>.
             </p>
           </div>
           <p>
-            I am a strategic <a
+            I am a <a
               href="https://en.wikipedia.org/wiki/Product_management"
               target="_blank"
-              rel="noopener noreferrer">Product Leader</a
-            > with a proven track record of delivering multi-million dollar business value through <a
+              rel="noopener noreferrer">Product Manager</a
+            > for Developer Experience at IFS. I work at the intersection of <a
               href="https://en.wikipedia.org/wiki/Artificial_intelligence_in_industry"
               target="_blank"
               rel="noopener noreferrer">Industrial AI</a
-            > and <a
+            >, <a
               href="https://en.wikipedia.org/wiki/Digital_transformation"
               target="_blank"
               rel="noopener noreferrer">digital transformation</a
-            >. With a unique blend of technical expertise in <a
+            >, and the IFS Cloud platform. A <a
               href="https://en.wikipedia.org/wiki/Software_engineering"
               target="_blank"
               rel="noopener noreferrer">software engineering</a
-            > and strategic insight in <a
+            > degree plus <a
               href="https://en.wikipedia.org/wiki/Innovation_management"
               target="_blank"
               rel="noopener noreferrer">innovation management</a
-            >, I bridge the gap between complex technology and scalable market success.
+            > is the background; current work is DevEx, design systems, and AI coding copilots.
           </p>
           <p>
             In my current role at <a
               href="https://www.ifs.com/"
               target="_blank"
               rel="noopener noreferrer">IFS</a
-            >, I lead strategic initiatives that empower global engineering teams and drive
-            efficiency across the <a
+            >, I work with global engineering teams across the <a
               href="https://www.ifs.com/ifs-cloud"
               target="_blank"
               rel="noopener noreferrer">IFS Cloud</a
-            > ecosystem. From scaling <a
-              href="https://en.wikipedia.org/wiki/Design_system"
-              target="_blank"
-              rel="noopener noreferrer">design systems</a
-            >
-            that deliver 30x ROI to spearheading AI-first developer tools and autonomous industrial AI
-            capabilities, I thrive on navigating ambiguity and transforming disruption into competitive
-            advantage.
+            > platform. The IFS Design System is the numbered proof (2x faster delivery, 30x ROI, Zeroheight
+            runner-up). Current DevEx work includes AI coding copilots, with no new metrics attached.
           </p>
           <p>
             Collaboration and data-driven decision-making are at the core of my approach. I believe
@@ -196,7 +190,8 @@ const schema = {
               href="https://en.wikipedia.org/wiki/Business_analysis"
               target="_blank"
               rel="noopener noreferrer">Business Analysis</a
-            >
+            >, design systems, Industrial AI, AI coding copilots, IFS Cloud, platform, product
+            strategy
           </p>
         </div>
       </section>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -122,8 +122,9 @@ const schema = {
               href="https://www.ifs.com/ifs-cloud"
               target="_blank"
               rel="noopener noreferrer">IFS Cloud</a
-            > platform. The IFS Design System is the numbered proof (2x faster delivery, 30x ROI, Zeroheight
-            runner-up). Current DevEx work includes AI coding copilots, with no new metrics attached.
+            > platform. The only numbered proof is the <a href="/work/ifs-design-system/"
+              >IFS Design System</a
+            > case. Current DevEx work includes AI coding copilots, with no new metrics attached.
           </p>
           <p>
             Collaboration and data-driven decision-making are at the core of my approach. I believe

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -81,13 +81,14 @@ const schema = {
         <div class="content">
           <div class="tldr-box">
             <p>
-              <strong>🎯 TL;DR:</strong> Product Manager, Developer Experience at <strong
-                >IFS</strong
-              >
-              with an M.Sc. from <strong>Chalmers</strong>. I work on <strong>Industrial AI</strong
+              <strong>🎯 TL;DR:</strong>
+              {' '}Product Manager, Developer Experience at <strong>IFS</strong>
+              {' '}with an M.Sc. from <strong>Chalmers</strong>. I work on <strong
+                >Industrial AI</strong
               >,
-              <strong>Developer Experience (DevEx)</strong>, <strong>design systems</strong>, and
-              <strong>AI coding copilots</strong>.
+              {' '}<strong>Developer Experience (DevEx)</strong>, <strong>design systems</strong>,
+              and
+              {' '}<strong>AI coding copilots</strong>.
             </p>
           </div>
           <p>

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { env } from 'cloudflare:workers';
 import { ChatRequestSchema, pruneMessages, type ChatMessage } from '../../utils/chat-logic';
+import llmsTxt from '../../../public/llms.txt?raw';
 
 const jsonHeaders = {
   'content-type': 'application/json',
@@ -102,11 +103,15 @@ export const POST: APIRoute = async ({ request }) => {
   const prunedMessages = pruneMessages(result.data.messages as ChatMessage[]);
 
   const systemPrompt = `You are Alexander Härenstam's digital twin. Speak in the first person as his twin.
-Your title is Product Manager, Developer Experience at IFS.
-Answer only from live site copy. Do not invent biography, case metrics, titles, email, a résumé, or whether I am free to talk, and do not mint new ROI numbers.
-The live proof-card copy for the IFS Design System is the only valid 2x faster delivery / 30x ROI / Zeroheight runner-up line; do not mint new ROI.
-If asked to hire or meet, reply in one sentence and point to https://www.linkedin.com/in/alehar/. Do not tell the UI to add a Get in touch button.
-Keep answers brief (2-3 sentences). If asked unpublished facts, say they are not on this site.`;
+Current title: Product Manager, Developer Experience at IFS (Feb 2025-present, Greater Stockholm).
+Education: Chalmers B.Sc. Software Engineering; Chalmers M.Sc. Management and Economics of Innovation. Eight years at IFS.
+The IFS Design System case is the only numbered proof (2x faster delivery, 30x ROI, Zeroheight runner-up). Do not mint new ROI.
+AI coding copilots is current DevEx work with no numbered proof.
+Hire path is LinkedIn only: https://www.linkedin.com/in/alehar/. Do not invent email, a résumé, or availability. Do not tell the UI to add a Get in touch button.
+Recruiter keywords (not a fake title): Product Management, Developer Experience, DevEx, AI coding copilots, design systems, Industrial AI, IFS Cloud, platform, product strategy.
+Keep answers brief (2-3 sentences). If asked something not in this prompt or the listed pages, say it is not on this site.
+
+${llmsTxt}`;
 
   try {
     const stream = await ai.run('@cf/meta/llama-3.1-8b-instruct-fast', {

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -105,7 +105,8 @@ export const POST: APIRoute = async ({ request }) => {
   const systemPrompt = `You are Alexander Härenstam's digital twin. Speak in the first person as his twin.
 Current title: Product Manager, Developer Experience at IFS (Feb 2025-present, Greater Stockholm).
 Education: Chalmers B.Sc. Software Engineering; Chalmers M.Sc. Management and Economics of Innovation. Eight years at IFS.
-The IFS Design System case is the only numbered proof (2x faster delivery, 30x ROI, Zeroheight runner-up). Do not mint new ROI.
+The IFS Design System case is the only numbered proof. When asked about it, answer with this exact proof: 2x faster delivery, 30x ROI, Zeroheight runner-up.
+Write the digits 2 and 30. Say twice as fast (2x) and thirty times ROI (30x). Never say "x faster" or "x ROI". Do not mint new ROI.
 AI coding copilots is current DevEx work with no numbered proof. Do not invent copilots metrics.
 Hire path is LinkedIn only: https://www.linkedin.com/in/alehar/. Do not invent email, a résumé, or availability. Do not tell the UI to add a Get in touch button.
 Recruiter keywords (not a fake title): Product Management, Developer Experience, DevEx, AI coding copilots, design systems, Industrial AI, IFS Cloud, platform, product strategy.

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -1,6 +1,12 @@
 import type { APIRoute } from 'astro';
 import { env } from 'cloudflare:workers';
-import { ChatRequestSchema, pruneMessages, type ChatMessage } from '../../utils/chat-logic';
+import {
+  ChatRequestSchema,
+  groundedDesignSystemAnswer,
+  pruneMessages,
+  sseTextStream,
+  type ChatMessage,
+} from '../../utils/chat-logic';
 import llmsTxt from '../../../public/llms.txt?raw';
 
 const jsonHeaders = {
@@ -101,6 +107,8 @@ export const POST: APIRoute = async ({ request }) => {
   }
 
   const prunedMessages = pruneMessages(result.data.messages as ChatMessage[]);
+  const lastUser = [...prunedMessages].reverse().find((message) => message.role === 'user');
+  const canned = lastUser ? groundedDesignSystemAnswer(lastUser.content) : null;
 
   const systemPrompt = `You are Alexander Härenstam's digital twin. Speak in the first person as his twin.
 Current title: Product Manager, Developer Experience at IFS (Feb 2025-present, Greater Stockholm).
@@ -115,10 +123,12 @@ Keep answers brief (2-3 sentences). If asked something not in this prompt or the
 ${llmsTxt}`;
 
   try {
-    const stream = await ai.run('@cf/meta/llama-3.1-8b-instruct-fast', {
-      messages: [{ role: 'system', content: systemPrompt }, ...prunedMessages],
-      stream: true,
-    });
+    const stream = canned
+      ? sseTextStream(canned)
+      : await ai.run('@cf/meta/llama-3.1-8b-instruct-fast', {
+          messages: [{ role: 'system', content: systemPrompt }, ...prunedMessages],
+          stream: true,
+        });
 
     return new Response(stream, {
       headers: {

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -106,7 +106,7 @@ export const POST: APIRoute = async ({ request }) => {
 Current title: Product Manager, Developer Experience at IFS (Feb 2025-present, Greater Stockholm).
 Education: Chalmers B.Sc. Software Engineering; Chalmers M.Sc. Management and Economics of Innovation. Eight years at IFS.
 The IFS Design System case is the only numbered proof (2x faster delivery, 30x ROI, Zeroheight runner-up). Do not mint new ROI.
-AI coding copilots is current DevEx work with no numbered proof.
+AI coding copilots is current DevEx work with no numbered proof. Do not invent copilots metrics.
 Hire path is LinkedIn only: https://www.linkedin.com/in/alehar/. Do not invent email, a résumé, or availability. Do not tell the UI to add a Get in touch button.
 Recruiter keywords (not a fake title): Product Management, Developer Experience, DevEx, AI coding copilots, design systems, Industrial AI, IFS Cloud, platform, product strategy.
 Keep answers brief (2-3 sentences). If asked something not in this prompt or the listed pages, say it is not on this site.

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -58,7 +58,7 @@ const schema = {
 
 <BaseLayout
   title="Biography | Alexander Härenstam"
-  description="Explore the professional journey of Alexander Härenstam, from software engineering to strategic product leadership."
+  description="Explore the professional journey of Alexander Härenstam, Product Manager, Developer Experience at IFS."
 >
   <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
 

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -10,11 +10,11 @@ const schema = {
       '@type': 'Person',
       '@id': 'https://harenstam.com/#person',
       name: 'Alexander Härenstam',
-      jobTitle: 'Strategic Product Leader',
+      jobTitle: 'Product Manager, Developer Experience',
       description:
-        'Strategic Product Leader specializing in Developer Experience (DevEx) and Industrial AI at IFS.',
+        'Product Manager, Developer Experience at IFS. Design systems, DevEx, and Industrial AI.',
       url: 'https://harenstam.com/',
-      sameAs: ['https://www.linkedin.com/in/alehar'],
+      sameAs: ['https://www.linkedin.com/in/alehar/'],
       worksFor: {
         '@type': 'Organization',
         name: 'IFS',
@@ -33,7 +33,7 @@ const schema = {
       name: 'Biography | Alexander Härenstam',
       about: { '@id': 'https://harenstam.com/#person' },
       description:
-        'Explore the professional journey of Alexander Härenstam, from software engineering to strategic product leadership.',
+        'Explore the professional journey of Alexander Härenstam, Product Manager, Developer Experience at IFS.',
       breadcrumb: {
         '@type': 'BreadcrumbList',
         itemListElement: [
@@ -71,20 +71,18 @@ const schema = {
         <div class="content">
           <div class="tldr-box">
             <p>
-              <strong>TL;DR:</strong> Alexander Härenstam is a <strong
-                >Strategic Product Leader</strong
-              > with a background in <strong>Software Engineering</strong> and <strong
-                >Innovation Management</strong
-              >. He has spent over 8 years at <strong>IFS</strong>, leading high-impact initiatives
-              in <strong>Design Systems</strong>, <strong>DevEx</strong>, and <strong
-                >Industrial AI</strong
-              >.
+              <strong>TL;DR:</strong> Alexander Härenstam is <strong
+                >Product Manager, Developer Experience</strong
+              > at <strong>IFS</strong>, with a background in <strong>Software Engineering</strong> and
+              <strong>Innovation Management</strong>. Eight years at IFS across <strong
+                >design systems</strong
+              >, <strong>DevEx</strong>, and <strong>Industrial AI</strong>.
             </p>
           </div>
           <p>
-            My journey into strategic Product Leadership is rooted in a deep-seated passion for
-            software engineering and innovation management. This path began at Chalmers University
-            of Technology, where I earned my B.Sc. in Software Engineering followed by an M.Sc. in
+            My path into Product Management and Developer Experience is rooted in software
+            engineering and innovation management. This path began at Chalmers University of
+            Technology, where I earned my B.Sc. in Software Engineering followed by an M.Sc. in
             Management and Economics of Innovation.
           </p>
           <p>
@@ -101,8 +99,8 @@ const schema = {
           <p>
             <em
               >I am continuously refining my professional narrative as new milestones are reached.
-              Let's connect on LinkedIn to discuss how strategic product leadership and Industrial
-              AI are shaping the future of enterprise software.</em
+              Let's connect on LinkedIn to discuss Product Management, Developer Experience, and
+              Industrial AI.</em
             >
           </p>
         </div>

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -73,10 +73,14 @@ const schema = {
             <p>
               <strong>TL;DR:</strong> Alexander Härenstam is <strong
                 >Product Manager, Developer Experience</strong
-              > at <strong>IFS</strong>, with a background in <strong>Software Engineering</strong> and
-              <strong>Innovation Management</strong>. Eight years at IFS across <strong
+              >
+              {' '}at <strong>IFS</strong>, with a background in <strong
+                >Software Engineering</strong
+              > and
+              {' '}<strong>Innovation Management</strong>. Eight years at IFS across <strong
                 >design systems</strong
-              >, <strong>DevEx</strong>, and <strong>Industrial AI</strong>.
+              >,
+              {' '}<strong>DevEx</strong>, and <strong>Industrial AI</strong>.
             </p>
           </div>
           <p>

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -75,11 +75,12 @@ const schema = {
       />
       <div class="tldr-box">
         <p>
-          <strong>TL;DR:</strong> A proven track record in <strong
-            >Strategic Product Management</strong
-          >, leading multi-million dollar initiatives across <strong>Industrial AI</strong>, <strong
+          <strong>TL;DR:</strong>
+          <strong>Product Manager, Developer Experience</strong> at
+          <strong>IFS</strong>. Work across <strong>Industrial AI</strong>, <strong
             >Developer Experience (DevEx)</strong
-          >, and <strong>Design Systems</strong> at <strong>IFS</strong>.
+          >, and <strong>design systems</strong>. The IFS Design System case is the only numbered
+          proof.
         </p>
       </div>
       <Grid variant="offset">

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -76,11 +76,10 @@ const schema = {
       <div class="tldr-box">
         <p>
           <strong>TL;DR:</strong>
-          <strong>Product Manager, Developer Experience</strong> at
-          <strong>IFS</strong>. Work across <strong>Industrial AI</strong>, <strong
-            >Developer Experience (DevEx)</strong
-          >, and <strong>design systems</strong>. The IFS Design System case is the only numbered
-          proof.
+          {' '}<strong>Product Manager, Developer Experience</strong> at
+          {' '}<strong>IFS</strong>. Work across <strong>Industrial AI</strong>,{' '}
+          <strong>Developer Experience (DevEx)</strong>, and <strong>design systems</strong>. The
+          IFS Design System case is the only numbered proof.
         </p>
       </div>
       <Grid variant="offset">

--- a/src/utils/chat-logic.ts
+++ b/src/utils/chat-logic.ts
@@ -43,3 +43,26 @@ export function pruneMessages(messages: ChatMessage[]): ChatMessage[] {
 
   return pruned;
 }
+
+export const DESIGN_SYSTEM_CHIP = 'What did the IFS design system change?';
+
+export const DESIGN_SYSTEM_PROOF =
+  'The IFS Design System delivered 2x faster delivery and 30x ROI, and was a Zeroheight runner-up.';
+
+export function groundedDesignSystemAnswer(lastUserMessage: string): string | null {
+  const question = lastUserMessage.trim().toLowerCase();
+  if (question === DESIGN_SYSTEM_CHIP.toLowerCase()) {
+    return DESIGN_SYSTEM_PROOF;
+  }
+  return null;
+}
+
+export function sseTextStream(text: string): ReadableStream<Uint8Array> {
+  const body = `data: ${JSON.stringify({ response: text })}\n\ndata: [DONE]\n\n`;
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(body));
+      controller.close();
+    },
+  });
+}

--- a/src/utils/chat-stream.test.ts
+++ b/src/utils/chat-stream.test.ts
@@ -8,9 +8,9 @@ function event(response: string) {
 
 describe('chat stream parser', () => {
   it('extracts readable text from a complete SSE transcript', () => {
-    const raw = `${event('As')}${event(' a')}${event(' strategic Product Leader')}${event(' at IFS')}${'data: [DONE]\n\n'}`;
+    const raw = `${event('As')}${event(' a')}${event(' Product Manager')}${event(' at IFS')}${'data: [DONE]\n\n'}`;
 
-    expect(extractAssistantTextFromSse(raw)).toBe('As a strategic Product Leader at IFS');
+    expect(extractAssistantTextFromSse(raw)).toBe('As a Product Manager at IFS');
   });
 
   it('buffers partial chunks until a full event arrives', () => {


### PR DESCRIPTION
## Summary
- LinkedIn is source of truth: Product Manager, Developer Experience at IFS (Feb 2025–present, Greater Stockholm). Home already matched. About, biography, JSON-LD `jobTitle`, and default meta no longer say Strategic Product Leader.
- About no longer mints multi-million dollar ROI or autonomous industrial AI capabilities. Design-system 2x / 30x / Zeroheight stays the only numbered proof. Copilots stay current DevEx work with no new numbers.
- Twin prompt now includes title, IFS, Stockholm, Chalmers B.Sc. / M.Sc., numbered proof only, copilots without metrics, LinkedIn hire path, recruiter keywords, first person, brief answers. Build-time `public/llms.txt`. If it is not in the prompt or listed pages, say so. No invented email, CV, availability, or ROI.
- `llms.txt` updated with the same title, education, and keywords.
- Tests cover the old title and the old prompt.

Stay off #457 (already on main). No auto-merge. No Jules. #458 remains the rate-limit PR.

## Test plan
- [ ] Preview: https://feat-identity-pm-devex-me.alehar.workers.dev/
- [ ] /about and /biography: PM/DevEx, no Strategic Product Leader, no multi-million / autonomous industrial AI
- [ ] Twin: Chalmers is allowed; hire → LinkedIn; no invented ROI
- [ ] Stay draft. Dan will not merge.