### PR TITLE
feat: demote Lidköping off the /work card grid

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -14,7 +14,7 @@ Recruiter keywords (not a fake title): Product Management, Developer Experience,
 
 - [Home](https://me.alehar.workers.dev/): Product Manager, Developer Experience at IFS. One design-system proof card. Get in touch goes to LinkedIn.
 - [Contact](https://me.alehar.workers.dev/contact/): Hire path. LinkedIn only.
-- [Work](https://me.alehar.workers.dev/work/): Case list.
+- [Work](https://me.alehar.workers.dev/work/): Case list. Design system and DevEx cases in the main grid. Lidköping is earlier work, not an equal card.
 - [IFS Design System](https://me.alehar.workers.dev/work/ifs-design-system/): Numbered proof. 2x delivery, 30x ROI, Zeroheight runner-up.
 - [Biography](https://me.alehar.workers.dev/biography/): Experience timeline. Product Manager, Developer Experience at IFS. /about/ redirects here.
 

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -52,6 +52,13 @@ describe('identity copy', () => {
     expect(work).toContain("{' '}<strong>IFS</strong>");
   });
 
+  it('keeps Lidköping off the main /work card grid', () => {
+    const work = sources.find((s) => s.path.endsWith('work.astro'))!.text;
+    expect(work).toContain("project.id !== 'lidkoping-stenhuggeri'");
+    expect(work).toContain('Earlier work');
+    expect(work).toContain('Early Android work, 2013.');
+  });
+
   it('drops the /about/ duplicate in favor of /biography/', () => {
     const nav = readFileSync('src/components/Nav.astro', 'utf8');
     const astro = readFileSync('astro.config.mjs', 'utf8');

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -9,6 +9,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 const projects = (await getCollection('work')).sort(
   (a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf()
 );
+const featured = projects.filter((project) => project.id !== 'lidkoping-stenhuggeri');
+const earlier = projects.filter((project) => project.id === 'lidkoping-stenhuggeri');
 
 const schema = {
   '@context': 'https://schema.org',
@@ -84,7 +86,7 @@ const schema = {
       </div>
       <Grid variant="offset">
         {
-          projects.map((project, index) => (
+          featured.map((project, index) => (
             <li>
               <PortfolioPreview
                 project={project}
@@ -95,7 +97,67 @@ const schema = {
           ))
         }
       </Grid>
+      <section class="earlier" aria-labelledby="earlier-work-heading">
+        <h2 id="earlier-work-heading">Earlier work</h2>
+        <ul>
+          {
+            earlier.map((project) => (
+              <li>
+                <a href={`/work/${project.id}/`}>{project.data.title}</a>
+                <p>Early Android work, 2013.</p>
+              </li>
+            ))
+          }
+        </ul>
+      </section>
     </main>
     <ContactCTA />
   </div>
 </BaseLayout>
+
+<style>
+  .earlier {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    color: var(--gray-300);
+  }
+
+  .earlier h2 {
+    margin: 0;
+    font-size: var(--text-sm);
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--gray-400);
+  }
+
+  .earlier ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .earlier li {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+
+  .earlier a {
+    color: var(--gray-200);
+    text-decoration: 1px solid underline transparent;
+    text-underline-offset: 0.25em;
+  }
+
+  .earlier a:hover,
+  .earlier a:focus-visible {
+    text-decoration-color: currentColor;
+  }
+
+  .earlier p {
+    margin: 0;
+    font-size: var(--text-sm);
+  }
+</style>
+

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -160,4 +160,3 @@ const schema = {
     font-size: var(--text-sm);
   }
 </style>
-


### PR DESCRIPTION
## Summary
- Lidköping Stenhuggeri is no longer a full card in the /work grid next to the IFS Design System.
- It sits under Earlier work as a text link (early Android, 2013). Design system and DevEx cases stay in the main grid.
- Hire path unchanged (LinkedIn via ContactCTA). No new metrics.

## Test plan
- [ ] /work/ main grid has IFS Design System, not Lidköping as an equal card
- [ ] Lidköping is listed under Earlier work and still links through
- [ ] Get in touch is still LinkedIn