### PR TITLE
fix: open the visit glance on tap at 375

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -153,32 +153,48 @@ const currentYear = new Date().getFullYear();
           if (open) place();
         };
 
+        let openedByHover = false;
+
         trigger.addEventListener('click', (event) => {
           event.preventDefault();
           event.stopPropagation();
+          // DevTools 375 still reports hover:hover. pointerenter then click would
+          // toggle the panel shut. A tap should leave it open.
+          if (openedByHover && !panel.hidden) {
+            openedByHover = false;
+            return;
+          }
+          openedByHover = false;
           setOpen(panel.hidden);
         });
 
-        if (window.matchMedia('(hover: hover) and (pointer: fine)').matches) {
-          trigger.addEventListener('pointerenter', () => setOpen(true));
-          trigger.addEventListener('pointerleave', (event) => {
-            if (event.relatedTarget instanceof Node && panel.contains(event.relatedTarget)) return;
-            setOpen(false);
-          });
-          panel.addEventListener('pointerleave', () => setOpen(false));
-        }
+        trigger.addEventListener('pointerenter', (event) => {
+          if (event.pointerType !== 'mouse') return;
+          openedByHover = true;
+          setOpen(true);
+        });
+        trigger.addEventListener('pointerleave', (event) => {
+          if (event.pointerType !== 'mouse') return;
+          if (event.relatedTarget instanceof Node && panel.contains(event.relatedTarget)) return;
+          openedByHover = false;
+          setOpen(false);
+        });
+        panel.addEventListener('pointerleave', (event) => {
+          if (event.pointerType !== 'mouse') return;
+          openedByHover = false;
+          setOpen(false);
+        });
 
         document.addEventListener('keydown', (event) => {
           if (event.key === 'Escape') setOpen(false);
         });
-        document.addEventListener('click', (event) => {
-          if (
-            event.target instanceof Node &&
-            !trigger.contains(event.target) &&
-            !panel.contains(event.target)
-          ) {
-            setOpen(false);
-          }
+        document.addEventListener('pointerup', (event) => {
+          if (panel.hidden) return;
+          const target = event.target;
+          if (!(target instanceof Node)) return;
+          if (trigger.contains(target) || panel.contains(target)) return;
+          openedByHover = false;
+          setOpen(false);
         });
         window.addEventListener('resize', () => {
           if (!panel.hidden) place();
@@ -273,7 +289,7 @@ const currentYear = new Date().getFullYear();
   }
 
   .visit-trigger {
-    display: inline;
+    display: inline-block;
     appearance: none;
     -webkit-appearance: none;
     margin: 0;
@@ -283,6 +299,8 @@ const currentYear = new Date().getFullYear();
     font: inherit;
     color: var(--gray-400);
     cursor: pointer;
+    touch-action: manipulation;
+    white-space: nowrap;
     text-underline-offset: 0.25em;
     text-decoration: 1px dotted underline transparent;
   }


### PR DESCRIPTION
## Summary
- Click/tap on the pageview count toggles the overlay (`aria-expanded`, panel visible).
- Hover still opens on a mouse. A tap no longer races `pointerenter` into a toggle-close (Johan FAIL at ~375 on merged #460).
- Escape and outside click still close. Body-level `position:fixed` overlay; footer does not grow. No `details`.

## Test plan
- [ ] ~375: tap the count → panel opens, `aria-expanded=true`, four fields paint
- [ ] ~375: tap outside / Escape → closes
- [ ] Laptop: hover still opens; footer height does not grow
- [ ] Second tap on the count toggles closed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the visit-glance panel’s interaction behavior across mouse, touch, and other pointer devices.
  * Tap-open panels now remain open as expected after hover interactions.
  * Panels close reliably when releasing the pointer outside the trigger or panel.
  * Improved trigger layout and touch responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->