### PR TITLE
feat: inline footer pageviews with an exec glance

### DIFF
--- a/src/__tests__/visits-api.test.ts
+++ b/src/__tests__/visits-api.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { env as workerEnv } from 'cloudflare:workers';
+import { GET, HOGQL } from '../pages/api/visits';
+
+type VisitEnv = {
+  POSTHOG_PERSONAL_API_KEY?: string;
+  POSTHOG_PROJECT_ID?: string;
+  POSTHOG_QUERY_HOST?: string;
+};
+
+describe('visits API', () => {
+  beforeEach(() => {
+    const bindings = workerEnv as VisitEnv;
+    delete bindings.POSTHOG_PERSONAL_API_KEY;
+    delete bindings.POSTHOG_PROJECT_ID;
+    delete bindings.POSTHOG_QUERY_HOST;
+  });
+
+  it('uses one HogQL query for pageviews, uniques, first seen, and 7d splits', () => {
+    expect(HOGQL.match(/SELECT/g)?.length).toBe(1);
+    expect(HOGQL).toContain("event = '$pageview'");
+    expect(HOGQL).toContain('unique_visitors');
+    expect(HOGQL).toContain('first_seen');
+    expect(HOGQL).toContain('pageviews_7d');
+    expect(HOGQL).toContain('INTERVAL 7 DAY');
+  });
+
+  it('returns 204 when the PostHog key is missing', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const response = await GET({} as Parameters<typeof GET>[0]);
+    expect(response.status).toBe(204);
+  });
+});

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -29,7 +29,21 @@ const currentYear = new Date().getFullYear();
         Report an issue
       </a>
     </p>
-    <div class="colophon">Built and run with agentic engineering.</div>
+    <div class="colophon">
+      Built and run with agentic engineering.<span class="visit-stats" data-visit-stats hidden>
+        <span aria-hidden="true"> · </span>
+        <details class="visit-glance">
+          <summary>
+            <span data-visit-count></span>
+          </summary>
+          <div class="visit-panel">
+            <p data-glance-all></p>
+            <p data-glance-7d></p>
+            <p data-glance-first></p>
+          </div>
+        </details>
+      </span>
+    </div>
   </div>
   <p class="socials">
     <a href="https://www.linkedin.com/in/alehar/"> LinkedIn</a>
@@ -51,8 +65,8 @@ const currentYear = new Date().getFullYear();
 <script>
   import { fetchGitHubReleases } from '../utils/github-releases';
   import {
-    formatFirstSeen,
     formatPageviewCount,
+    formatVisitGlance,
     shouldShowVisitCount,
     type VisitGlance,
   } from '../utils/visit-stats';
@@ -70,7 +84,7 @@ const currentYear = new Date().getFullYear();
     });
   }
 
-  const visitStats = document.querySelector('.colophon');
+  const visitStats = document.querySelector('[data-visit-stats]');
 
   function isVisitGlance(data: unknown): data is VisitGlance {
     if (!data || typeof data !== 'object') return false;
@@ -80,8 +94,8 @@ const currentYear = new Date().getFullYear();
       typeof row.uniqueVisitors === 'number' &&
       Number.isFinite(row.uniqueVisitors) &&
       typeof row.firstSeen === 'string' &&
-      typeof row.pageviews7d === 'number' &&
-      typeof row.uniqueVisitors7d === 'number'
+      Number.isFinite(row.pageviews7d) &&
+      Number.isFinite(row.uniqueVisitors7d)
     );
   }
 
@@ -99,38 +113,40 @@ const currentYear = new Date().getFullYear();
 
         if (!isVisitGlance(data)) return;
 
-        const firstSeen = formatFirstSeen(data.firstSeen);
-        const summary = document.createElement('summary');
-        summary.textContent = formatPageviewCount(data.pageviews);
+        const count = visitStats.querySelector('[data-visit-count]');
+        const all = visitStats.querySelector('[data-glance-all]');
+        const last7d = visitStats.querySelector('[data-glance-7d]');
+        const first = visitStats.querySelector('[data-glance-first]');
+        const details = visitStats.querySelector('.visit-glance');
+        if (
+          !(count instanceof HTMLElement) ||
+          !(all instanceof HTMLElement) ||
+          !(last7d instanceof HTMLElement) ||
+          !(first instanceof HTMLElement) ||
+          !(details instanceof HTMLDetailsElement)
+        ) {
+          return;
+        }
 
-        const panel = document.createElement('div');
-        panel.className = 'visit-panel';
+        const lines = formatVisitGlance(data);
+        count.textContent = formatPageviewCount(data.pageviews);
+        all.textContent = lines.all;
+        last7d.textContent = lines.last7d;
+        first.textContent = lines.firstSeen;
+        visitStats.hidden = false;
 
-        const addLine = (label: string, value: string) => {
-          const row = document.createElement('p');
-          row.append(document.createTextNode(`${label} `));
-          const strong = document.createElement('strong');
-          strong.textContent = value;
-          row.append(strong);
-          panel.append(row);
-        };
+        if (window.matchMedia('(hover: hover) and (pointer: fine)').matches) {
+          details.addEventListener('pointerenter', () => {
+            details.open = true;
+          });
+          details.addEventListener('pointerleave', () => {
+            details.open = false;
+          });
+        }
 
-        addLine('Pageviews', String(data.pageviews));
-        addLine('Unique visitors', String(data.uniqueVisitors));
-        if (firstSeen) addLine('First seen', firstSeen);
-        addLine('Last 7 days', `${data.pageviews7d} · ${data.uniqueVisitors7d}`);
-
-        const details = document.createElement('details');
-        details.className = 'visit-glance';
-        details.append(summary, panel);
-        details.addEventListener('pointerenter', () => {
-          details.open = true;
+        document.addEventListener('keydown', (event) => {
+          if (event.key === 'Escape') details.open = false;
         });
-        details.addEventListener('pointerleave', () => {
-          details.open = false;
-        });
-
-        visitStats.append(document.createTextNode(' · '), details);
       })
       .catch(() => {
         // Fail-open: keep the count hidden.
@@ -212,9 +228,21 @@ const currentYear = new Date().getFullYear();
     line-height: 1.5;
   }
 
-  .visit-glance {
-    display: inline;
+  .colophon {
     position: relative;
+    overflow: visible;
+  }
+
+  .visit-stats {
+    display: inline;
+    color: inherit;
+    font-size: inherit;
+  }
+
+  .visit-glance {
+    display: inline-block;
+    position: relative;
+    vertical-align: baseline;
   }
 
   .visit-glance summary {
@@ -222,6 +250,8 @@ const currentYear = new Date().getFullYear();
     cursor: pointer;
     list-style: none;
     color: var(--gray-400);
+    text-underline-offset: 0.25em;
+    text-decoration: 1px dotted underline transparent;
   }
 
   .visit-glance summary::-webkit-details-marker,
@@ -230,31 +260,35 @@ const currentYear = new Date().getFullYear();
     content: '';
   }
 
+  .visit-glance summary:hover,
+  .visit-glance summary:focus-visible {
+    text-decoration-color: currentColor;
+  }
+
   .visit-panel {
     position: absolute;
-    bottom: calc(100% + 0.4rem);
-    left: 50%;
-    transform: translateX(-50%);
-    min-width: 12rem;
-    padding: 0.6rem 0.75rem;
+    bottom: calc(100% + 0.5rem);
+    left: 0;
+    z-index: 4;
+    min-width: 14rem;
+    max-width: 18rem;
+    padding: 0.5rem 0.75rem;
     text-align: left;
-    background: var(--gray-900);
-    border: 1px solid var(--gray-800);
-    border-radius: 0.5rem;
-    box-shadow: var(--shadow-sm);
-    color: var(--gray-200);
     font-size: 0.75rem;
     line-height: 1.45;
-    z-index: 2;
+    color: var(--gray-200);
+    background: var(--gray-900);
+    border: 1px solid var(--gray-700);
+    border-radius: 0.375rem;
+    box-shadow: var(--shadow-sm);
   }
 
   .visit-panel p {
     margin: 0;
   }
 
-  .visit-panel strong {
-    color: var(--gray-0);
-    font-weight: 600;
+  .visit-panel p + p {
+    margin-top: 0.25rem;
   }
 
   /* Source icon link styling: keep visual weight minimal */

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -32,19 +32,13 @@ const currentYear = new Date().getFullYear();
     <div class="colophon">
       Built and run with agentic engineering.<span class="visit-stats" data-visit-stats hidden>
         <span aria-hidden="true"> · </span>
-        <span class="visit-glance">
-          <button
-            type="button"
-            class="visit-trigger"
-            data-visit-count
-            aria-expanded="false"
-            aria-controls="visit-glance-panel"></button>
-          <span class="visit-panel" id="visit-glance-panel" hidden>
-            <span data-glance-all></span>
-            <span data-glance-7d></span>
-            <span data-glance-first></span>
-          </span>
-        </span>
+        <button
+          type="button"
+          class="visit-trigger"
+          data-visit-count
+          aria-expanded="false"
+          aria-controls="visit-glance-panel"
+          aria-haspopup="true"></button>
       </span>
     </div>
   </div>
@@ -64,6 +58,11 @@ const currentYear = new Date().getFullYear();
     </a>
   </p>
 </footer>
+<div class="visit-panel" id="visit-glance-panel" hidden>
+  <span data-glance-all></span>
+  <span data-glance-7d></span>
+  <span data-glance-first></span>
+</div>
 
 <script>
   import { fetchGitHubReleases } from '../utils/github-releases';
@@ -117,18 +116,16 @@ const currentYear = new Date().getFullYear();
         if (!isVisitGlance(data)) return;
 
         const trigger = visitStats.querySelector('[data-visit-count]');
-        const all = visitStats.querySelector('[data-glance-all]');
-        const last7d = visitStats.querySelector('[data-glance-7d]');
-        const first = visitStats.querySelector('[data-glance-first]');
-        const glance = visitStats.querySelector('.visit-glance');
-        const panel = visitStats.querySelector('.visit-panel');
+        const panel = document.getElementById('visit-glance-panel');
+        const all = panel?.querySelector('[data-glance-all]');
+        const last7d = panel?.querySelector('[data-glance-7d]');
+        const first = panel?.querySelector('[data-glance-first]');
         if (
           !(trigger instanceof HTMLButtonElement) ||
+          !(panel instanceof HTMLElement) ||
           !(all instanceof HTMLElement) ||
           !(last7d instanceof HTMLElement) ||
-          !(first instanceof HTMLElement) ||
-          !(glance instanceof HTMLElement) ||
-          !(panel instanceof HTMLElement)
+          !(first instanceof HTMLElement)
         ) {
           return;
         }
@@ -139,24 +136,52 @@ const currentYear = new Date().getFullYear();
         last7d.textContent = lines.last7d;
         first.textContent = lines.firstSeen;
         visitStats.hidden = false;
+        document.body.append(panel);
+
+        const place = () => {
+          const box = trigger.getBoundingClientRect();
+          panel.style.position = 'fixed';
+          panel.style.left = `${Math.max(8, Math.min(box.left, window.innerWidth - 280))}px`;
+          panel.style.top = 'auto';
+          panel.style.right = 'auto';
+          panel.style.bottom = `${Math.max(8, window.innerHeight - box.top + 8)}px`;
+        };
 
         const setOpen = (open: boolean) => {
           panel.hidden = !open;
           trigger.setAttribute('aria-expanded', open ? 'true' : 'false');
+          if (open) place();
         };
 
         trigger.addEventListener('click', (event) => {
           event.preventDefault();
+          event.stopPropagation();
           setOpen(panel.hidden);
         });
 
         if (window.matchMedia('(hover: hover) and (pointer: fine)').matches) {
-          glance.addEventListener('pointerenter', () => setOpen(true));
-          glance.addEventListener('pointerleave', () => setOpen(false));
+          trigger.addEventListener('pointerenter', () => setOpen(true));
+          trigger.addEventListener('pointerleave', (event) => {
+            if (event.relatedTarget instanceof Node && panel.contains(event.relatedTarget)) return;
+            setOpen(false);
+          });
+          panel.addEventListener('pointerleave', () => setOpen(false));
         }
 
         document.addEventListener('keydown', (event) => {
           if (event.key === 'Escape') setOpen(false);
+        });
+        document.addEventListener('click', (event) => {
+          if (
+            event.target instanceof Node &&
+            !trigger.contains(event.target) &&
+            !panel.contains(event.target)
+          ) {
+            setOpen(false);
+          }
+        });
+        window.addEventListener('resize', () => {
+          if (!panel.hidden) place();
         });
       })
       .catch(() => {
@@ -241,16 +266,16 @@ const currentYear = new Date().getFullYear();
     line-height: 1.5;
   }
 
-  .visit-stats,
-  .visit-glance {
+  .visit-stats {
     display: inline;
-    position: relative;
     color: inherit;
     font-size: inherit;
   }
 
   .visit-trigger {
     display: inline;
+    appearance: none;
+    -webkit-appearance: none;
     margin: 0;
     padding: 0;
     border: 0;
@@ -277,10 +302,8 @@ const currentYear = new Date().getFullYear();
     display: flex;
     flex-direction: column;
     gap: 0.25rem;
-    position: absolute;
-    bottom: calc(100% + 0.5rem);
-    left: 0;
-    z-index: 4;
+    position: fixed;
+    z-index: 40;
     min-width: 14rem;
     max-width: 18rem;
     padding: 0.5rem 0.75rem;
@@ -295,7 +318,7 @@ const currentYear = new Date().getFullYear();
   }
 
   .visit-panel[hidden] {
-    display: none;
+    display: none !important;
   }
 
   /* Source icon link styling: keep visual weight minimal */

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -29,8 +29,7 @@ const currentYear = new Date().getFullYear();
         Report an issue
       </a>
     </p>
-    <p class="colophon">Built and run with agentic engineering.</p>
-    <p class="visit-stats" data-visit-stats hidden></p>
+    <div class="colophon">Built and run with agentic engineering.</div>
   </div>
   <p class="socials">
     <a href="https://www.linkedin.com/in/alehar/"> LinkedIn</a>
@@ -51,7 +50,12 @@ const currentYear = new Date().getFullYear();
 
 <script>
   import { fetchGitHubReleases } from '../utils/github-releases';
-  import { formatPageviewCount, shouldShowVisitCount } from '../utils/visit-stats';
+  import {
+    formatFirstSeen,
+    formatPageviewCount,
+    shouldShowVisitCount,
+    type VisitGlance,
+  } from '../utils/visit-stats';
 
   const versionLink = document.querySelector('[data-latest-version]');
 
@@ -66,7 +70,20 @@ const currentYear = new Date().getFullYear();
     });
   }
 
-  const visitStats = document.querySelector('[data-visit-stats]');
+  const visitStats = document.querySelector('.colophon');
+
+  function isVisitGlance(data: unknown): data is VisitGlance {
+    if (!data || typeof data !== 'object') return false;
+    const row = data as VisitGlance;
+    return (
+      shouldShowVisitCount(row.pageviews) &&
+      typeof row.uniqueVisitors === 'number' &&
+      Number.isFinite(row.uniqueVisitors) &&
+      typeof row.firstSeen === 'string' &&
+      typeof row.pageviews7d === 'number' &&
+      typeof row.uniqueVisitors7d === 'number'
+    );
+  }
 
   if (visitStats instanceof HTMLElement) {
     fetch('/api/visits')
@@ -80,15 +97,40 @@ const currentYear = new Date().getFullYear();
           return;
         }
 
-        const pageviews =
-          data && typeof data === 'object' && 'pageviews' in data
-            ? (data as { pageviews: unknown }).pageviews
-            : undefined;
+        if (!isVisitGlance(data)) return;
 
-        if (!shouldShowVisitCount(pageviews)) return;
+        const firstSeen = formatFirstSeen(data.firstSeen);
+        const summary = document.createElement('summary');
+        summary.textContent = formatPageviewCount(data.pageviews);
 
-        visitStats.textContent = formatPageviewCount(pageviews);
-        visitStats.hidden = false;
+        const panel = document.createElement('div');
+        panel.className = 'visit-panel';
+
+        const addLine = (label: string, value: string) => {
+          const row = document.createElement('p');
+          row.append(document.createTextNode(`${label} `));
+          const strong = document.createElement('strong');
+          strong.textContent = value;
+          row.append(strong);
+          panel.append(row);
+        };
+
+        addLine('Pageviews', String(data.pageviews));
+        addLine('Unique visitors', String(data.uniqueVisitors));
+        if (firstSeen) addLine('First seen', firstSeen);
+        addLine('Last 7 days', `${data.pageviews7d} · ${data.uniqueVisitors7d}`);
+
+        const details = document.createElement('details');
+        details.className = 'visit-glance';
+        details.append(summary, panel);
+        details.addEventListener('pointerenter', () => {
+          details.open = true;
+        });
+        details.addEventListener('pointerleave', () => {
+          details.open = false;
+        });
+
+        visitStats.append(document.createTextNode(' · '), details);
       })
       .catch(() => {
         // Fail-open: keep the count hidden.
@@ -170,9 +212,49 @@ const currentYear = new Date().getFullYear();
     line-height: 1.5;
   }
 
-  .visit-stats {
+  .visit-glance {
+    display: inline;
+    position: relative;
+  }
+
+  .visit-glance summary {
+    display: inline;
+    cursor: pointer;
+    list-style: none;
     color: var(--gray-400);
-    font-size: var(--text-sm);
+  }
+
+  .visit-glance summary::-webkit-details-marker,
+  .visit-glance summary::marker {
+    display: none;
+    content: '';
+  }
+
+  .visit-panel {
+    position: absolute;
+    bottom: calc(100% + 0.4rem);
+    left: 50%;
+    transform: translateX(-50%);
+    min-width: 12rem;
+    padding: 0.6rem 0.75rem;
+    text-align: left;
+    background: var(--gray-900);
+    border: 1px solid var(--gray-800);
+    border-radius: 0.5rem;
+    box-shadow: var(--shadow-sm);
+    color: var(--gray-200);
+    font-size: 0.75rem;
+    line-height: 1.45;
+    z-index: 2;
+  }
+
+  .visit-panel p {
+    margin: 0;
+  }
+
+  .visit-panel strong {
+    color: var(--gray-0);
+    font-weight: 600;
   }
 
   /* Source icon link styling: keep visual weight minimal */
@@ -236,10 +318,6 @@ const currentYear = new Date().getFullYear();
       flex-direction: row;
       gap: 1rem;
       flex-wrap: wrap;
-    }
-
-    .colophon {
-      flex-basis: 100%;
     }
 
     .socials {

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -32,16 +32,19 @@ const currentYear = new Date().getFullYear();
     <div class="colophon">
       Built and run with agentic engineering.<span class="visit-stats" data-visit-stats hidden>
         <span aria-hidden="true"> · </span>
-        <details class="visit-glance">
-          <summary>
-            <span data-visit-count></span>
-          </summary>
-          <div class="visit-panel">
-            <p data-glance-all></p>
-            <p data-glance-7d></p>
-            <p data-glance-first></p>
-          </div>
-        </details>
+        <span class="visit-glance">
+          <button
+            type="button"
+            class="visit-trigger"
+            data-visit-count
+            aria-expanded="false"
+            aria-controls="visit-glance-panel"></button>
+          <span class="visit-panel" id="visit-glance-panel" hidden>
+            <span data-glance-all></span>
+            <span data-glance-7d></span>
+            <span data-glance-first></span>
+          </span>
+        </span>
       </span>
     </div>
   </div>
@@ -113,39 +116,47 @@ const currentYear = new Date().getFullYear();
 
         if (!isVisitGlance(data)) return;
 
-        const count = visitStats.querySelector('[data-visit-count]');
+        const trigger = visitStats.querySelector('[data-visit-count]');
         const all = visitStats.querySelector('[data-glance-all]');
         const last7d = visitStats.querySelector('[data-glance-7d]');
         const first = visitStats.querySelector('[data-glance-first]');
-        const details = visitStats.querySelector('.visit-glance');
+        const glance = visitStats.querySelector('.visit-glance');
+        const panel = visitStats.querySelector('.visit-panel');
         if (
-          !(count instanceof HTMLElement) ||
+          !(trigger instanceof HTMLButtonElement) ||
           !(all instanceof HTMLElement) ||
           !(last7d instanceof HTMLElement) ||
           !(first instanceof HTMLElement) ||
-          !(details instanceof HTMLDetailsElement)
+          !(glance instanceof HTMLElement) ||
+          !(panel instanceof HTMLElement)
         ) {
           return;
         }
 
         const lines = formatVisitGlance(data);
-        count.textContent = formatPageviewCount(data.pageviews);
+        trigger.textContent = formatPageviewCount(data.pageviews);
         all.textContent = lines.all;
         last7d.textContent = lines.last7d;
         first.textContent = lines.firstSeen;
         visitStats.hidden = false;
 
+        const setOpen = (open: boolean) => {
+          panel.hidden = !open;
+          trigger.setAttribute('aria-expanded', open ? 'true' : 'false');
+        };
+
+        trigger.addEventListener('click', (event) => {
+          event.preventDefault();
+          setOpen(panel.hidden);
+        });
+
         if (window.matchMedia('(hover: hover) and (pointer: fine)').matches) {
-          details.addEventListener('pointerenter', () => {
-            details.open = true;
-          });
-          details.addEventListener('pointerleave', () => {
-            details.open = false;
-          });
+          glance.addEventListener('pointerenter', () => setOpen(true));
+          glance.addEventListener('pointerleave', () => setOpen(false));
         }
 
         document.addEventListener('keydown', (event) => {
-          if (event.key === 'Escape') details.open = false;
+          if (event.key === 'Escape') setOpen(false);
         });
       })
       .catch(() => {
@@ -223,49 +234,49 @@ const currentYear = new Date().getFullYear();
   }
 
   .colophon {
+    position: relative;
+    overflow: visible;
     font-size: 0.75rem;
     color: var(--gray-600);
     line-height: 1.5;
   }
 
-  .colophon {
-    position: relative;
-    overflow: visible;
-  }
-
-  .visit-stats {
+  .visit-stats,
+  .visit-glance {
     display: inline;
+    position: relative;
     color: inherit;
     font-size: inherit;
   }
 
-  .visit-glance {
-    display: inline-block;
-    position: relative;
-    vertical-align: baseline;
-  }
-
-  .visit-glance summary {
+  .visit-trigger {
     display: inline;
-    cursor: pointer;
-    list-style: none;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: none;
+    font: inherit;
     color: var(--gray-400);
+    cursor: pointer;
     text-underline-offset: 0.25em;
     text-decoration: 1px dotted underline transparent;
   }
 
-  .visit-glance summary::-webkit-details-marker,
-  .visit-glance summary::marker {
-    display: none;
-    content: '';
-  }
-
-  .visit-glance summary:hover,
-  .visit-glance summary:focus-visible {
+  .visit-trigger:hover,
+  .visit-trigger:focus-visible {
     text-decoration-color: currentColor;
   }
 
+  .visit-trigger:focus-visible {
+    outline: 2px solid var(--accent-regular);
+    outline-offset: 4px;
+    border-radius: 0.25rem;
+  }
+
   .visit-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
     position: absolute;
     bottom: calc(100% + 0.5rem);
     left: 0;
@@ -283,12 +294,8 @@ const currentYear = new Date().getFullYear();
     box-shadow: var(--shadow-sm);
   }
 
-  .visit-panel p {
-    margin: 0;
-  }
-
-  .visit-panel p + p {
-    margin-top: 0.25rem;
+  .visit-panel[hidden] {
+    display: none;
   }
 
   /* Source icon link styling: keep visual weight minimal */

--- a/src/pages/api/visits.ts
+++ b/src/pages/api/visits.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { env } from 'cloudflare:workers';
-import { shouldShowVisitCount } from '../../utils/visit-stats';
+import { parseVisitGlance, shouldShowVisitCount } from '../../utils/visit-stats';
 
 const securityHeaders = {
   'X-Content-Type-Options': 'nosniff',
@@ -31,37 +31,17 @@ interface VisitEnv {
 const DEFAULT_PROJECT_ID = '171414';
 const DEFAULT_QUERY_HOST = 'https://eu.posthog.com';
 const QUERY_TIMEOUT_MS = 5000;
-const HOGQL =
-  "SELECT count() AS pageviews FROM events WHERE event = '$pageview' AND timestamp >= toDateTime('1970-01-01 00:00:00')";
+export const HOGQL = `SELECT
+  count() AS pageviews,
+  uniq(distinct_id) AS unique_visitors,
+  min(timestamp) AS first_seen,
+  countIf(timestamp >= now() - INTERVAL 7 DAY) AS pageviews_7d,
+  uniqIf(distinct_id, timestamp >= now() - INTERVAL 7 DAY) AS unique_visitors_7d
+FROM events
+WHERE event = '$pageview' AND timestamp >= toDateTime('1970-01-01 00:00:00')`;
 
 function empty204() {
   return new Response(null, { status: 204, headers: emptyHeaders });
-}
-
-function parsePageviews(payload: unknown): number | null {
-  if (!payload || typeof payload !== 'object') return null;
-  const results = (payload as { results?: unknown }).results;
-  if (!Array.isArray(results) || results.length === 0) return null;
-
-  const row = results[0];
-  let raw: unknown;
-
-  if (typeof row === 'number' || typeof row === 'string') {
-    raw = row;
-  } else if (Array.isArray(row)) {
-    raw = row[0];
-  } else if (row && typeof row === 'object' && 'pageviews' in row) {
-    raw = (row as { pageviews: unknown }).pageviews;
-  } else {
-    return null;
-  }
-
-  if (typeof raw === 'number') return raw;
-  if (typeof raw === 'string' && raw.trim() !== '') {
-    const n = Number(raw);
-    return Number.isFinite(n) ? n : null;
-  }
-  return null;
 }
 
 function readVisitEnv(): VisitEnv {
@@ -133,13 +113,13 @@ export const GET: APIRoute = async () => {
         return empty204();
       }
 
-      const count = parsePageviews(payload);
-      if (!shouldShowVisitCount(count)) {
+      const glance = parseVisitGlance(payload);
+      if (!glance || !shouldShowVisitCount(glance.pageviews)) {
         console.error({ event: 'visits_count_hidden' });
         return empty204();
       }
 
-      return new Response(JSON.stringify({ pageviews: count }), {
+      return new Response(JSON.stringify(glance), {
         status: 200,
         headers: jsonHeaders,
       });

--- a/src/utils/visit-stats.test.ts
+++ b/src/utils/visit-stats.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatPageviewCount, shouldShowVisitCount } from './visit-stats';
+import { formatPageviewCount, parseVisitGlance, shouldShowVisitCount } from './visit-stats';
 
 describe('shouldShowVisitCount', () => {
   it('hides 0', () => {
@@ -34,5 +34,62 @@ describe('formatPageviewCount', () => {
 
   it('uses plural for 29', () => {
     expect(formatPageviewCount(29)).toBe('29 pageviews');
+  });
+});
+
+describe('parseVisitGlance', () => {
+  it('reads a named object row', () => {
+    const glance = parseVisitGlance({
+      results: [
+        {
+          pageviews: 94,
+          unique_visitors: 12,
+          first_seen: '2026-08-14 07:03:00',
+          pageviews_7d: 20,
+          unique_visitors_7d: 8,
+        },
+      ],
+    });
+    expect(glance?.pageviews).toBe(94);
+    expect(glance?.uniqueVisitors).toBe(12);
+    expect(glance?.pageviews7d).toBe(20);
+    expect(glance?.uniqueVisitors7d).toBe(8);
+    expect(glance?.firstSeen).toContain('2026-08-14');
+  });
+
+  it('reads a column-ordered array row', () => {
+    const glance = parseVisitGlance({
+      columns: ['pageviews', 'unique_visitors', 'first_seen', 'pageviews_7d', 'unique_visitors_7d'],
+      results: [[94, 12, '2026-08-14T07:03:00.000Z', 20, 8]],
+    });
+    expect(glance).toEqual({
+      pageviews: 94,
+      uniqueVisitors: 12,
+      firstSeen: '2026-08-14T07:03:00.000Z',
+      pageviews7d: 20,
+      uniqueVisitors7d: 8,
+    });
+  });
+
+  it('parses a zero row so the API can fail-open', () => {
+    expect(
+      parseVisitGlance({
+        results: [
+          {
+            pageviews: 0,
+            unique_visitors: 0,
+            first_seen: '2026-08-14T07:03:00.000Z',
+            pageviews_7d: 0,
+            unique_visitors_7d: 0,
+          },
+        ],
+      })
+    ).toEqual({
+      pageviews: 0,
+      uniqueVisitors: 0,
+      firstSeen: '2026-08-14T07:03:00.000Z',
+      pageviews7d: 0,
+      uniqueVisitors7d: 0,
+    });
   });
 });

--- a/src/utils/visit-stats.test.ts
+++ b/src/utils/visit-stats.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { formatPageviewCount, parseVisitGlance, shouldShowVisitCount } from './visit-stats';
+import {
+  formatPageviewCount,
+  formatVisitGlance,
+  parseVisitGlance,
+  shouldShowVisitCount,
+} from './visit-stats';
 
 describe('shouldShowVisitCount', () => {
   it('hides 0', () => {
@@ -91,5 +96,30 @@ describe('parseVisitGlance', () => {
       pageviews7d: 0,
       uniqueVisitors7d: 0,
     });
+  });
+});
+
+describe('formatVisitGlance', () => {
+  const glance = {
+    pageviews: 242,
+    uniqueVisitors: 17,
+    firstSeen: '2026-05-03T18:34:08.880Z',
+    pageviews7d: 213,
+    uniqueVisitors7d: 15,
+  };
+
+  it('always includes first seen and last 7 days', () => {
+    const lines = formatVisitGlance(glance);
+    expect(lines.all).toContain('242 pageviews');
+    expect(lines.all).toContain('17 visitors');
+    expect(lines.last7d).toContain('last 7 days');
+    expect(lines.last7d).toContain('213 pageviews');
+    expect(lines.firstSeen).toMatch(/^First seen /);
+    expect(lines.firstSeen).toContain('2026');
+  });
+
+  it('does not invent 7d numbers when they are zero', () => {
+    const lines = formatVisitGlance({ ...glance, pageviews7d: 0, uniqueVisitors7d: 0 });
+    expect(lines.last7d).toBe('No visits in the last 7 days');
   });
 });

--- a/src/utils/visit-stats.ts
+++ b/src/utils/visit-stats.ts
@@ -91,3 +91,21 @@ export function formatFirstSeen(iso: string): string {
     year: 'numeric',
   }).format(d);
 }
+
+export function formatVisitGlance(glance: VisitGlance): {
+  all: string;
+  last7d: string;
+  firstSeen: string;
+} {
+  const visitors = (count: number) => `${count} visitor${count === 1 ? '' : 's'}`;
+  const seen = formatFirstSeen(glance.firstSeen) || glance.firstSeen;
+  const last7d =
+    glance.pageviews7d === 0 && glance.uniqueVisitors7d === 0
+      ? 'No visits in the last 7 days'
+      : `${formatPageviewCount(glance.pageviews7d)} · ${visitors(glance.uniqueVisitors7d)} in the last 7 days`;
+  return {
+    all: `${formatPageviewCount(glance.pageviews)} · ${visitors(glance.uniqueVisitors)}`,
+    last7d,
+    firstSeen: `First seen ${seen}`,
+  };
+}

--- a/src/utils/visit-stats.ts
+++ b/src/utils/visit-stats.ts
@@ -1,7 +1,93 @@
+export type VisitGlance = {
+  pageviews: number;
+  uniqueVisitors: number;
+  firstSeen: string;
+  pageviews7d: number;
+  uniqueVisitors7d: number;
+};
+
 export function shouldShowVisitCount(count: unknown): count is number {
   return typeof count === 'number' && Number.isFinite(count) && count > 0;
 }
 
 export function formatPageviewCount(count: number): string {
   return `${count} pageview${count === 1 ? '' : 's'}`;
+}
+
+function asFiniteNumber(raw: unknown): number | null {
+  if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+  if (typeof raw === 'string' && raw.trim() !== '') {
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function asIsoTimestamp(raw: unknown): string | null {
+  if (raw instanceof Date && !Number.isNaN(raw.getTime())) {
+    return raw.toISOString();
+  }
+  if (typeof raw !== 'string' || raw.trim() === '') return null;
+  const normalized = raw.includes('T') ? raw : raw.replace(' ', 'T');
+  const d = new Date(normalized);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString();
+}
+
+function valueFromRow(
+  row: unknown,
+  columns: string[] | undefined,
+  key: string,
+  index: number
+): unknown {
+  if (Array.isArray(row)) return row[index];
+  if (row && typeof row === 'object' && key in row) {
+    return (row as Record<string, unknown>)[key];
+  }
+  if (Array.isArray(row) && columns) {
+    const colIndex = columns.indexOf(key);
+    if (colIndex >= 0) return row[colIndex];
+  }
+  return undefined;
+}
+
+export function parseVisitGlance(payload: unknown): VisitGlance | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const results = (payload as { results?: unknown }).results;
+  if (!Array.isArray(results) || results.length === 0) return null;
+
+  const columns = (payload as { columns?: unknown }).columns;
+  const columnNames = Array.isArray(columns)
+    ? columns.filter((c): c is string => typeof c === 'string')
+    : undefined;
+
+  const row = results[0];
+  const pageviews = asFiniteNumber(valueFromRow(row, columnNames, 'pageviews', 0));
+  const uniqueVisitors = asFiniteNumber(valueFromRow(row, columnNames, 'unique_visitors', 1));
+  const firstSeen = asIsoTimestamp(valueFromRow(row, columnNames, 'first_seen', 2));
+  const pageviews7d = asFiniteNumber(valueFromRow(row, columnNames, 'pageviews_7d', 3));
+  const uniqueVisitors7d = asFiniteNumber(valueFromRow(row, columnNames, 'unique_visitors_7d', 4));
+
+  if (
+    pageviews === null ||
+    uniqueVisitors === null ||
+    !firstSeen ||
+    pageviews7d === null ||
+    uniqueVisitors7d === null
+  ) {
+    return null;
+  }
+
+  return { pageviews, uniqueVisitors, firstSeen, pageviews7d, uniqueVisitors7d };
+}
+
+export function formatFirstSeen(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return new Intl.DateTimeFormat('en-GB', {
+    timeZone: 'Europe/Stockholm',
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  }).format(d);
 }


### PR DESCRIPTION
## Summary
- Pageview count sits on the colophon line (`Built and run with agentic engineering. · 94 pageviews`). Extra row and `flex-basis: 100%` are gone.
- Hover or tap opens a small exec glance: pageviews, unique visitors, first seen, last-7-day splits. Not a dashboard.
- One HogQL query on existing PostHog personal API key. Fail-open 204 if the secret or query is missing. No fake 0.
- Left #457 and #458 alone. No wrangler change. No Jules.

## Test plan
- [ ] Preview: https://feat-footer-exec-glance-me.alehar.workers.dev/
- [ ] Colophon is one line; count inlines after a 200 from `/api/visits`
- [ ] 204 keeps the count hidden
- [ ] Hover (desktop) and tap (phone) open the glance
- [ ] Stay draft. Auto-merge off. Dan will not merge.