### PR TITLE
Pruning: Remove Unused Export formatFirstSeen

### DIFF
--- a/.Pruning/metrics.md
+++ b/.Pruning/metrics.md
@@ -4,3 +4,4 @@
 | 2026-05-19 | github-releases.ts (REPO_URL/ReleaseItem) | 2                | 0MB               |
 | 2026-05-19 | posthog.ts / posthog.test.ts              | 103              | 0MB               |
 | 2026-05-19 | posthog-node (dependency)                 | 0                | 0MB               |
+| 2026-05-19 | visit-stats.ts (formatFirstSeen export)   | 1                | 0MB               |

--- a/src/utils/visit-stats.ts
+++ b/src/utils/visit-stats.ts
@@ -81,7 +81,7 @@ export function parseVisitGlance(payload: unknown): VisitGlance | null {
   return { pageviews, uniqueVisitors, firstSeen, pageviews7d, uniqueVisitors7d };
 }
 
-export function formatFirstSeen(iso: string): string {
+function formatFirstSeen(iso: string): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return '';
   return new Intl.DateTimeFormat('en-GB', {


### PR DESCRIPTION
Removed unreferenced export modifier from `formatFirstSeen` in `src/utils/visit-stats.ts` and logged the metric in `.Pruning/metrics.md`.

---
*PR created automatically by Jules for task [4858929642009633520](https://jules.google.com/task/4858929642009633520) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal maintenance completed with no changes to user-visible behavior.
  * Existing visit formatting remains unchanged.
  * No impact to bundle size or application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->