### PR TITLE
fix: do not glue feat/fix PR titles into Visitors can now

### DIFF
--- a/src/__tests__/release-summary.test.ts
+++ b/src/__tests__/release-summary.test.ts
@@ -79,6 +79,15 @@ describe('isSafeReleaseSummary', () => {
       )
     ).toBe(false);
   });
+
+  it('rejects glued Render and squash-title PR subjects', () => {
+    expect(
+      isSafeReleaseSummary(
+        'The latest release is 2026.08.15.1826. Visitors can now alias cloudflare:workers to a Node stub on Render; do not paint squash titles in the /whats-new exec box. More is in the changelog on this page.',
+        source
+      )
+    ).toBe(false);
+  });
 });
 
 describe('prepareReleaseSummary', () => {
@@ -137,8 +146,20 @@ describe('release summary helpers', () => {
     expect(summary).not.toMatch(/on \/whats-new/i);
   });
 
+  it('does not glue later squash titles into Visitors can now', () => {
+    const body = `- 9d0a655 feat: alias cloudflare:workers to a Node stub on Render (#464)
+- ae23d9d feat: do not paint squash titles in the /whats-new exec box (#463)`;
+    const summary = groundedReleaseSummary('2026.08.15.1826', body, '2026.08.15.1826');
+    expect(summary).toBe(
+      'The latest release is 2026.08.15.1826. See the changelog below for what shipped. Details stay on this page.'
+    );
+    expect(summary).not.toMatch(/visitors can now/i);
+    expect(summary).not.toMatch(/cloudflare:workers/i);
+    expect(summary).not.toMatch(/node stub/i);
+  });
+
   it('caches by tag', () => {
-    expect(releaseSummaryKey('2026.08.15.1714')).toBe('release-summary:v3:2026.08.15.1714');
+    expect(releaseSummaryKey('2026.08.15.1714')).toBe('release-summary:v4:2026.08.15.1714');
   });
 
   it('asks for 2-4 sentences and no invented metrics', () => {
@@ -176,7 +197,7 @@ describe('release summary API', () => {
       tag: latest.version,
       summary: okSummary,
     });
-    expect(get).toHaveBeenCalledWith('release-summary:v3:2026.08.15.1714');
+    expect(get).toHaveBeenCalledWith('release-summary:v4:2026.08.15.1714');
     expect(ai.run).not.toHaveBeenCalled();
     expect(put).not.toHaveBeenCalled();
   });
@@ -198,7 +219,7 @@ describe('release summary API', () => {
       '@cf/meta/llama-3.1-8b-instruct-fast',
       expect.objectContaining({ stream: false })
     );
-    expect(put).toHaveBeenCalledWith('release-summary:v3:2026.08.15.1714', okSummary);
+    expect(put).toHaveBeenCalledWith('release-summary:v4:2026.08.15.1714', okSummary);
   });
 
   it('uses a notes-only fallback when AI is missing', async () => {
@@ -246,7 +267,7 @@ describe('release summary API', () => {
       tag: latest.version,
       summary: notesFallback,
     });
-    expect(put).toHaveBeenCalledWith('release-summary:v3:2026.08.15.1714', notesFallback);
+    expect(put).toHaveBeenCalledWith('release-summary:v4:2026.08.15.1714', notesFallback);
   });
 
   it('drops invented 2x / 30x and falls back to the notes', async () => {

--- a/src/utils/release-summary.ts
+++ b/src/utils/release-summary.ts
@@ -1,17 +1,21 @@
 import { splitReleaseBody } from './github-releases';
 
 export const RELEASE_SUMMARY_MODEL = '@cf/meta/llama-3.1-8b-instruct-fast';
-export const RELEASE_SUMMARY_KEY_PREFIX = 'release-summary:v3:';
+export const RELEASE_SUMMARY_KEY_PREFIX = 'release-summary:v4:';
 
 const BANNED_NAME = /\b(palette|oracle|scribe|sentinel|vantage|bolt|jules)\b/gi;
 const SHA_ONE = /\b[a-f0-9]{7,40}\b/i;
 const SHA_ALL = /\b[a-f0-9]{7,40}\b/gi;
 const CONVENTIONAL = /\b(?:feat|fix|chore|docs|refactor|test|style|perf|build|ci):\s*/i;
-const SQUASH_TITLE_LEAK = /\bexec summary\b|\bof the latest github release\b/i;
+const ENGINEERING_LEAK =
+  /\bexec summary\b|\bof the latest github release\b|cloudflare:workers|\bnode stub\b|\bsessionstorage\b|\bdo not paint\b|\bexec box\b|\bon \/whats-new\b|\balias\b/i;
+const VISITOR_VERB =
+  /^(open|tap|see|read|view|show|visit|browse|get|use|download|contact|inline)\b/i;
 
 export function isVisitorFacingBullet(message: string): boolean {
   const text = message.trim();
-  return text.length > 0 && !SQUASH_TITLE_LEAK.test(text);
+  if (!text || ENGINEERING_LEAK.test(text)) return false;
+  return VISITOR_VERB.test(text);
 }
 
 export function releaseSummaryKey(tag: string): string {
@@ -69,7 +73,7 @@ export function isSafeReleaseSummary(summary: string, source: string): boolean {
     /\bcommit hash\b/i.test(text) ||
     /\B#\d+\b/.test(text) ||
     CONVENTIONAL.test(text) ||
-    SQUASH_TITLE_LEAK.test(text)
+    ENGINEERING_LEAK.test(text)
   ) {
     return false;
   }


### PR DESCRIPTION
## Summary
- After #463, prod no longer says “Visitors can now exec summary…”. Auto-release 2026.08.15.1826 glued the next squash titles instead: `alias cloudflare:workers…` and `do not paint squash titles…`.
- Only visitor-action bullets (open, tap, inline, …) may follow “Visitors can now”. Engineering PR titles fall back to “See the changelog below.”
- KV prefix `release-summary:v4:`. Changelog list unchanged. No revert.

## Test plan
- [ ] Preview `/whats-new/` exec is not “Visitors can now alias cloudflare:workers…”
- [ ] Fallback sentences still paint
- [ ] “open the visit glance on tap at 375” still becomes visitor copy