### PR TITLE
fix: do not serve a stale changelog list from sessionStorage

### DIFF
--- a/src/__tests__/github-releases.test.ts
+++ b/src/__tests__/github-releases.test.ts
@@ -301,22 +301,27 @@ describe('github releases utility', () => {
       },
     ];
 
-    it('returns cached data if available and not expired', async () => {
+    it('ignores sessionStorage and loads /api/releases so a new tag is not stuck behind a stale list', async () => {
       vi.stubGlobal('window', {});
       const getItem = vi.fn().mockReturnValue(
         JSON.stringify({
-          data: mockReleases,
+          data: [{ ...mockReleases[0], version: '2026.08.15.1720' }],
           timestamp: Date.now() - 1000,
         })
       );
       vi.stubGlobal('sessionStorage', { getItem });
 
-      const fetchMock = vi.fn();
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => mockReleases,
+      });
       const result = await fetchGitHubReleases(fetchMock as typeof fetch);
 
       expect(result).toEqual(mockReleases);
-      expect(getItem).toHaveBeenCalledWith('github-releases-cache');
-      expect(fetchMock).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/releases',
+        expect.objectContaining({ headers: { Accept: 'application/json' } })
+      );
     });
 
     it('fetches and saves to cache if cache is expired', async () => {
@@ -338,7 +343,10 @@ describe('github releases utility', () => {
       const result = await fetchGitHubReleases(fetchMock as typeof fetch);
 
       expect(result).toEqual(mockReleases);
-      expect(setItem).toHaveBeenCalledWith('github-releases-cache', expect.any(String));
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/releases',
+        expect.objectContaining({ headers: { Accept: 'application/json' } })
+      );
     });
 
     it('handles cache read errors gracefully', async () => {

--- a/src/utils/github-releases.ts
+++ b/src/utils/github-releases.ts
@@ -83,19 +83,8 @@ export async function fetchGitHubReleases(
   url: string = RELEASES_API_URL
 ): Promise<SiteRelease[]> {
   if (typeof window !== 'undefined' && url === RELEASES_API_URL) {
-    try {
-      const cached = sessionStorage.getItem(CACHE_KEY);
-      if (cached) {
-        const { data, timestamp } = JSON.parse(cached);
-        const parsed = z.array(SiteReleaseSchema).safeParse(data);
-        if (Date.now() - timestamp < CACHE_TTL && parsed.success && parsed.data.length > 0) {
-          return parsed.data;
-        }
-      }
-    } catch {
-      /* ignore cache errors */
-    }
-
+    // Same-origin /api/releases is cheap. Skip sessionStorage so a new GitHub
+    // release is not hidden behind a 1-hour stale list (exec 1814 / list 1720).
     try {
       const response = await fetchImpl('/api/releases', {
         headers: { Accept: 'application/json' },
@@ -104,14 +93,6 @@ export async function fetchGitHubReleases(
         const json = await response.json();
         const parsed = z.array(SiteReleaseSchema).safeParse(json);
         if (parsed.success && parsed.data.length > 0) {
-          try {
-            sessionStorage.setItem(
-              CACHE_KEY,
-              JSON.stringify({ data: parsed.data, timestamp: Date.now() })
-            );
-          } catch {
-            /* ignore cache errors */
-          }
           return parsed.data;
         }
         if (!parsed.success) {

--- a/src/utils/github-releases.ts
+++ b/src/utils/github-releases.ts
@@ -27,9 +27,6 @@ const RELEASES_API_URL =
 const RELEASES_PAGE_URL =
   'https://github.com/alehar9320/astro-cloudflare-personal-website/releases';
 const REPO_URL = 'https://github.com/alehar9320/astro-cloudflare-personal-website';
-const CACHE_KEY = 'github-releases-cache';
-const CACHE_TTL = 3600 * 1000; // 1 hour
-
 function logReleaseValidationFailed(issues: z.ZodIssue[]): void {
   const sanitizedIssues = issues.map((issue) => {
     const safeIssue = { ...issue } as Record<string, unknown>;
@@ -153,17 +150,6 @@ export async function fetchGitHubReleases(
       .filter((release) => !release.prerelease)
       .map(normalizeRelease)
       .filter((release): release is SiteRelease => release !== null);
-
-    if (typeof window !== 'undefined' && url === RELEASES_API_URL && releases.length > 0) {
-      try {
-        sessionStorage.setItem(
-          CACHE_KEY,
-          JSON.stringify({ data: releases, timestamp: Date.now() })
-        );
-      } catch {
-        /* ignore cache errors */
-      }
-    }
 
     return releases;
   } catch (error) {


### PR DESCRIPTION
## Summary
- After auto-release 2026.08.15.1814, exec showed 1814 while the public list stayed on 1720. `/api/releases` already returns 1814; the browser 1-hour sessionStorage cache did not.
- Browser `fetchGitHubReleases` always hits same-origin `/api/releases`. No stale list on reload.
- #463 squash-title copy fix is already on main. This is the leftover list mismatch. Stay draft.

## Test plan
- [ ] Preview `/whats-new/` list latest tag matches `/api/releases` after reload
- [ ] Exec box does not say “Visitors can now exec summary…” (#463 on main)
- [ ] Jules / Johan nits still hidden