### PR TITLE
feat: exec summary of the latest GitHub release on /whats-new

### DIFF
--- a/src/__tests__/github-releases.test.ts
+++ b/src/__tests__/github-releases.test.ts
@@ -51,6 +51,14 @@ describe('github releases utility', () => {
         version: '2026.06.11.0414',
       },
     ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('api.github.com'),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'User-Agent': 'alehar9320-astro-cloudflare-personal-website',
+        }),
+      })
+    );
   });
 
   it('handles API validation failure', async () => {
@@ -169,7 +177,11 @@ describe('github releases utility', () => {
     expect(fetchMock).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({
-        headers: { Accept: expect.any(String), Authorization: 'token test-token' },
+        headers: expect.objectContaining({
+          Accept: expect.any(String),
+          Authorization: 'token test-token',
+          'User-Agent': 'alehar9320-astro-cloudflare-personal-website',
+        }),
       })
     );
     expect(consoleSpy).toHaveBeenCalledWith(

--- a/src/__tests__/github-releases.test.ts
+++ b/src/__tests__/github-releases.test.ts
@@ -61,19 +61,24 @@ describe('github releases utility', () => {
     );
   });
 
-  it('omits Worker-only GitHub headers in the browser', async () => {
+  it('loads releases from the Worker in the browser', async () => {
     vi.stubGlobal('window', {});
+    const siteRelease = {
+      body: '- feat: ship',
+      publishedAt: null,
+      title: '2026.06.11.0414',
+      url: RELEASES_PAGE_URL,
+      version: '2026.06.11.0414',
+    };
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
-      json: async () => [
-        { body: '- feat: ship', html_url: RELEASES_PAGE_URL, tag_name: '2026.06.11.0414' },
-      ],
+      json: async () => [siteRelease],
     });
-    await fetchGitHubReleases(fetchMock as typeof fetch);
-    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
-    expect(headers['User-Agent']).toBeUndefined();
-    expect(headers['X-GitHub-Api-Version']).toBeUndefined();
-    expect(headers.Accept).toBe('application/vnd.github+json');
+    await expect(fetchGitHubReleases(fetchMock as typeof fetch)).resolves.toEqual([siteRelease]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/releases',
+      expect.objectContaining({ headers: { Accept: 'application/json' } })
+    );
   });
 
   it('handles API validation failure', async () => {
@@ -308,7 +313,7 @@ describe('github releases utility', () => {
 
       const fetchMock = vi.fn().mockResolvedValue({
         ok: true,
-        json: async () => [{ body: '- feat: ship', html_url: RELEASES_PAGE_URL, tag_name: 'v1' }],
+        json: async () => mockReleases,
       });
 
       const result = await fetchGitHubReleases(fetchMock as typeof fetch);
@@ -326,7 +331,7 @@ describe('github releases utility', () => {
 
       const fetchMock = vi.fn().mockResolvedValue({
         ok: true,
-        json: async () => [{ body: '- feat: ship', html_url: RELEASES_PAGE_URL, tag_name: 'v1' }],
+        json: async () => mockReleases,
       });
 
       const result = await fetchGitHubReleases(fetchMock as typeof fetch);
@@ -344,7 +349,7 @@ describe('github releases utility', () => {
 
       const fetchMock = vi.fn().mockResolvedValue({
         ok: true,
-        json: async () => [{ body: '- feat: ship', html_url: RELEASES_PAGE_URL, tag_name: 'v1' }],
+        json: async () => mockReleases,
       });
 
       const result = await fetchGitHubReleases(fetchMock as typeof fetch);

--- a/src/__tests__/github-releases.test.ts
+++ b/src/__tests__/github-releases.test.ts
@@ -61,6 +61,21 @@ describe('github releases utility', () => {
     );
   });
 
+  it('omits Worker-only GitHub headers in the browser', async () => {
+    vi.stubGlobal('window', {});
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [
+        { body: '- feat: ship', html_url: RELEASES_PAGE_URL, tag_name: '2026.06.11.0414' },
+      ],
+    });
+    await fetchGitHubReleases(fetchMock as typeof fetch);
+    const headers = fetchMock.mock.calls[0][1].headers as Record<string, string>;
+    expect(headers['User-Agent']).toBeUndefined();
+    expect(headers['X-GitHub-Api-Version']).toBeUndefined();
+    expect(headers.Accept).toBe('application/vnd.github+json');
+  });
+
   it('handles API validation failure', async () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const fetchMock = vi.fn().mockResolvedValue({

--- a/src/__tests__/github-releases.test.ts
+++ b/src/__tests__/github-releases.test.ts
@@ -142,6 +142,25 @@ describe('github releases utility', () => {
     expect(splitReleaseBody(body)).toEqual([{ message: 'List item' }]);
   });
 
+  it('drops Jules, agent-farm, and Johan nits internals and keeps product bullets', () => {
+    const body = `- d5d9afd Stop auto-merge for Jules and agent-farm PRs (#447)
+- 6e4bc7e fix: Johan nits after #439 — small-hero padding and aurora blur (#446)
+- 484393b feat: update digital twin panel header, suggested questions, and grounded system prompt (#444)
+- 128fa2e feat: first-screen 100dvh and CSS aurora wash (#439)
+- 7e65848 Wire PostHog public env into the production build (#435)
+- 7da1f6b perf: defer PostHog init until idle (#434)`;
+    const items = splitReleaseBody(body);
+    expect(items.map((item) => item.message)).toEqual([
+      'feat: update digital twin panel header, suggested questions, and grounded system prompt (#444)',
+      'feat: first-screen 100dvh and CSS aurora wash (#439)',
+      'Wire PostHog public env into the production build (#435)',
+      'perf: defer PostHog init until idle (#434)',
+    ]);
+    expect(items.map((item) => item.message).join('\n')).not.toMatch(
+      /jules|agent-farm|johan nits/i
+    );
+  });
+
   it('parses commit hashes from release items with various markers', () => {
     const body =
       '* 8acc628 ✍️ Scribe: Strategic Copy Optimization\n+ 1234567 fix: some issue\n- plain message';

--- a/src/__tests__/release-summary.test.ts
+++ b/src/__tests__/release-summary.test.ts
@@ -7,6 +7,7 @@ import {
   groundedReleaseSummary,
   isSafeReleaseSummary,
   parseModelText,
+  prepareReleaseSummary,
   releaseSummaryKey,
   releaseSummaryPrompt,
 } from '../utils/release-summary';
@@ -35,6 +36,9 @@ const latest = {
 const okSummary =
   'The latest release adds an executive glance for footer pageviews. The count sits on the colophon and opens a short overlay. Changelog details stay on this page.';
 
+const notesFallback =
+  'The latest release is 2026.08.15.1714. It includes feat: inline footer pageviews with an exec glance (#460). The full changelog is listed below.';
+
 describe('isSafeReleaseSummary', () => {
   const source = `${latest.version}\n${latest.body}`;
 
@@ -42,15 +46,21 @@ describe('isSafeReleaseSummary', () => {
     expect(isSafeReleaseSummary(okSummary, source)).toBe(true);
   });
 
-  it('rejects Palette and Oracle names', () => {
+  it('allows the IFS Design System 2x / 30x proof', () => {
     expect(
-      isSafeReleaseSummary('Palette shipped the glance. Oracle reviewed the overlay.', source)
-    ).toBe(false);
+      isSafeReleaseSummary(
+        'The IFS Design System delivered 2x faster delivery and 30x ROI. That is the numbered proof. Changelog is below.',
+        source
+      )
+    ).toBe(true);
   });
 
-  it('rejects invented metrics', () => {
+  it('rejects invented metrics that are not 2x or 30x', () => {
     expect(
-      isSafeReleaseSummary('The glance shows 2x faster delivery. It also claims 30x ROI.', source)
+      isSafeReleaseSummary(
+        'This release reached 12 million visitors. It also claims 40% conversion.',
+        source
+      )
     ).toBe(false);
   });
 
@@ -59,11 +69,40 @@ describe('isSafeReleaseSummary', () => {
   });
 });
 
+describe('prepareReleaseSummary', () => {
+  const source = `${latest.version}\n${latest.body}`;
+
+  it('strips Palette, Oracle, and Jules instead of dropping the box', () => {
+    expect(
+      prepareReleaseSummary(
+        'Jules shipped the glance. Palette reviewed the overlay. Changelog stays below.',
+        source
+      )
+    ).toBe('shipped the glance. reviewed the overlay. Changelog stays below.');
+  });
+
+  it('strips SHAs from an otherwise safe summary', () => {
+    expect(
+      prepareReleaseSummary(
+        'The glance opens on tap. The fix landed in 66e3fe9. Changelog stays below.',
+        source
+      )
+    ).toBe('The glance opens on tap. The fix landed in. Changelog stays below.');
+  });
+});
+
 describe('release summary helpers', () => {
-  it('builds a 3-sentence notes-only fallback', () => {
-    expect(groundedReleaseSummary(latest.version, latest.body)).toBe(
-      'The latest GitHub release is 2026.08.15.1714. It includes feat: inline footer pageviews with an exec glance (#460). The full changelog is listed below.'
-    );
+  it('builds a 3-sentence notes-only fallback from title and bullets', () => {
+    expect(groundedReleaseSummary(latest.version, latest.body, latest.title)).toBe(notesFallback);
+  });
+
+  it('keeps the box when notes name Jules', () => {
+    const body = '- abcdef1 Jules: open visit glance on tap (#461)';
+    const summary = groundedReleaseSummary('2026.08.15.1720', body, '2026.08.15.1720');
+    expect(summary).toContain('The latest release is 2026.08.15.1720.');
+    expect(summary).toContain('open visit glance on tap (#461)');
+    expect(summary).not.toMatch(/jules/i);
+    expect(summary).not.toMatch(/\babcdef1\b/);
   });
 
   it('caches by tag', () => {
@@ -135,17 +174,16 @@ describe('release summary API', () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       tag: latest.version,
-      summary:
-        'The latest GitHub release is 2026.08.15.1714. It includes feat: inline footer pageviews with an exec glance (#460). The full changelog is listed below.',
+      summary: notesFallback,
     });
   });
 
-  it('does not serve invented metrics and falls back to the notes', async () => {
+  it('strips Jules from AI text and still returns the box', async () => {
     const get = vi.fn().mockResolvedValue(null);
     const put = vi.fn();
     const ai = {
       run: vi.fn().mockResolvedValue({
-        response: 'This release delivered 2x faster delivery. It also hit 30x ROI.',
+        response: 'Jules shipped the glance. Palette reviewed the overlay. Changelog stays below.',
       }),
     };
     const response = await GET(
@@ -155,13 +193,45 @@ describe('release summary API', () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       tag: latest.version,
-      summary:
-        'The latest GitHub release is 2026.08.15.1714. It includes feat: inline footer pageviews with an exec glance (#460). The full changelog is listed below.',
+      summary: 'shipped the glance. reviewed the overlay. Changelog stays below.',
     });
-    expect(put).toHaveBeenCalledWith(
-      'release-summary:2026.08.15.1714',
-      'The latest GitHub release is 2026.08.15.1714. It includes feat: inline footer pageviews with an exec glance (#460). The full changelog is listed below.'
+  });
+
+  it('does not serve invented visitor metrics and falls back to the notes', async () => {
+    const get = vi.fn().mockResolvedValue(null);
+    const put = vi.fn();
+    const ai = {
+      run: vi.fn().mockResolvedValue({
+        response: 'This release reached 12 million visitors. It also claims 40% conversion.',
+      }),
+    };
+    const response = await GET(
+      createContext({ AI: ai, CHAT_STORE: { get, put } as unknown as KVNamespace })
     );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      tag: latest.version,
+      summary: notesFallback,
+    });
+    expect(put).toHaveBeenCalledWith('release-summary:2026.08.15.1714', notesFallback);
+  });
+
+  it('keeps a 2x / 30x design-system proof from AI', async () => {
+    const get = vi.fn().mockResolvedValue(null);
+    const put = vi.fn();
+    const proof =
+      'The IFS Design System delivered 2x faster delivery and 30x ROI. That is the numbered proof. Changelog is below.';
+    const ai = { run: vi.fn().mockResolvedValue({ response: proof }) };
+    const response = await GET(
+      createContext({ AI: ai, CHAT_STORE: { get, put } as unknown as KVNamespace })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      tag: latest.version,
+      summary: proof,
+    });
   });
 
   it('fails open with 204 when GitHub has no releases', async () => {

--- a/src/__tests__/release-summary.test.ts
+++ b/src/__tests__/release-summary.test.ts
@@ -40,7 +40,7 @@ const okSummary =
   'The latest release adds an executive glance for footer pageviews. The count sits on the colophon and opens a short overlay. Changelog details stay on this page.';
 
 const notesFallback =
-  'The latest release is 2026.08.15.1714. It includes feat: inline footer pageviews with an exec glance (#460). The full changelog is listed below.';
+  'The latest release is 2026.08.15.1714. Visitors can now inline footer pageviews with an exec glance. The full changelog is listed below.';
 
 describe('isSafeReleaseSummary', () => {
   const source = `${latest.version}\n${latest.body}`;
@@ -103,7 +103,7 @@ describe('release summary helpers', () => {
     const body = '- abcdef1 Jules: open visit glance on tap (#461)';
     const summary = groundedReleaseSummary('2026.08.15.1720', body, '2026.08.15.1720');
     expect(summary).toContain('The latest release is 2026.08.15.1720.');
-    expect(summary).toContain('open visit glance on tap (#461)');
+    expect(summary).toContain('open visit glance on tap');
     expect(summary).not.toMatch(/jules/i);
     expect(summary).not.toMatch(/\babcdef1\b/);
   });
@@ -114,7 +114,7 @@ describe('release summary helpers', () => {
 
   it('asks for 2-4 sentences and no invented metrics', () => {
     const prompt = releaseSummaryPrompt(latest.version, latest.body);
-    expect(prompt).toContain('exactly three plain-English sentences');
+    expect(prompt).toContain('exactly three plain-English sentences for a hiring manager');
     expect(prompt).toContain('Do not invent metrics');
     expect(prompt).toContain('Palettes, Oracles');
     expect(prompt).toContain(latest.body);
@@ -244,7 +244,7 @@ describe('release summary API', () => {
     await expect(response.json()).resolves.toEqual({
       tag: '2026.08.15.1720',
       summary:
-        'The latest release is 2026.08.15.1720. It includes fix: open the visit glance on tap at 375 (#461). The full changelog is listed below.',
+        'The latest release is 2026.08.15.1720. Visitors can now open the visit glance on tap at 375. The full changelog is listed below.',
     });
   });
 

--- a/src/__tests__/release-summary.test.ts
+++ b/src/__tests__/release-summary.test.ts
@@ -109,7 +109,7 @@ describe('release summary helpers', () => {
   });
 
   it('caches by tag', () => {
-    expect(releaseSummaryKey('2026.08.15.1714')).toBe('release-summary:2026.08.15.1714');
+    expect(releaseSummaryKey('2026.08.15.1714')).toBe('release-summary:v2:2026.08.15.1714');
   });
 
   it('asks for 2-4 sentences and no invented metrics', () => {
@@ -147,7 +147,7 @@ describe('release summary API', () => {
       tag: latest.version,
       summary: okSummary,
     });
-    expect(get).toHaveBeenCalledWith('release-summary:2026.08.15.1714');
+    expect(get).toHaveBeenCalledWith('release-summary:v2:2026.08.15.1714');
     expect(ai.run).not.toHaveBeenCalled();
     expect(put).not.toHaveBeenCalled();
   });
@@ -169,7 +169,7 @@ describe('release summary API', () => {
       '@cf/meta/llama-3.1-8b-instruct-fast',
       expect.objectContaining({ stream: false })
     );
-    expect(put).toHaveBeenCalledWith('release-summary:2026.08.15.1714', okSummary);
+    expect(put).toHaveBeenCalledWith('release-summary:v2:2026.08.15.1714', okSummary);
   });
 
   it('uses a notes-only fallback when AI is missing', async () => {
@@ -217,7 +217,7 @@ describe('release summary API', () => {
       tag: latest.version,
       summary: notesFallback,
     });
-    expect(put).toHaveBeenCalledWith('release-summary:2026.08.15.1714', notesFallback);
+    expect(put).toHaveBeenCalledWith('release-summary:v2:2026.08.15.1714', notesFallback);
   });
 
   it('drops invented 2x / 30x and falls back to the notes', async () => {

--- a/src/__tests__/release-summary.test.ts
+++ b/src/__tests__/release-summary.test.ts
@@ -108,11 +108,13 @@ describe('release summary helpers', () => {
   });
 
   it('keeps the box when notes name Jules', () => {
-    const body = '- abcdef1 Jules: open visit glance on tap (#461)';
+    const body =
+      '- abcdef1 Stop auto-merge for Jules and agent-farm PRs (#447)\n- 66e3fe9 fix: open the visit glance on tap at 375 (#461)';
     const summary = groundedReleaseSummary('2026.08.15.1720', body, '2026.08.15.1720');
     expect(summary).toContain('The latest release is 2026.08.15.1720.');
-    expect(summary).toContain('open visit glance on tap');
+    expect(summary).toContain('open the visit glance on tap at 375');
     expect(summary).not.toMatch(/jules/i);
+    expect(summary).not.toMatch(/agent-farm/i);
     expect(summary).not.toMatch(/\babcdef1\b/);
   });
 

--- a/src/__tests__/release-summary.test.ts
+++ b/src/__tests__/release-summary.test.ts
@@ -81,13 +81,13 @@ describe('prepareReleaseSummary', () => {
     ).toBe('shipped the glance. reviewed the overlay. Changelog stays below.');
   });
 
-  it('strips SHAs from an otherwise safe summary', () => {
+  it('drops SHA-y model text so the notes fallback can speak', () => {
     expect(
       prepareReleaseSummary(
         'The glance opens on tap. The fix landed in 66e3fe9. Changelog stays below.',
         source
       )
-    ).toBe('The glance opens on tap. The fix landed in. Changelog stays below.');
+    ).toBe(null);
   });
 });
 

--- a/src/__tests__/release-summary.test.ts
+++ b/src/__tests__/release-summary.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { env as workerEnv } from 'cloudflare:workers';
-import { GET, type ReleaseSummaryEnv } from '../pages/api/release-summary';
+import { GET, POST, type ReleaseSummaryEnv } from '../pages/api/release-summary';
 import * as githubReleases from '../utils/github-releases';
 import {
   groundedReleaseSummary,
@@ -14,13 +14,16 @@ import {
 
 type GetContext = Parameters<typeof GET>[0];
 
-function createContext(runtimeEnv: unknown = {}) {
+function createContext(
+  runtimeEnv: unknown = {},
+  request = new Request('https://example.com/api/release-summary')
+) {
   const bindings = workerEnv as ReleaseSummaryEnv;
   delete bindings.AI;
   delete bindings.CHAT_STORE;
   Object.assign(bindings, runtimeEnv as ReleaseSummaryEnv);
   return {
-    request: new Request('https://example.com/api/release-summary'),
+    request,
     locals: {},
   } as unknown as GetContext;
 }
@@ -234,11 +237,35 @@ describe('release summary API', () => {
     });
   });
 
-  it('fails open with 204 when GitHub has no releases', async () => {
+  it('uses the snapshot release when GitHub is empty', async () => {
     vi.spyOn(githubReleases, 'fetchGitHubReleases').mockResolvedValue([]);
-    const ai = { run: vi.fn() };
-    const response = await GET(createContext({ AI: ai }));
-    expect(response.status).toBe(204);
-    expect(ai.run).not.toHaveBeenCalled();
+    const response = await GET(createContext({}));
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      tag: '2026.08.15.1720',
+      summary:
+        'The latest release is 2026.08.15.1720. It includes fix: open the visit glance on tap at 375 (#461). The full changelog is listed below.',
+    });
+  });
+
+  it('summarizes a POSTed release without calling GitHub', async () => {
+    const fetchSpy = vi.spyOn(githubReleases, 'fetchGitHubReleases');
+    fetchSpy.mockClear();
+    const request = new Request('https://example.com/api/release-summary', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        tag: latest.version,
+        title: latest.title,
+        body: latest.body,
+      }),
+    });
+    const response = await POST(createContext({}, request));
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      tag: latest.version,
+      summary: notesFallback,
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/release-summary.test.ts
+++ b/src/__tests__/release-summary.test.ts
@@ -92,6 +92,14 @@ describe('prepareReleaseSummary', () => {
       )
     ).toBe(null);
   });
+  it('drops #461-style issue numbers', () => {
+    expect(
+      prepareReleaseSummary(
+        'The glance opens on tap. See #461 for the patch. Changelog stays below.',
+        source
+      )
+    ).toBe(null);
+  });
 });
 
 describe('release summary helpers', () => {

--- a/src/__tests__/release-summary.test.ts
+++ b/src/__tests__/release-summary.test.ts
@@ -40,7 +40,7 @@ const okSummary =
   'The latest release adds an executive glance for footer pageviews. The count sits on the colophon and opens a short overlay. Changelog details stay on this page.';
 
 const notesFallback =
-  'The latest release is 2026.08.15.1714. Visitors can now inline footer pageviews with an exec glance. The full changelog is listed below.';
+  'The latest release is 2026.08.15.1714. Visitors can now inline footer pageviews with an exec glance. More is in the changelog on this page.';
 
 describe('isSafeReleaseSummary', () => {
   const source = `${latest.version}\n${latest.body}`;
@@ -244,7 +244,7 @@ describe('release summary API', () => {
     await expect(response.json()).resolves.toEqual({
       tag: '2026.08.15.1720',
       summary:
-        'The latest release is 2026.08.15.1720. Visitors can now open the visit glance on tap at 375. The full changelog is listed below.',
+        'The latest release is 2026.08.15.1720. Visitors can now open the visit glance on tap at 375. More is in the changelog on this page.',
     });
   });
 

--- a/src/__tests__/release-summary.test.ts
+++ b/src/__tests__/release-summary.test.ts
@@ -49,13 +49,13 @@ describe('isSafeReleaseSummary', () => {
     expect(isSafeReleaseSummary(okSummary, source)).toBe(true);
   });
 
-  it('allows the IFS Design System 2x / 30x proof', () => {
+  it('rejects invented 2x / 30x that are not in the notes', () => {
     expect(
       isSafeReleaseSummary(
         'The IFS Design System delivered 2x faster delivery and 30x ROI. That is the numbered proof. Changelog is below.',
         source
       )
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it('rejects invented metrics that are not 2x or 30x', () => {
@@ -220,7 +220,7 @@ describe('release summary API', () => {
     expect(put).toHaveBeenCalledWith('release-summary:2026.08.15.1714', notesFallback);
   });
 
-  it('keeps a 2x / 30x design-system proof from AI', async () => {
+  it('drops invented 2x / 30x and falls back to the notes', async () => {
     const get = vi.fn().mockResolvedValue(null);
     const put = vi.fn();
     const proof =
@@ -233,7 +233,7 @@ describe('release summary API', () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       tag: latest.version,
-      summary: proof,
+      summary: notesFallback,
     });
   });
 

--- a/src/__tests__/release-summary.test.ts
+++ b/src/__tests__/release-summary.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { env as workerEnv } from 'cloudflare:workers';
+import { GET, type ReleaseSummaryEnv } from '../pages/api/release-summary';
+import * as githubReleases from '../utils/github-releases';
+import {
+  isSafeReleaseSummary,
+  parseModelText,
+  releaseSummaryKey,
+  releaseSummaryPrompt,
+} from '../utils/release-summary';
+
+type GetContext = Parameters<typeof GET>[0];
+
+function createContext(runtimeEnv: unknown = {}) {
+  const bindings = workerEnv as ReleaseSummaryEnv;
+  delete bindings.AI;
+  delete bindings.CHAT_STORE;
+  Object.assign(bindings, runtimeEnv as ReleaseSummaryEnv);
+  return {
+    request: new Request('https://example.com/api/release-summary'),
+    locals: {},
+  } as unknown as GetContext;
+}
+
+const latest = {
+  body: '- 5a5a58a feat: inline footer pageviews with an exec glance (#460)',
+  publishedAt: '2026-08-15T17:14:07Z',
+  title: '2026.08.15.1714',
+  url: 'https://github.com/alehar9320/astro-cloudflare-personal-website/releases/tag/2026.08.15.1714',
+  version: '2026.08.15.1714',
+};
+
+const okSummary =
+  'The latest release adds an executive glance for footer pageviews. The count sits on the colophon and opens a short overlay. Changelog details stay on this page.';
+
+describe('isSafeReleaseSummary', () => {
+  const source = `${latest.version}\n${latest.body}`;
+
+  it('accepts 2-4 plain sentences grounded in the notes', () => {
+    expect(isSafeReleaseSummary(okSummary, source)).toBe(true);
+  });
+
+  it('rejects Palette and Oracle names', () => {
+    expect(
+      isSafeReleaseSummary('Palette shipped the glance. Oracle reviewed the overlay.', source)
+    ).toBe(false);
+  });
+
+  it('rejects invented metrics', () => {
+    expect(
+      isSafeReleaseSummary('The glance shows 2x faster delivery. It also claims 30x ROI.', source)
+    ).toBe(false);
+  });
+
+  it('rejects a one-sentence answer', () => {
+    expect(isSafeReleaseSummary('The release adds a footer glance.', source)).toBe(false);
+  });
+});
+
+describe('release summary helpers', () => {
+  it('caches by tag', () => {
+    expect(releaseSummaryKey('2026.08.15.1714')).toBe('release-summary:2026.08.15.1714');
+  });
+
+  it('asks for 2-4 sentences and no invented metrics', () => {
+    const prompt = releaseSummaryPrompt(latest.version, latest.body);
+    expect(prompt).toContain('2 to 4 plain-English sentences');
+    expect(prompt).toContain('Do not invent metrics');
+    expect(prompt).toContain('Palettes, Oracles');
+    expect(prompt).toContain(latest.body);
+  });
+
+  it('reads Workers AI text from response', () => {
+    expect(parseModelText({ response: `  ${okSummary}  ` })).toBe(okSummary);
+    expect(parseModelText(null)).toBe('');
+  });
+});
+
+describe('release summary API', () => {
+  beforeEach(() => {
+    const bindings = workerEnv as ReleaseSummaryEnv;
+    delete bindings.AI;
+    delete bindings.CHAT_STORE;
+    vi.spyOn(githubReleases, 'fetchGitHubReleases').mockResolvedValue([latest]);
+  });
+
+  it('returns a cached summary for the latest tag without calling AI', async () => {
+    const get = vi.fn().mockResolvedValue(okSummary);
+    const put = vi.fn();
+    const ai = { run: vi.fn() };
+    const response = await GET(
+      createContext({ AI: ai, CHAT_STORE: { get, put } as unknown as KVNamespace })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      tag: latest.version,
+      summary: okSummary,
+    });
+    expect(get).toHaveBeenCalledWith('release-summary:2026.08.15.1714');
+    expect(ai.run).not.toHaveBeenCalled();
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  it('generates, caches by tag, and returns 2-4 sentences', async () => {
+    const get = vi.fn().mockResolvedValue(null);
+    const put = vi.fn();
+    const ai = { run: vi.fn().mockResolvedValue({ response: okSummary }) };
+    const response = await GET(
+      createContext({ AI: ai, CHAT_STORE: { get, put } as unknown as KVNamespace })
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      tag: latest.version,
+      summary: okSummary,
+    });
+    expect(ai.run).toHaveBeenCalledWith(
+      '@cf/meta/llama-3.1-8b-instruct-fast',
+      expect.objectContaining({ stream: false })
+    );
+    expect(put).toHaveBeenCalledWith('release-summary:2026.08.15.1714', okSummary);
+  });
+
+  it('fails open with 204 when AI is missing', async () => {
+    const response = await GET(createContext({}));
+    expect(response.status).toBe(204);
+  });
+
+  it('fails open with 204 when the model invents metrics', async () => {
+    const get = vi.fn().mockResolvedValue(null);
+    const put = vi.fn();
+    const ai = {
+      run: vi.fn().mockResolvedValue({
+        response: 'This release delivered 2x faster delivery. It also hit 30x ROI.',
+      }),
+    };
+    const response = await GET(
+      createContext({ AI: ai, CHAT_STORE: { get, put } as unknown as KVNamespace })
+    );
+
+    expect(response.status).toBe(204);
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  it('fails open with 204 when GitHub has no releases', async () => {
+    vi.spyOn(githubReleases, 'fetchGitHubReleases').mockResolvedValue([]);
+    const ai = { run: vi.fn() };
+    const response = await GET(createContext({ AI: ai }));
+    expect(response.status).toBe(204);
+    expect(ai.run).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/release-summary.test.ts
+++ b/src/__tests__/release-summary.test.ts
@@ -4,6 +4,7 @@ import { env as workerEnv } from 'cloudflare:workers';
 import { GET, type ReleaseSummaryEnv } from '../pages/api/release-summary';
 import * as githubReleases from '../utils/github-releases';
 import {
+  groundedReleaseSummary,
   isSafeReleaseSummary,
   parseModelText,
   releaseSummaryKey,
@@ -59,13 +60,19 @@ describe('isSafeReleaseSummary', () => {
 });
 
 describe('release summary helpers', () => {
+  it('builds a 3-sentence notes-only fallback', () => {
+    expect(groundedReleaseSummary(latest.version, latest.body)).toBe(
+      'The latest GitHub release is 2026.08.15.1714. It includes feat: inline footer pageviews with an exec glance (#460). The full changelog is listed below.'
+    );
+  });
+
   it('caches by tag', () => {
     expect(releaseSummaryKey('2026.08.15.1714')).toBe('release-summary:2026.08.15.1714');
   });
 
   it('asks for 2-4 sentences and no invented metrics', () => {
     const prompt = releaseSummaryPrompt(latest.version, latest.body);
-    expect(prompt).toContain('2 to 4 plain-English sentences');
+    expect(prompt).toContain('exactly three plain-English sentences');
     expect(prompt).toContain('Do not invent metrics');
     expect(prompt).toContain('Palettes, Oracles');
     expect(prompt).toContain(latest.body);
@@ -123,12 +130,17 @@ describe('release summary API', () => {
     expect(put).toHaveBeenCalledWith('release-summary:2026.08.15.1714', okSummary);
   });
 
-  it('fails open with 204 when AI is missing', async () => {
+  it('uses a notes-only fallback when AI is missing', async () => {
     const response = await GET(createContext({}));
-    expect(response.status).toBe(204);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      tag: latest.version,
+      summary:
+        'The latest GitHub release is 2026.08.15.1714. It includes feat: inline footer pageviews with an exec glance (#460). The full changelog is listed below.',
+    });
   });
 
-  it('fails open with 204 when the model invents metrics', async () => {
+  it('does not serve invented metrics and falls back to the notes', async () => {
     const get = vi.fn().mockResolvedValue(null);
     const put = vi.fn();
     const ai = {
@@ -140,8 +152,16 @@ describe('release summary API', () => {
       createContext({ AI: ai, CHAT_STORE: { get, put } as unknown as KVNamespace })
     );
 
-    expect(response.status).toBe(204);
-    expect(put).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      tag: latest.version,
+      summary:
+        'The latest GitHub release is 2026.08.15.1714. It includes feat: inline footer pageviews with an exec glance (#460). The full changelog is listed below.',
+    });
+    expect(put).toHaveBeenCalledWith(
+      'release-summary:2026.08.15.1714',
+      'The latest GitHub release is 2026.08.15.1714. It includes feat: inline footer pageviews with an exec glance (#460). The full changelog is listed below.'
+    );
   });
 
   it('fails open with 204 when GitHub has no releases', async () => {

--- a/src/data/latest-release.ts
+++ b/src/data/latest-release.ts
@@ -1,0 +1,10 @@
+import type { SiteRelease } from '../utils/github-releases';
+
+/** Last known GitHub release, used when the Worker cannot reach api.github.com. */
+export const LATEST_RELEASE_SNAPSHOT: SiteRelease = {
+  body: '- 66e3fe9 fix: open the visit glance on tap at 375 (#461)',
+  publishedAt: '2026-08-15T17:20:18Z',
+  title: '2026.08.15.1720',
+  url: 'https://github.com/alehar9320/astro-cloudflare-personal-website/releases/tag/2026.08.15.1720',
+  version: '2026.08.15.1720',
+};

--- a/src/pages/api/release-summary.ts
+++ b/src/pages/api/release-summary.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from 'astro';
 import { env } from 'cloudflare:workers';
-import { fetchGitHubReleases } from '../../utils/github-releases';
+import { LATEST_RELEASE_SNAPSHOT } from '../../data/latest-release';
+import { fetchGitHubReleases, type SiteRelease } from '../../utils/github-releases';
 import {
   groundedReleaseSummary,
   parseModelText,
@@ -23,11 +24,6 @@ const jsonHeaders = {
   ...securityHeaders,
 } as const;
 
-const emptyHeaders = {
-  'Cache-Control': 'no-store',
-  ...securityHeaders,
-} as const;
-
 export const prerender = false;
 
 export interface ReleaseSummaryEnv {
@@ -35,10 +31,7 @@ export interface ReleaseSummaryEnv {
     run: (model: string, input: unknown) => Promise<unknown>;
   };
   CHAT_STORE?: KVNamespace;
-}
-
-function empty204() {
-  return new Response(null, { status: 204, headers: emptyHeaders });
+  GITHUB_TOKEN?: string;
 }
 
 function readEnv(): ReleaseSummaryEnv {
@@ -50,29 +43,89 @@ function readEnv(): ReleaseSummaryEnv {
   return {};
 }
 
-export const GET: APIRoute = async () => {
+function jsonBody(tag: string, summary: string) {
+  return new Response(JSON.stringify({ tag, summary }), { headers: jsonHeaders });
+}
+
+function postedRelease(data: unknown): SiteRelease | null {
+  if (!data || typeof data !== 'object') return null;
+  const row = data as {
+    tag?: unknown;
+    version?: unknown;
+    title?: unknown;
+    body?: unknown;
+    notes?: unknown;
+  };
+  const version =
+    typeof row.tag === 'string' ? row.tag : typeof row.version === 'string' ? row.version : '';
+  const body =
+    typeof row.body === 'string' ? row.body : typeof row.notes === 'string' ? row.notes : '';
+  const title = typeof row.title === 'string' && row.title.trim() ? row.title : version;
+  if (!version.trim()) return null;
+  return {
+    body,
+    publishedAt: null,
+    title,
+    url: LATEST_RELEASE_SNAPSHOT.url,
+    version: version.trim(),
+  };
+}
+
+async function summarize(request: Request) {
   try {
     const bindings = readEnv();
-    const releases = await fetchGitHubReleases();
-    const latest = releases[0];
-    if (!latest) return empty204();
+    let latest: SiteRelease | null = null;
+    let source = 'github';
 
-    const source = `${latest.version}\n${latest.body}`;
+    if (request.method === 'POST') {
+      try {
+        latest = postedRelease(await request.json());
+        if (latest) source = 'post';
+        else {
+          console.error({
+            event: 'release_summary_204',
+            reason: 'method',
+            method: 'POST',
+            detail: 'missing_tag',
+          });
+        }
+      } catch (error: unknown) {
+        console.error({
+          event: 'release_summary_204',
+          reason: 'method',
+          method: 'POST',
+          error: String(error),
+        });
+      }
+    }
+
+    if (!latest) {
+      const releases = await fetchGitHubReleases();
+      latest = releases[0] ?? null;
+      if (latest) source = 'github';
+    }
+
+    if (!latest) {
+      latest = LATEST_RELEASE_SNAPSHOT;
+      source = 'snapshot';
+      console.error({
+        event: 'release_summary_github_empty',
+        reason: 'tag_miss',
+        using: 'snapshot',
+      });
+    }
+
+    const notes = `${latest.version}\n${latest.body}`;
     const key = releaseSummaryKey(latest.version);
     const store = bindings.CHAT_STORE;
 
     if (store) {
       const cached = await store.get(key);
-      const preparedCache = cached ? prepareReleaseSummary(cached, source) : null;
+      const preparedCache = cached ? prepareReleaseSummary(cached, notes) : null;
       if (preparedCache) {
-        return new Response(JSON.stringify({ tag: latest.version, summary: preparedCache }), {
-          headers: jsonHeaders,
-        });
+        return jsonBody(latest.version, preparedCache);
       }
     }
-
-    const json = (summary: string) =>
-      new Response(JSON.stringify({ tag: latest.version, summary }), { headers: jsonHeaders });
 
     const ai = bindings.AI;
     if (ai) {
@@ -86,22 +139,40 @@ export const GET: APIRoute = async () => {
           ],
           stream: false,
         });
-        const summary = prepareReleaseSummary(parseModelText(result), source);
+        const summary = prepareReleaseSummary(parseModelText(result), notes);
         if (summary) {
           if (store) await store.put(key, summary);
-          return json(summary);
+          return jsonBody(latest.version, summary);
         }
+        console.error({
+          event: 'release_summary_sanitizer',
+          reason: 'sanitizer',
+          tag: latest.version,
+          source,
+        });
       } catch (error: unknown) {
-        console.error({ event: 'release_summary_ai_error', error: String(error) });
+        console.error({
+          event: 'release_summary_ai_error',
+          error: String(error),
+          tag: latest.version,
+        });
       }
     }
 
     const fallback = groundedReleaseSummary(latest.version, latest.body, latest.title);
-    if (!fallback) return empty204();
     if (store) await store.put(key, fallback);
-    return json(fallback);
+    return jsonBody(latest.version, fallback);
   } catch (error: unknown) {
-    console.error({ event: 'release_summary_error', error: String(error) });
-    return empty204();
+    console.error({ event: 'release_summary_204', reason: 'error', error: String(error) });
+    const fallback = groundedReleaseSummary(
+      LATEST_RELEASE_SNAPSHOT.version,
+      LATEST_RELEASE_SNAPSHOT.body,
+      LATEST_RELEASE_SNAPSHOT.title
+    );
+    return jsonBody(LATEST_RELEASE_SNAPSHOT.version, fallback);
   }
-};
+}
+
+export const GET: APIRoute = async ({ request }) => summarize(request);
+
+export const POST: APIRoute = async ({ request }) => summarize(request);

--- a/src/pages/api/release-summary.ts
+++ b/src/pages/api/release-summary.ts
@@ -3,8 +3,8 @@ import { env } from 'cloudflare:workers';
 import { fetchGitHubReleases } from '../../utils/github-releases';
 import {
   groundedReleaseSummary,
-  isSafeReleaseSummary,
   parseModelText,
+  prepareReleaseSummary,
   RELEASE_SUMMARY_MODEL,
   releaseSummaryKey,
   releaseSummaryPrompt,
@@ -63,8 +63,9 @@ export const GET: APIRoute = async () => {
 
     if (store) {
       const cached = await store.get(key);
-      if (cached && isSafeReleaseSummary(cached, source)) {
-        return new Response(JSON.stringify({ tag: latest.version, summary: cached }), {
+      const preparedCache = cached ? prepareReleaseSummary(cached, source) : null;
+      if (preparedCache) {
+        return new Response(JSON.stringify({ tag: latest.version, summary: preparedCache }), {
           headers: jsonHeaders,
         });
       }
@@ -85,8 +86,8 @@ export const GET: APIRoute = async () => {
           ],
           stream: false,
         });
-        const summary = parseModelText(result);
-        if (isSafeReleaseSummary(summary, source)) {
+        const summary = prepareReleaseSummary(parseModelText(result), source);
+        if (summary) {
           if (store) await store.put(key, summary);
           return json(summary);
         }
@@ -95,7 +96,7 @@ export const GET: APIRoute = async () => {
       }
     }
 
-    const fallback = groundedReleaseSummary(latest.version, latest.body);
+    const fallback = groundedReleaseSummary(latest.version, latest.body, latest.title);
     if (!fallback) return empty204();
     if (store) await store.put(key, fallback);
     return json(fallback);

--- a/src/pages/api/release-summary.ts
+++ b/src/pages/api/release-summary.ts
@@ -2,6 +2,7 @@ import type { APIRoute } from 'astro';
 import { env } from 'cloudflare:workers';
 import { fetchGitHubReleases } from '../../utils/github-releases';
 import {
+  groundedReleaseSummary,
   isSafeReleaseSummary,
   parseModelText,
   RELEASE_SUMMARY_MODEL,
@@ -69,29 +70,35 @@ export const GET: APIRoute = async () => {
       }
     }
 
+    const json = (summary: string) =>
+      new Response(JSON.stringify({ tag: latest.version, summary }), { headers: jsonHeaders });
+
     const ai = bindings.AI;
-    if (!ai) return empty204();
-
-    const result = await ai.run(RELEASE_SUMMARY_MODEL, {
-      messages: [
-        {
-          role: 'user',
-          content: releaseSummaryPrompt(latest.version, latest.body),
-        },
-      ],
-      stream: false,
-    });
-
-    const summary = parseModelText(result);
-    if (!isSafeReleaseSummary(summary, source)) return empty204();
-
-    if (store) {
-      await store.put(key, summary);
+    if (ai) {
+      try {
+        const result = await ai.run(RELEASE_SUMMARY_MODEL, {
+          messages: [
+            {
+              role: 'user',
+              content: releaseSummaryPrompt(latest.version, latest.body),
+            },
+          ],
+          stream: false,
+        });
+        const summary = parseModelText(result);
+        if (isSafeReleaseSummary(summary, source)) {
+          if (store) await store.put(key, summary);
+          return json(summary);
+        }
+      } catch (error: unknown) {
+        console.error({ event: 'release_summary_ai_error', error: String(error) });
+      }
     }
 
-    return new Response(JSON.stringify({ tag: latest.version, summary }), {
-      headers: jsonHeaders,
-    });
+    const fallback = groundedReleaseSummary(latest.version, latest.body);
+    if (!fallback) return empty204();
+    if (store) await store.put(key, fallback);
+    return json(fallback);
   } catch (error: unknown) {
     console.error({ event: 'release_summary_error', error: String(error) });
     return empty204();

--- a/src/pages/api/release-summary.ts
+++ b/src/pages/api/release-summary.ts
@@ -1,0 +1,99 @@
+import type { APIRoute } from 'astro';
+import { env } from 'cloudflare:workers';
+import { fetchGitHubReleases } from '../../utils/github-releases';
+import {
+  isSafeReleaseSummary,
+  parseModelText,
+  RELEASE_SUMMARY_MODEL,
+  releaseSummaryKey,
+  releaseSummaryPrompt,
+} from '../../utils/release-summary';
+
+const securityHeaders = {
+  'X-Content-Type-Options': 'nosniff',
+  'X-Frame-Options': 'DENY',
+  'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
+  'Content-Security-Policy': "default-src 'none'; frame-ancestors 'none';",
+} as const;
+
+const jsonHeaders = {
+  'content-type': 'application/json',
+  'Cache-Control': 'public, max-age=60',
+  ...securityHeaders,
+} as const;
+
+const emptyHeaders = {
+  'Cache-Control': 'no-store',
+  ...securityHeaders,
+} as const;
+
+export const prerender = false;
+
+export interface ReleaseSummaryEnv {
+  AI?: {
+    run: (model: string, input: unknown) => Promise<unknown>;
+  };
+  CHAT_STORE?: KVNamespace;
+}
+
+function empty204() {
+  return new Response(null, { status: 204, headers: emptyHeaders });
+}
+
+function readEnv(): ReleaseSummaryEnv {
+  try {
+    if (env && typeof env === 'object') return env as ReleaseSummaryEnv;
+  } catch {
+    // cloudflare:workers env is the only binding surface after adapter v13.
+  }
+  return {};
+}
+
+export const GET: APIRoute = async () => {
+  try {
+    const bindings = readEnv();
+    const releases = await fetchGitHubReleases();
+    const latest = releases[0];
+    if (!latest) return empty204();
+
+    const source = `${latest.version}\n${latest.body}`;
+    const key = releaseSummaryKey(latest.version);
+    const store = bindings.CHAT_STORE;
+
+    if (store) {
+      const cached = await store.get(key);
+      if (cached && isSafeReleaseSummary(cached, source)) {
+        return new Response(JSON.stringify({ tag: latest.version, summary: cached }), {
+          headers: jsonHeaders,
+        });
+      }
+    }
+
+    const ai = bindings.AI;
+    if (!ai) return empty204();
+
+    const result = await ai.run(RELEASE_SUMMARY_MODEL, {
+      messages: [
+        {
+          role: 'user',
+          content: releaseSummaryPrompt(latest.version, latest.body),
+        },
+      ],
+      stream: false,
+    });
+
+    const summary = parseModelText(result);
+    if (!isSafeReleaseSummary(summary, source)) return empty204();
+
+    if (store) {
+      await store.put(key, summary);
+    }
+
+    return new Response(JSON.stringify({ tag: latest.version, summary }), {
+      headers: jsonHeaders,
+    });
+  } catch (error: unknown) {
+    console.error({ event: 'release_summary_error', error: String(error) });
+    return empty204();
+  }
+};

--- a/src/pages/api/releases.ts
+++ b/src/pages/api/releases.ts
@@ -1,0 +1,23 @@
+import type { APIRoute } from 'astro';
+import { fetchGitHubReleases } from '../../utils/github-releases';
+
+const jsonHeaders = {
+  'content-type': 'application/json',
+  'Cache-Control': 'public, max-age=60',
+  'X-Content-Type-Options': 'nosniff',
+  'X-Frame-Options': 'DENY',
+  'Strict-Transport-Security': 'max-age=31536000; includeSubDomains',
+  'Content-Security-Policy': "default-src 'none'; frame-ancestors 'none';",
+} as const;
+
+export const prerender = false;
+
+export const GET: APIRoute = async () => {
+  try {
+    const releases = await fetchGitHubReleases();
+    return new Response(JSON.stringify(releases), { headers: jsonHeaders });
+  } catch (error: unknown) {
+    console.error({ event: 'releases_api_error', error: String(error) });
+    return new Response(JSON.stringify([]), { headers: jsonHeaders });
+  }
+};

--- a/src/pages/whats-new.astro
+++ b/src/pages/whats-new.astro
@@ -76,9 +76,23 @@ const schema = {
     formatReleaseDate,
     splitReleaseBody,
   } from '../utils/github-releases';
+  import { groundedReleaseSummary } from '../utils/release-summary';
 
   const releaseList = document.querySelector('[data-release-list]');
   const summaryContainer = document.querySelector('[data-release-summary]');
+
+  const paintSummary = (summary: string) => {
+    if (!(summaryContainer instanceof HTMLElement)) return;
+    const tldr = document.createElement('div');
+    tldr.className = 'tldr-box';
+    const p = document.createElement('p');
+    const strong = document.createElement('strong');
+    strong.textContent = 'Latest release';
+    p.appendChild(strong);
+    p.appendChild(document.createTextNode(` ${summary.trim()}`));
+    tldr.appendChild(p);
+    summaryContainer.replaceChildren(tldr);
+  };
 
   if (summaryContainer instanceof HTMLElement) {
     fetch('/api/release-summary')
@@ -93,19 +107,10 @@ const schema = {
         if (!data || typeof data !== 'object') return;
         const summary = (data as { summary?: unknown }).summary;
         if (typeof summary !== 'string' || !summary.trim()) return;
-
-        const tldr = document.createElement('div');
-        tldr.className = 'tldr-box';
-        const p = document.createElement('p');
-        const strong = document.createElement('strong');
-        strong.textContent = 'Latest release';
-        p.appendChild(strong);
-        p.appendChild(document.createTextNode(` ${summary.trim()}`));
-        tldr.appendChild(p);
-        summaryContainer.replaceChildren(tldr);
+        paintSummary(summary);
       })
       .catch(() => {
-        // Fail-open: changelog still renders.
+        // Fail-open: notes-only fallback still paints with the changelog.
       });
   }
 
@@ -126,6 +131,11 @@ const schema = {
 
         releaseList.replaceChildren(empty);
         return;
+      }
+
+      if (summaryContainer instanceof HTMLElement && !summaryContainer.hasChildNodes()) {
+        const fallback = groundedReleaseSummary(releases[0].version, releases[0].body);
+        if (fallback) paintSummary(fallback);
       }
 
       const fragment = document.createDocumentFragment();

--- a/src/pages/whats-new.astro
+++ b/src/pages/whats-new.astro
@@ -134,7 +134,11 @@ const schema = {
       }
 
       if (summaryContainer instanceof HTMLElement && !summaryContainer.hasChildNodes()) {
-        const fallback = groundedReleaseSummary(releases[0].version, releases[0].body);
+        const fallback = groundedReleaseSummary(
+          releases[0].version,
+          releases[0].body,
+          releases[0].title
+        );
         if (fallback) paintSummary(fallback);
       }
 

--- a/src/pages/whats-new.astro
+++ b/src/pages/whats-new.astro
@@ -51,18 +51,7 @@ const schema = {
       />
 
       <div class="content">
-        <div data-release-summary>
-          <div class="tldr-box">
-            <p>
-              <strong>Topical Anchor:</strong> This page serves as the <strong
-                >Source of Truth</strong
-              >
-              for the latest technical refinements, portfolio updates, and professional milestones. It
-              is optimized for both human readers and <strong>AI agents</strong> to synthesize Alexander
-              Härenstam's real-time project impact.
-            </p>
-          </div>
-        </div>
+        <div data-release-summary></div>
         <div class="release-list" data-release-list>
           <p class="release-status">Fetching latest project updates...</p>
         </div>
@@ -89,6 +78,36 @@ const schema = {
   } from '../utils/github-releases';
 
   const releaseList = document.querySelector('[data-release-list]');
+  const summaryContainer = document.querySelector('[data-release-summary]');
+
+  if (summaryContainer instanceof HTMLElement) {
+    fetch('/api/release-summary')
+      .then(async (response) => {
+        if (response.status === 204 || !response.ok) return;
+        let data: unknown;
+        try {
+          data = await response.json();
+        } catch {
+          return;
+        }
+        if (!data || typeof data !== 'object') return;
+        const summary = (data as { summary?: unknown }).summary;
+        if (typeof summary !== 'string' || !summary.trim()) return;
+
+        const tldr = document.createElement('div');
+        tldr.className = 'tldr-box';
+        const p = document.createElement('p');
+        const strong = document.createElement('strong');
+        strong.textContent = 'Latest release';
+        p.appendChild(strong);
+        p.appendChild(document.createTextNode(` ${summary.trim()}`));
+        tldr.appendChild(p);
+        summaryContainer.replaceChildren(tldr);
+      })
+      .catch(() => {
+        // Fail-open: changelog still renders.
+      });
+  }
 
   if (releaseList instanceof HTMLDivElement) {
     fetchGitHubReleases().then((releases) => {
@@ -110,51 +129,6 @@ const schema = {
       }
 
       const fragment = document.createDocumentFragment();
-
-      // Generate summary from the first 3 most significant items across latest releases
-      const summaryItems = releases
-        .flatMap((r) => splitReleaseBody(r.body))
-        .filter((item) => {
-          const msg = item.message.toLowerCase();
-          // Prioritize features, fixes, and persona-driven updates
-          return (
-            msg.includes('feat') ||
-            msg.includes('fix') ||
-            msg.includes('scribe') ||
-            msg.includes('oracle') ||
-            msg.includes('sentinel') ||
-            msg.includes('palette') ||
-            msg.includes('vantage') ||
-            msg.includes('bolt')
-          );
-        })
-        .slice(0, 3)
-        .map((item) => item.message);
-
-      // Fallback to first 3 items if no prioritized items found
-      if (summaryItems.length === 0) {
-        summaryItems.push(
-          ...releases
-            .flatMap((r) => splitReleaseBody(r.body))
-            .slice(0, 3)
-            .map((item) => item.message)
-        );
-      }
-
-      if (summaryItems.length > 0) {
-        const summaryContainer = document.querySelector('[data-release-summary]');
-        if (summaryContainer) {
-          const tldr = document.createElement('div');
-          tldr.className = 'tldr-box';
-          const p = document.createElement('p');
-          const strong = document.createElement('strong');
-          strong.textContent = 'Recent Highlights:';
-          p.appendChild(strong);
-          p.appendChild(document.createTextNode(` ${summaryItems.join('; ')}.`));
-          tldr.appendChild(p);
-          summaryContainer.replaceChildren(tldr);
-        }
-      }
 
       releases.forEach((release) => {
         const article = document.createElement('article');
@@ -231,6 +205,10 @@ const schema = {
   .release-list {
     display: grid;
     gap: 1.5rem;
+  }
+
+  [data-release-summary]:not(:empty) {
+    margin-bottom: 1.5rem;
   }
 
   .release-card {

--- a/src/pages/whats-new.astro
+++ b/src/pages/whats-new.astro
@@ -72,6 +72,7 @@ const schema = {
 <script>
   import { LATEST_RELEASE_SNAPSHOT } from '../data/latest-release';
   import {
+    RELEASES_PAGE_URL,
     fetchGitHubReleases,
     formatReleaseDate,
     splitReleaseBody,
@@ -118,13 +119,24 @@ const schema = {
   }
 
   if (releaseList instanceof HTMLDivElement) {
-    fetchGitHubReleases().then((fetched) => {
-      const releases = fetched.length > 0 ? fetched : [LATEST_RELEASE_SNAPSHOT];
-
+    fetchGitHubReleases().then((releases) => {
       if (summaryContainer instanceof HTMLElement && !summaryContainer.hasChildNodes()) {
-        paintSummary(
-          groundedReleaseSummary(releases[0].version, releases[0].body, releases[0].title)
-        );
+        const latest = releases[0] ?? LATEST_RELEASE_SNAPSHOT;
+        paintSummary(groundedReleaseSummary(latest.version, latest.body, latest.title));
+      }
+
+      if (releases.length === 0) {
+        const empty = document.createElement('p');
+        empty.className = 'release-status';
+        empty.textContent = 'Project history is currently unavailable.';
+        const link = document.createElement('a');
+        link.href = RELEASES_PAGE_URL;
+        link.textContent = 'View GitHub Releases';
+        empty.appendChild(document.createTextNode(' '));
+        empty.appendChild(link);
+        empty.appendChild(document.createTextNode('.'));
+        releaseList.replaceChildren(empty);
+        return;
       }
 
       const fragment = document.createDocumentFragment();

--- a/src/pages/whats-new.astro
+++ b/src/pages/whats-new.astro
@@ -70,13 +70,13 @@ const schema = {
 </BaseLayout>
 
 <script>
+  import { LATEST_RELEASE_SNAPSHOT } from '../data/latest-release';
   import {
-    RELEASES_PAGE_URL,
     fetchGitHubReleases,
     formatReleaseDate,
     splitReleaseBody,
   } from '../utils/github-releases';
-  import { groundedReleaseSummary } from '../utils/release-summary';
+  import { groundedReleaseSummary, prepareReleaseSummary } from '../utils/release-summary';
 
   const releaseList = document.querySelector('[data-release-list]');
   const summaryContainer = document.querySelector('[data-release-summary]');
@@ -106,8 +106,11 @@ const schema = {
         }
         if (!data || typeof data !== 'object') return;
         const summary = (data as { summary?: unknown }).summary;
+        const tag = (data as { tag?: unknown }).tag;
         if (typeof summary !== 'string' || !summary.trim()) return;
-        paintSummary(summary);
+        const source = `${typeof tag === 'string' ? tag : ''}\n${LATEST_RELEASE_SNAPSHOT.body}`;
+        const prepared = prepareReleaseSummary(summary, source);
+        if (prepared) paintSummary(prepared);
       })
       .catch(() => {
         // Fail-open: notes-only fallback still paints with the changelog.
@@ -115,31 +118,13 @@ const schema = {
   }
 
   if (releaseList instanceof HTMLDivElement) {
-    fetchGitHubReleases().then((releases) => {
-      if (releases.length === 0) {
-        const empty = document.createElement('p');
-        empty.className = 'release-status';
-        empty.textContent = 'Project history is currently unavailable.';
-
-        const link = document.createElement('a');
-        link.href = RELEASES_PAGE_URL;
-        link.textContent = 'View GitHub Releases';
-
-        empty.appendChild(document.createTextNode(' '));
-        empty.appendChild(link);
-        empty.appendChild(document.createTextNode('.'));
-
-        releaseList.replaceChildren(empty);
-        return;
-      }
+    fetchGitHubReleases().then((fetched) => {
+      const releases = fetched.length > 0 ? fetched : [LATEST_RELEASE_SNAPSHOT];
 
       if (summaryContainer instanceof HTMLElement && !summaryContainer.hasChildNodes()) {
-        const fallback = groundedReleaseSummary(
-          releases[0].version,
-          releases[0].body,
-          releases[0].title
+        paintSummary(
+          groundedReleaseSummary(releases[0].version, releases[0].body, releases[0].title)
         );
-        if (fallback) paintSummary(fallback);
       }
 
       const fragment = document.createDocumentFragment();

--- a/src/utils/github-releases.ts
+++ b/src/utils/github-releases.ts
@@ -234,9 +234,16 @@ export function parseReleaseItem(line: string): ReleaseItem {
   };
 }
 
+const INTERNAL_CHANGELOG_ITEM = /\bjules\b|\bagent[- ]farm\b|\bjohan nits\b/i;
+
+export function isPublicChangelogItem(item: ReleaseItem): boolean {
+  return !INTERNAL_CHANGELOG_ITEM.test(item.message);
+}
+
 /**
  * Splits a release body into individual, formatted ReleaseItem objects.
  * Filters for lines starting with list markers (-, *, +).
+ * Drops Jules, agent-farm, and Johan-nits internals from the public list.
  * @param {string} body - The full Markdown body of a GitHub release.
  * @returns {ReleaseItem[]} An array of parsed release items.
  */
@@ -246,7 +253,8 @@ export function splitReleaseBody(body: string): ReleaseItem[] {
     .map((line) => line.trim())
     .filter((line) => /^[-*+]\s+/.test(line))
     .map((line) => line.replace(/^[-*+]\s+/, ''))
-    .map(parseReleaseItem);
+    .map(parseReleaseItem)
+    .filter(isPublicChangelogItem);
 }
 
 export { RELEASES_PAGE_URL };

--- a/src/utils/github-releases.ts
+++ b/src/utils/github-releases.ts
@@ -74,13 +74,39 @@ export async function fetchGitHubReleases(
       const cached = sessionStorage.getItem(CACHE_KEY);
       if (cached) {
         const { data, timestamp } = JSON.parse(cached);
-        if (Date.now() - timestamp < CACHE_TTL) {
-          return data;
+        const parsed = z.array(SiteReleaseSchema).safeParse(data);
+        if (Date.now() - timestamp < CACHE_TTL && parsed.success && parsed.data.length > 0) {
+          return parsed.data;
         }
       }
     } catch {
       /* ignore cache errors */
     }
+
+    try {
+      const response = await fetchImpl('/api/releases', {
+        headers: { Accept: 'application/json' },
+      });
+      if (response.ok) {
+        const json = await response.json();
+        const parsed = z.array(SiteReleaseSchema).safeParse(json);
+        if (parsed.success && parsed.data.length > 0) {
+          try {
+            sessionStorage.setItem(
+              CACHE_KEY,
+              JSON.stringify({ data: parsed.data, timestamp: Date.now() })
+            );
+          } catch {
+            /* ignore cache errors */
+          }
+          return parsed.data;
+        }
+      }
+    } catch (error: unknown) {
+      console.error({ event: 'github_releases_proxy_error', error: String(error) });
+    }
+
+    return [];
   }
 
   let githubToken: string | undefined;

--- a/src/utils/github-releases.ts
+++ b/src/utils/github-releases.ts
@@ -30,6 +30,19 @@ const REPO_URL = 'https://github.com/alehar9320/astro-cloudflare-personal-websit
 const CACHE_KEY = 'github-releases-cache';
 const CACHE_TTL = 3600 * 1000; // 1 hour
 
+function logReleaseValidationFailed(issues: z.ZodIssue[]): void {
+  const sanitizedIssues = issues.map((issue) => {
+    const safeIssue = { ...issue } as Record<string, unknown>;
+    delete safeIssue.received;
+    delete safeIssue.value;
+    return safeIssue;
+  });
+  console.error({
+    event: 'github_releases_validation_failed',
+    issues: sanitizedIssues,
+  });
+}
+
 /**
  * Represents a single item within a release's changelog.
  */
@@ -101,6 +114,9 @@ export async function fetchGitHubReleases(
           }
           return parsed.data;
         }
+        if (!parsed.success) {
+          logReleaseValidationFailed(parsed.error.issues);
+        }
       }
     } catch (error: unknown) {
       console.error({ event: 'github_releases_proxy_error', error: String(error) });
@@ -148,17 +164,7 @@ export async function fetchGitHubReleases(
     const result = z.array(GitHubReleaseApiItemSchema).safeParse(json);
 
     if (!result.success) {
-      // Sanitize issues for telemetry to prevent data leaks (redact 'received' and 'value')
-      const sanitizedIssues = result.error.issues.map((issue) => {
-        const safeIssue = { ...issue } as Record<string, unknown>;
-        delete safeIssue.received;
-        delete safeIssue.value;
-        return safeIssue;
-      });
-      console.error({
-        event: 'github_releases_validation_failed',
-        issues: sanitizedIssues,
-      });
+      logReleaseValidationFailed(result.error.issues);
       return [];
     }
 

--- a/src/utils/github-releases.ts
+++ b/src/utils/github-releases.ts
@@ -97,14 +97,16 @@ export async function fetchGitHubReleases(
   }
 
   try {
-    const response = await fetchImpl(url, {
-      headers: {
-        Accept: 'application/vnd.github+json',
-        'User-Agent': 'alehar9320-astro-cloudflare-personal-website',
-        'X-GitHub-Api-Version': '2022-11-28',
-        ...(githubToken ? { Authorization: `token ${githubToken}` } : {}),
-      },
-    });
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.github+json',
+      ...(githubToken ? { Authorization: `token ${githubToken}` } : {}),
+    };
+    if (typeof window === 'undefined') {
+      headers['User-Agent'] = 'alehar9320-astro-cloudflare-personal-website';
+      headers['X-GitHub-Api-Version'] = '2022-11-28';
+    }
+
+    const response = await fetchImpl(url, { headers });
 
     if (!response.ok) {
       // Intentionally avoiding logging headers that might contain sensitive information

--- a/src/utils/github-releases.ts
+++ b/src/utils/github-releases.ts
@@ -83,7 +83,12 @@ export async function fetchGitHubReleases(
     }
   }
 
-  const githubToken = typeof process !== 'undefined' ? process.env.GITHUB_TOKEN : undefined;
+  let githubToken: string | undefined;
+  try {
+    githubToken = typeof process !== 'undefined' ? process.env.GITHUB_TOKEN : undefined;
+  } catch {
+    githubToken = undefined;
+  }
 
   // Defensive check to ensure we only fetch from the trusted GitHub API domain
   if (!url.startsWith('https://api.github.com/')) {
@@ -95,6 +100,8 @@ export async function fetchGitHubReleases(
     const response = await fetchImpl(url, {
       headers: {
         Accept: 'application/vnd.github+json',
+        'User-Agent': 'alehar9320-astro-cloudflare-personal-website',
+        'X-GitHub-Api-Version': '2022-11-28',
         ...(githubToken ? { Authorization: `token ${githubToken}` } : {}),
       },
     });

--- a/src/utils/release-summary.ts
+++ b/src/utils/release-summary.ts
@@ -3,7 +3,9 @@ import { splitReleaseBody } from './github-releases';
 export const RELEASE_SUMMARY_MODEL = '@cf/meta/llama-3.1-8b-instruct-fast';
 export const RELEASE_SUMMARY_KEY_PREFIX = 'release-summary:';
 
-const BANNED_NAME = /\b(palette|oracle|scribe|sentinel|vantage|bolt|jules)\b/i;
+const BANNED_NAME = /\b(palette|oracle|scribe|sentinel|vantage|bolt|jules)\b/gi;
+const SHA = /\b[a-f0-9]{7,40}\b/g;
+const ALLOWED_METRICS = new Set(['2x', '30x', 'roi']);
 
 export function releaseSummaryKey(tag: string): string {
   return `${RELEASE_SUMMARY_KEY_PREFIX}${tag}`;
@@ -11,9 +13,10 @@ export function releaseSummaryKey(tag: string): string {
 
 export function releaseSummaryPrompt(tag: string, notes: string): string {
   return `Write exactly three plain-English sentences summarizing this GitHub release for an executive.
-Use only facts in the notes. Do not invent metrics, ROI, visitor counts, titles, or outcomes.
+Use only facts in the notes. Do not invent metrics, visitor counts, titles, or outcomes.
+The IFS Design System 2x faster delivery / 30x ROI line is allowed if the notes mention it.
 Do not name agents, Palettes, Oracles, Scribes, Sentinels, Vantage, Bolt, or Jules.
-No bullets, headings, or quotation marks around the whole answer.
+Do not include git SHAs. No bullets, headings, or quotation marks around the whole answer.
 
 Release: ${tag}
 Notes:
@@ -32,17 +35,32 @@ function metricTokens(text: string): string[] {
   return matches ? matches.map((token) => token.toLowerCase()) : [];
 }
 
+export function stripExecBanned(text: string): string {
+  return text
+    .replace(BANNED_NAME, '')
+    .replace(SHA, '')
+    .replace(/\s+([.,;:])/g, '$1')
+    .replace(/^[\s:;\-]+/, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}
+
 export function isSafeReleaseSummary(summary: string, source: string): boolean {
   const text = summary.trim();
   if (!text) return false;
   const count = sentenceCount(text);
   if (count < 2 || count > 4) return false;
-  if (BANNED_NAME.test(text)) return false;
   const sourceLower = source.toLowerCase();
   for (const token of metricTokens(text)) {
+    if (ALLOWED_METRICS.has(token)) continue;
     if (!sourceLower.includes(token)) return false;
   }
   return true;
+}
+
+export function prepareReleaseSummary(summary: string, source: string): string | null {
+  const text = stripExecBanned(summary);
+  return isSafeReleaseSummary(text, source) ? text : null;
 }
 
 export function parseModelText(result: unknown): string {
@@ -52,13 +70,15 @@ export function parseModelText(result: unknown): string {
   return typeof row.response === 'string' ? row.response.trim() : '';
 }
 
-export function groundedReleaseSummary(tag: string, body: string): string | null {
+export function groundedReleaseSummary(tag: string, body: string, title = tag): string | null {
   const items = splitReleaseBody(body)
-    .map((item) => item.message.trim())
-    .filter((message) => message.length > 0 && !BANNED_NAME.test(message));
-  const listed = (items.length > 0 ? items : body.trim() ? [body.trim()] : []).slice(0, 3);
+    .map((item) => stripExecBanned(item.message.trim()).replace(/^[:\-\s]+/, ''))
+    .filter((message) => message.length > 0);
+  const listed = (items.length > 0 ? items : body.trim() ? [stripExecBanned(body.trim())] : [])
+    .filter((message) => message.length > 0)
+    .slice(0, 3);
   if (listed.length === 0) return null;
-  const text = `The latest GitHub release is ${tag}. It includes ${listed.join('; ')}. The full changelog is listed below.`;
-  const source = `${tag}\n${body}`;
-  return isSafeReleaseSummary(text, source) ? text : null;
+  const text = `The latest release is ${title}. It includes ${listed.join('; ')}. The full changelog is listed below.`;
+  const source = `${tag}\n${title}\n${body}`;
+  return prepareReleaseSummary(text, source);
 }

--- a/src/utils/release-summary.ts
+++ b/src/utils/release-summary.ts
@@ -4,7 +4,8 @@ export const RELEASE_SUMMARY_MODEL = '@cf/meta/llama-3.1-8b-instruct-fast';
 export const RELEASE_SUMMARY_KEY_PREFIX = 'release-summary:';
 
 const BANNED_NAME = /\b(palette|oracle|scribe|sentinel|vantage|bolt|jules)\b/gi;
-const SHA = /\b[a-f0-9]{7,40}\b/g;
+const SHA_ONE = /\b[a-f0-9]{7,40}\b/i;
+const SHA_ALL = /\b[a-f0-9]{7,40}\b/gi;
 const ALLOWED_METRICS = new Set(['2x', '30x', 'roi']);
 
 export function releaseSummaryKey(tag: string): string {
@@ -38,7 +39,7 @@ function metricTokens(text: string): string[] {
 export function stripExecBanned(text: string): string {
   return text
     .replace(BANNED_NAME, '')
-    .replace(SHA, '')
+    .replace(SHA_ALL, '')
     .replace(/\s+([.,;:])/g, '$1')
     .replace(/^[\s:;\-]+/, '')
     .replace(/\s{2,}/g, ' ')
@@ -59,7 +60,9 @@ export function isSafeReleaseSummary(summary: string, source: string): boolean {
 }
 
 export function prepareReleaseSummary(summary: string, source: string): string | null {
-  const text = stripExecBanned(summary);
+  const original = summary.trim();
+  if (SHA_ONE.test(original)) return null;
+  const text = stripExecBanned(original);
   return isSafeReleaseSummary(text, source) ? text : null;
 }
 
@@ -80,5 +83,5 @@ export function groundedReleaseSummary(tag: string, body: string, title = tag): 
   if (listed.length === 0) return null;
   const text = `The latest release is ${title}. It includes ${listed.join('; ')}. The full changelog is listed below.`;
   const source = `${tag}\n${title}\n${body}`;
-  return prepareReleaseSummary(text, source);
+  return isSafeReleaseSummary(text, source) ? text : null;
 }

--- a/src/utils/release-summary.ts
+++ b/src/utils/release-summary.ts
@@ -6,17 +6,20 @@ export const RELEASE_SUMMARY_KEY_PREFIX = 'release-summary:';
 const BANNED_NAME = /\b(palette|oracle|scribe|sentinel|vantage|bolt|jules)\b/gi;
 const SHA_ONE = /\b[a-f0-9]{7,40}\b/i;
 const SHA_ALL = /\b[a-f0-9]{7,40}\b/gi;
+const CONVENTIONAL = /^(feat|fix|chore|docs|refactor|test|style|perf|build|ci):\s*/i;
 
 export function releaseSummaryKey(tag: string): string {
   return `${RELEASE_SUMMARY_KEY_PREFIX}${tag}`;
 }
 
 export function releaseSummaryPrompt(tag: string, notes: string): string {
-  return `Write exactly three plain-English sentences summarizing this GitHub release for an executive.
-Use only facts in the notes. Do not invent metrics, visitor counts, titles, or outcomes.
+  return `Write exactly three plain-English sentences for a hiring manager about this GitHub release.
+Say what a visitor can now see or do. Use only facts in the notes.
+Do not invent metrics, visitor counts, titles, or outcomes.
 The IFS Design System 2x faster delivery / 30x ROI line is allowed if the notes mention it.
 Do not name agents, Palettes, Oracles, Scribes, Sentinels, Vantage, Bolt, or Jules.
-Do not include git SHAs. No bullets, headings, or quotation marks around the whole answer.
+Do not include git SHAs, issue numbers, or feat/fix prefixes.
+No bullets, headings, or quotation marks around the whole answer.
 
 Release: ${tag}
 Notes:
@@ -39,6 +42,9 @@ export function stripExecBanned(text: string): string {
   return text
     .replace(BANNED_NAME, '')
     .replace(SHA_ALL, '')
+    .replace(/\(#\d+\)/g, '')
+    .replace(/\bissue number\s+\d+\b/gi, '')
+    .replace(CONVENTIONAL, '')
     .replace(/\s+([.,;:])/g, '$1')
     .replace(/^[\s:;\-]+/, '')
     .replace(/\s{2,}/g, ' ')
@@ -50,6 +56,9 @@ export function isSafeReleaseSummary(summary: string, source: string): boolean {
   if (!text) return false;
   const count = sentenceCount(text);
   if (count < 2 || count > 4) return false;
+  if (SHA_ONE.test(text) || /\bissue number\b/i.test(text) || /\bcommit hash\b/i.test(text)) {
+    return false;
+  }
   const sourceLower = source.toLowerCase();
   for (const token of metricTokens(text)) {
     if (!sourceLower.includes(token)) return false;
@@ -59,7 +68,13 @@ export function isSafeReleaseSummary(summary: string, source: string): boolean {
 
 export function prepareReleaseSummary(summary: string, source: string): string | null {
   const original = summary.trim();
-  if (SHA_ONE.test(original) || /\bissue number\b/i.test(original)) return null;
+  if (
+    SHA_ONE.test(original) ||
+    /\bissue number\b/i.test(original) ||
+    /\bcommit hash\b/i.test(original)
+  ) {
+    return null;
+  }
   const text = stripExecBanned(original);
   return isSafeReleaseSummary(text, source) ? text : null;
 }
@@ -73,14 +88,14 @@ export function parseModelText(result: unknown): string {
 
 export function groundedReleaseSummary(tag: string, body: string, title = tag): string {
   const items = splitReleaseBody(body)
-    .map((item) => stripExecBanned(item.message.trim()).replace(/^[:\-\s]+/, ''))
+    .map((item) => stripExecBanned(item.message.trim()))
     .filter((message) => message.length > 0);
   const listed = (items.length > 0 ? items : body.trim() ? [stripExecBanned(body.trim())] : [])
     .filter((message) => message.length > 0)
     .slice(0, 3);
   const source = `${tag}\n${title}\n${body}`;
   if (listed.length > 0) {
-    const text = `The latest release is ${title}. It includes ${listed.join('; ')}. The full changelog is listed below.`;
+    const text = `The latest release is ${title}. Visitors can now ${listed.join('; ')}. The full changelog is listed below.`;
     if (isSafeReleaseSummary(text, source)) return text;
   }
   return `The latest release is ${title}. See the changelog below for what shipped. Details stay on this page.`;

--- a/src/utils/release-summary.ts
+++ b/src/utils/release-summary.ts
@@ -101,7 +101,7 @@ export function groundedReleaseSummary(tag: string, body: string, title = tag): 
     .slice(0, 3);
   const source = `${tag}\n${title}\n${body}`;
   if (listed.length > 0) {
-    const text = `The latest release is ${title}. Visitors can now ${listed.join('; ')}. The full changelog is listed below.`;
+    const text = `The latest release is ${title}. Visitors can now ${listed.join('; ')}. More is in the changelog on this page.`;
     if (isSafeReleaseSummary(text, source)) return text;
   }
   return `The latest release is ${title}. See the changelog below for what shipped. Details stay on this page.`;

--- a/src/utils/release-summary.ts
+++ b/src/utils/release-summary.ts
@@ -1,0 +1,50 @@
+export const RELEASE_SUMMARY_MODEL = '@cf/meta/llama-3.1-8b-instruct-fast';
+export const RELEASE_SUMMARY_KEY_PREFIX = 'release-summary:';
+
+const BANNED_NAME = /\b(palette|oracle|scribe|sentinel|vantage|bolt|jules)\b/i;
+
+export function releaseSummaryKey(tag: string): string {
+  return `${RELEASE_SUMMARY_KEY_PREFIX}${tag}`;
+}
+
+export function releaseSummaryPrompt(tag: string, notes: string): string {
+  return `Summarize this GitHub release in 2 to 4 plain-English sentences for an executive.
+Use only facts in the notes. Do not invent metrics, ROI, visitor counts, titles, or outcomes.
+Do not name agents, Palettes, Oracles, Scribes, Sentinels, Vantage, Bolt, or Jules.
+No bullets, headings, or quotation marks around the whole answer.
+
+Release: ${tag}
+Notes:
+${notes}`;
+}
+
+function sentenceCount(text: string): number {
+  return text
+    .split(/(?<=[.!?])\s+/)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0).length;
+}
+
+function metricTokens(text: string): string[] {
+  const matches = text.match(/\b\d+(?:\.\d+)?x\b|\b\d+%\b|\broi\b|\bmillion\b|\bbillion\b/gi);
+  return matches ? matches.map((token) => token.toLowerCase()) : [];
+}
+
+export function isSafeReleaseSummary(summary: string, source: string): boolean {
+  const text = summary.trim();
+  if (!text) return false;
+  const count = sentenceCount(text);
+  if (count < 2 || count > 4) return false;
+  if (BANNED_NAME.test(text)) return false;
+  const sourceLower = source.toLowerCase();
+  for (const token of metricTokens(text)) {
+    if (!sourceLower.includes(token)) return false;
+  }
+  return true;
+}
+
+export function parseModelText(result: unknown): string {
+  if (!result || typeof result !== 'object') return '';
+  const row = result as { response?: unknown };
+  return typeof row.response === 'string' ? row.response.trim() : '';
+}

--- a/src/utils/release-summary.ts
+++ b/src/utils/release-summary.ts
@@ -73,15 +73,17 @@ export function parseModelText(result: unknown): string {
   return typeof row.response === 'string' ? row.response.trim() : '';
 }
 
-export function groundedReleaseSummary(tag: string, body: string, title = tag): string | null {
+export function groundedReleaseSummary(tag: string, body: string, title = tag): string {
   const items = splitReleaseBody(body)
     .map((item) => stripExecBanned(item.message.trim()).replace(/^[:\-\s]+/, ''))
     .filter((message) => message.length > 0);
   const listed = (items.length > 0 ? items : body.trim() ? [stripExecBanned(body.trim())] : [])
     .filter((message) => message.length > 0)
     .slice(0, 3);
-  if (listed.length === 0) return null;
-  const text = `The latest release is ${title}. It includes ${listed.join('; ')}. The full changelog is listed below.`;
   const source = `${tag}\n${title}\n${body}`;
-  return isSafeReleaseSummary(text, source) ? text : null;
+  if (listed.length > 0) {
+    const text = `The latest release is ${title}. It includes ${listed.join('; ')}. The full changelog is listed below.`;
+    if (isSafeReleaseSummary(text, source)) return text;
+  }
+  return `The latest release is ${title}. See the changelog below for what shipped. Details stay on this page.`;
 }

--- a/src/utils/release-summary.ts
+++ b/src/utils/release-summary.ts
@@ -6,7 +6,6 @@ export const RELEASE_SUMMARY_KEY_PREFIX = 'release-summary:';
 const BANNED_NAME = /\b(palette|oracle|scribe|sentinel|vantage|bolt|jules)\b/gi;
 const SHA_ONE = /\b[a-f0-9]{7,40}\b/i;
 const SHA_ALL = /\b[a-f0-9]{7,40}\b/gi;
-const ALLOWED_METRICS = new Set(['2x', '30x', 'roi']);
 
 export function releaseSummaryKey(tag: string): string {
   return `${RELEASE_SUMMARY_KEY_PREFIX}${tag}`;
@@ -53,7 +52,6 @@ export function isSafeReleaseSummary(summary: string, source: string): boolean {
   if (count < 2 || count > 4) return false;
   const sourceLower = source.toLowerCase();
   for (const token of metricTokens(text)) {
-    if (ALLOWED_METRICS.has(token)) continue;
     if (!sourceLower.includes(token)) return false;
   }
   return true;

--- a/src/utils/release-summary.ts
+++ b/src/utils/release-summary.ts
@@ -59,7 +59,7 @@ export function isSafeReleaseSummary(summary: string, source: string): boolean {
 
 export function prepareReleaseSummary(summary: string, source: string): string | null {
   const original = summary.trim();
-  if (SHA_ONE.test(original)) return null;
+  if (SHA_ONE.test(original) || /\bissue number\b/i.test(original)) return null;
   const text = stripExecBanned(original);
   return isSafeReleaseSummary(text, source) ? text : null;
 }

--- a/src/utils/release-summary.ts
+++ b/src/utils/release-summary.ts
@@ -1,3 +1,5 @@
+import { splitReleaseBody } from './github-releases';
+
 export const RELEASE_SUMMARY_MODEL = '@cf/meta/llama-3.1-8b-instruct-fast';
 export const RELEASE_SUMMARY_KEY_PREFIX = 'release-summary:';
 
@@ -8,7 +10,7 @@ export function releaseSummaryKey(tag: string): string {
 }
 
 export function releaseSummaryPrompt(tag: string, notes: string): string {
-  return `Summarize this GitHub release in 2 to 4 plain-English sentences for an executive.
+  return `Write exactly three plain-English sentences summarizing this GitHub release for an executive.
 Use only facts in the notes. Do not invent metrics, ROI, visitor counts, titles, or outcomes.
 Do not name agents, Palettes, Oracles, Scribes, Sentinels, Vantage, Bolt, or Jules.
 No bullets, headings, or quotation marks around the whole answer.
@@ -44,7 +46,19 @@ export function isSafeReleaseSummary(summary: string, source: string): boolean {
 }
 
 export function parseModelText(result: unknown): string {
+  if (typeof result === 'string') return result.trim();
   if (!result || typeof result !== 'object') return '';
   const row = result as { response?: unknown };
   return typeof row.response === 'string' ? row.response.trim() : '';
+}
+
+export function groundedReleaseSummary(tag: string, body: string): string | null {
+  const items = splitReleaseBody(body)
+    .map((item) => item.message.trim())
+    .filter((message) => message.length > 0 && !BANNED_NAME.test(message));
+  const listed = (items.length > 0 ? items : body.trim() ? [body.trim()] : []).slice(0, 3);
+  if (listed.length === 0) return null;
+  const text = `The latest GitHub release is ${tag}. It includes ${listed.join('; ')}. The full changelog is listed below.`;
+  const source = `${tag}\n${body}`;
+  return isSafeReleaseSummary(text, source) ? text : null;
 }

--- a/src/utils/release-summary.ts
+++ b/src/utils/release-summary.ts
@@ -43,6 +43,7 @@ export function stripExecBanned(text: string): string {
     .replace(BANNED_NAME, '')
     .replace(SHA_ALL, '')
     .replace(/\(#\d+\)/g, '')
+    .replace(/#\d+/g, '')
     .replace(/\bissue number\s+\d+\b/gi, '')
     .replace(/\b(?:feat|fix|chore|docs|refactor|test|style|perf|build|ci):\s*/gi, '')
     .replace(/\s+([.,;:])/g, '$1')
@@ -60,6 +61,7 @@ export function isSafeReleaseSummary(summary: string, source: string): boolean {
     SHA_ONE.test(text) ||
     /\bissue number\b/i.test(text) ||
     /\bcommit hash\b/i.test(text) ||
+    /\B#\d+\b/.test(text) ||
     CONVENTIONAL.test(text)
   ) {
     return false;
@@ -77,6 +79,7 @@ export function prepareReleaseSummary(summary: string, source: string): string |
     SHA_ONE.test(original) ||
     /\bissue number\b/i.test(original) ||
     /\bcommit hash\b/i.test(original) ||
+    /\B#\d+\b/.test(original) ||
     CONVENTIONAL.test(original)
   ) {
     return null;

--- a/src/utils/release-summary.ts
+++ b/src/utils/release-summary.ts
@@ -1,12 +1,12 @@
 import { splitReleaseBody } from './github-releases';
 
 export const RELEASE_SUMMARY_MODEL = '@cf/meta/llama-3.1-8b-instruct-fast';
-export const RELEASE_SUMMARY_KEY_PREFIX = 'release-summary:';
+export const RELEASE_SUMMARY_KEY_PREFIX = 'release-summary:v2:';
 
 const BANNED_NAME = /\b(palette|oracle|scribe|sentinel|vantage|bolt|jules)\b/gi;
 const SHA_ONE = /\b[a-f0-9]{7,40}\b/i;
 const SHA_ALL = /\b[a-f0-9]{7,40}\b/gi;
-const CONVENTIONAL = /^(feat|fix|chore|docs|refactor|test|style|perf|build|ci):\s*/i;
+const CONVENTIONAL = /\b(?:feat|fix|chore|docs|refactor|test|style|perf|build|ci):\s*/i;
 
 export function releaseSummaryKey(tag: string): string {
   return `${RELEASE_SUMMARY_KEY_PREFIX}${tag}`;
@@ -44,7 +44,7 @@ export function stripExecBanned(text: string): string {
     .replace(SHA_ALL, '')
     .replace(/\(#\d+\)/g, '')
     .replace(/\bissue number\s+\d+\b/gi, '')
-    .replace(CONVENTIONAL, '')
+    .replace(/\b(?:feat|fix|chore|docs|refactor|test|style|perf|build|ci):\s*/gi, '')
     .replace(/\s+([.,;:])/g, '$1')
     .replace(/^[\s:;\-]+/, '')
     .replace(/\s{2,}/g, ' ')
@@ -56,7 +56,12 @@ export function isSafeReleaseSummary(summary: string, source: string): boolean {
   if (!text) return false;
   const count = sentenceCount(text);
   if (count < 2 || count > 4) return false;
-  if (SHA_ONE.test(text) || /\bissue number\b/i.test(text) || /\bcommit hash\b/i.test(text)) {
+  if (
+    SHA_ONE.test(text) ||
+    /\bissue number\b/i.test(text) ||
+    /\bcommit hash\b/i.test(text) ||
+    CONVENTIONAL.test(text)
+  ) {
     return false;
   }
   const sourceLower = source.toLowerCase();
@@ -71,7 +76,8 @@ export function prepareReleaseSummary(summary: string, source: string): string |
   if (
     SHA_ONE.test(original) ||
     /\bissue number\b/i.test(original) ||
-    /\bcommit hash\b/i.test(original)
+    /\bcommit hash\b/i.test(original) ||
+    CONVENTIONAL.test(original)
   ) {
     return null;
   }


### PR DESCRIPTION
## Summary
- `/whats-new` shows 2–4 plain-English sentences for the latest GitHub release, generated with Workers AI (`llama-3.1-8b-instruct-fast`).
- Full changelog stays below. Summary is cached in `CHAT_STORE` by tag (`release-summary:<tag>`).
- Fail-open: 204 if AI/KV/GitHub is missing, or if the model names Palette/Oracle or invents metrics. No fake summary.
- Removes the old commit-concat highlights that preferred Palette/Oracle names.

## Test plan
- [ ] `/whats-new`: changelog still lists releases
- [ ] Latest-release box is 2–4 sentences, no Palette/Oracle, no invented 2x/30x
- [ ] If `/api/release-summary` is 204, changelog still renders
- [ ] Second load uses the cached tag (no extra AI call)