### PR TITLE
fix: alias cloudflare:workers to a Node stub on Render

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'astro/config';
 import { codecovVitePlugin } from '@codecov/vite-plugin';
 
@@ -72,5 +73,14 @@ export default defineConfig({
   vite: {
     // @ts-expect-error Codecov's Vite plugin is typed against a different Vite instance than Astro's bundled one.
     plugins: [codecovPlugin],
+    resolve: isRender
+      ? {
+          alias: {
+            'cloudflare:workers': fileURLToPath(
+              new URL('./src/env/cloudflare-workers.node.ts', import.meta.url)
+            ),
+          },
+        }
+      : undefined,
   },
 });

--- a/src/__tests__/cloudflare-workers-node.test.ts
+++ b/src/__tests__/cloudflare-workers-node.test.ts
@@ -1,0 +1,16 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { env } from '../env/cloudflare-workers.node';
+
+describe('cloudflare:workers Node stub', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('reads string secrets from process.env and has no AI binding', () => {
+    vi.stubEnv('POSTHOG_PERSONAL_API_KEY', 'phx_test');
+    expect(env.POSTHOG_PERSONAL_API_KEY).toBe('phx_test');
+    expect(env.AI).toBeUndefined();
+    expect(env.CHAT_STORE).toBeUndefined();
+  });
+});

--- a/src/env/cloudflare-workers.node.ts
+++ b/src/env/cloudflare-workers.node.ts
@@ -1,0 +1,13 @@
+/**
+ * Node stand-in for `cloudflare:workers` when RENDER=true.
+ * String secrets come from process.env. Worker bindings (AI, KV) stay absent.
+ */
+export const env: Record<string, unknown> = new Proxy(
+  {},
+  {
+    get(_target, prop) {
+      if (typeof prop !== 'string') return undefined;
+      return process.env[prop];
+    },
+  }
+);


### PR DESCRIPTION
## Summary
- Render Node cannot resolve `cloudflare:workers`. Static imports in chat, visits, and release-summary stay; Vite aliases that specifier to a process.env stub only when `RENDER=true`.
- Worker builds are unchanged: no alias, real bindings. Missing AI stays JSON 503. Missing PostHog key stays 204. No fake counts.

## Test plan
- [ ] `RENDER=true` Node start does not throw `Cannot find package 'cloudflare:workers'`
- [ ] Worker `/api/chat` still uses AI when bound; 503 JSON when missing
- [ ] Worker `/api/visits` still 204 when the PostHog key is missing
- [ ] Changelog / exec summary on Workers prod unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for accessing string-based environment secrets in Node-based deployments.
  * Improved compatibility with the Cloudflare Workers environment when running outside Cloudflare.

* **Bug Fixes**
  * Prevented unsupported Worker bindings from being exposed in Node environments.

* **Tests**
  * Added coverage confirming environment variables are read correctly and test state is reset between runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->