### PR TITLE
fix: do not paint squash titles in the /whats-new exec box

### DIFF
--- a/src/__tests__/release-summary.test.ts
+++ b/src/__tests__/release-summary.test.ts
@@ -70,6 +70,15 @@ describe('isSafeReleaseSummary', () => {
   it('rejects a one-sentence answer', () => {
     expect(isSafeReleaseSummary('The release adds a footer glance.', source)).toBe(false);
   });
+
+  it('rejects squash-title leftover visitor copy', () => {
+    expect(
+      isSafeReleaseSummary(
+        'The latest release is 2026.08.15.1814. Visitors can now exec summary of the latest GitHub release on /whats-new. More is in the changelog on this page.',
+        source
+      )
+    ).toBe(false);
+  });
 });
 
 describe('prepareReleaseSummary', () => {
@@ -118,8 +127,18 @@ describe('release summary helpers', () => {
     expect(summary).not.toMatch(/\babcdef1\b/);
   });
 
+  it('does not paint a squash title as Visitors can now', () => {
+    const body = '- 0701dfc feat: exec summary of the latest GitHub release on /whats-new (#462)';
+    const summary = groundedReleaseSummary('2026.08.15.1814', body, '2026.08.15.1814');
+    expect(summary).toBe(
+      'The latest release is 2026.08.15.1814. See the changelog below for what shipped. Details stay on this page.'
+    );
+    expect(summary).not.toMatch(/visitors can now exec summary/i);
+    expect(summary).not.toMatch(/on \/whats-new/i);
+  });
+
   it('caches by tag', () => {
-    expect(releaseSummaryKey('2026.08.15.1714')).toBe('release-summary:v2:2026.08.15.1714');
+    expect(releaseSummaryKey('2026.08.15.1714')).toBe('release-summary:v3:2026.08.15.1714');
   });
 
   it('asks for 2-4 sentences and no invented metrics', () => {
@@ -157,7 +176,7 @@ describe('release summary API', () => {
       tag: latest.version,
       summary: okSummary,
     });
-    expect(get).toHaveBeenCalledWith('release-summary:v2:2026.08.15.1714');
+    expect(get).toHaveBeenCalledWith('release-summary:v3:2026.08.15.1714');
     expect(ai.run).not.toHaveBeenCalled();
     expect(put).not.toHaveBeenCalled();
   });
@@ -179,7 +198,7 @@ describe('release summary API', () => {
       '@cf/meta/llama-3.1-8b-instruct-fast',
       expect.objectContaining({ stream: false })
     );
-    expect(put).toHaveBeenCalledWith('release-summary:v2:2026.08.15.1714', okSummary);
+    expect(put).toHaveBeenCalledWith('release-summary:v3:2026.08.15.1714', okSummary);
   });
 
   it('uses a notes-only fallback when AI is missing', async () => {
@@ -227,7 +246,7 @@ describe('release summary API', () => {
       tag: latest.version,
       summary: notesFallback,
     });
-    expect(put).toHaveBeenCalledWith('release-summary:v2:2026.08.15.1714', notesFallback);
+    expect(put).toHaveBeenCalledWith('release-summary:v3:2026.08.15.1714', notesFallback);
   });
 
   it('drops invented 2x / 30x and falls back to the notes', async () => {

--- a/src/utils/release-summary.ts
+++ b/src/utils/release-summary.ts
@@ -1,12 +1,18 @@
 import { splitReleaseBody } from './github-releases';
 
 export const RELEASE_SUMMARY_MODEL = '@cf/meta/llama-3.1-8b-instruct-fast';
-export const RELEASE_SUMMARY_KEY_PREFIX = 'release-summary:v2:';
+export const RELEASE_SUMMARY_KEY_PREFIX = 'release-summary:v3:';
 
 const BANNED_NAME = /\b(palette|oracle|scribe|sentinel|vantage|bolt|jules)\b/gi;
 const SHA_ONE = /\b[a-f0-9]{7,40}\b/i;
 const SHA_ALL = /\b[a-f0-9]{7,40}\b/gi;
 const CONVENTIONAL = /\b(?:feat|fix|chore|docs|refactor|test|style|perf|build|ci):\s*/i;
+const SQUASH_TITLE_LEAK = /\bexec summary\b|\bof the latest github release\b/i;
+
+export function isVisitorFacingBullet(message: string): boolean {
+  const text = message.trim();
+  return text.length > 0 && !SQUASH_TITLE_LEAK.test(text);
+}
 
 export function releaseSummaryKey(tag: string): string {
   return `${RELEASE_SUMMARY_KEY_PREFIX}${tag}`;
@@ -62,7 +68,8 @@ export function isSafeReleaseSummary(summary: string, source: string): boolean {
     /\bissue number\b/i.test(text) ||
     /\bcommit hash\b/i.test(text) ||
     /\B#\d+\b/.test(text) ||
-    CONVENTIONAL.test(text)
+    CONVENTIONAL.test(text) ||
+    SQUASH_TITLE_LEAK.test(text)
   ) {
     return false;
   }
@@ -98,9 +105,9 @@ export function parseModelText(result: unknown): string {
 export function groundedReleaseSummary(tag: string, body: string, title = tag): string {
   const items = splitReleaseBody(body)
     .map((item) => stripExecBanned(item.message.trim()))
-    .filter((message) => message.length > 0);
+    .filter(isVisitorFacingBullet);
   const listed = (items.length > 0 ? items : body.trim() ? [stripExecBanned(body.trim())] : [])
-    .filter((message) => message.length > 0)
+    .filter(isVisitorFacingBullet)
     .slice(0, 3);
   const source = `${tag}\n${title}\n${body}`;
   if (listed.length > 0) {


### PR DESCRIPTION
## Summary
- After #462, the live exec box painted the squash title as visitor copy: “Visitors can now exec summary of the latest GitHub release on /whats-new.”
- Drop that leftover from the notes fallback. If no visitor-facing bullets remain, use the changelog-below sentences.
- Reject the same leak in the sanitizer and bust KV cache (`release-summary:v3:`). Changelog list is unchanged.

## Test plan
- [ ] Preview `/whats-new/` exec box does not say “Visitors can now exec summary”
- [ ] Changelog list still renders; Jules / Johan nits stay filtered
- [ ] A real product bullet (tap glance) still becomes visitor copy