### PR TITLE
fix: keep chat FAB off Get in touch at 375

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -61,7 +61,8 @@ describe('identity copy', () => {
     expect(chat).toContain('bottom: var(--chat-fab-offset)');
     expect(chat).toContain('width: var(--chat-fab-size)');
     expect(home).toContain('padding-block: 1rem var(--chat-fab-clearance)');
-    expect(home).toContain('max-height: 32svh');
+    expect(home).toContain('justify-content: flex-start');
+    expect(home).toContain('max-height: calc(100svh - var(--chat-fab-clearance) - 20rem)');
     expect(home).toContain('https://www.linkedin.com/in/alehar/');
     expect(home).toContain('Get in touch');
     expect(cta).toContain('var(--chat-fab-clearance)');

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -62,7 +62,9 @@ describe('identity copy', () => {
     expect(chat).toContain('width: var(--chat-fab-size)');
     expect(home).toContain('padding-block: 1rem var(--chat-fab-clearance)');
     expect(home).toContain('justify-content: flex-start');
-    expect(home).toContain('max-height: calc(100svh - var(--chat-fab-clearance) - 20rem)');
+    expect(home).toContain('max-height: calc(100svh - var(--chat-fab-clearance) - 24rem)');
+    expect(home).toContain('max-width: min(10.5rem, calc(100% - 2.5rem))');
+    expect(home).toContain('margin-bottom: var(--chat-fab-clearance)');
     expect(home).toContain('https://www.linkedin.com/in/alehar/');
     expect(home).toContain('Get in touch');
     expect(cta).toContain('var(--chat-fab-clearance)');

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -52,6 +52,22 @@ describe('identity copy', () => {
     expect(work).toContain("{' '}<strong>IFS</strong>");
   });
 
+  it('keeps the chat FAB off Get in touch and the home portrait on a phone', () => {
+    const home = readFileSync('src/pages/index.astro', 'utf8');
+    const chat = readFileSync('src/components/Chat.astro', 'utf8');
+    const cta = readFileSync('src/components/ContactCTA.astro', 'utf8');
+    const global = readFileSync('src/styles/global.css', 'utf8');
+    expect(global).toContain('--chat-fab-clearance');
+    expect(chat).toContain('bottom: var(--chat-fab-offset)');
+    expect(chat).toContain('width: var(--chat-fab-size)');
+    expect(home).toContain('padding-block: 1rem var(--chat-fab-clearance)');
+    expect(home).toContain('max-height: 32svh');
+    expect(home).toContain('https://www.linkedin.com/in/alehar/');
+    expect(home).toContain('Get in touch');
+    expect(cta).toContain('var(--chat-fab-clearance)');
+    expect(cta).toContain('https://www.linkedin.com/in/alehar/');
+  });
+
   it('keeps Lidköping off the main /work card grid', () => {
     const work = sources.find((s) => s.path.endsWith('work.astro'))!.text;
     expect(work).toContain("project.id !== 'lidkoping-stenhuggeri'");

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -83,16 +83,16 @@
 <style>
   .chat-container {
     position: fixed;
-    bottom: 2rem;
-    right: 2rem;
+    bottom: var(--chat-fab-offset);
+    right: var(--chat-fab-offset);
     z-index: 1000;
     font-family: var(--font-body);
   }
 
   .chat-toggle {
     position: relative;
-    width: 3.5rem;
-    height: 3.5rem;
+    width: var(--chat-fab-size);
+    height: var(--chat-fab-size);
     padding: 0;
     border-radius: 50%;
     background-color: hsla(var(--gray-999-basis), 0.55);

--- a/src/components/ContactCTA.astro
+++ b/src/components/ContactCTA.astro
@@ -28,7 +28,7 @@ import Icon from './Icon.astro';
     gap: 3rem;
     border-top: 1px solid hsla(var(--gray-999-basis), 0.2);
     border-bottom: 1px solid hsla(var(--gray-999-basis), 0.2);
-    padding: 5rem 1.5rem;
+    padding: 5rem 1.5rem var(--chat-fab-clearance);
     background: hsla(var(--gray-999-basis), 0.05);
     backdrop-filter: blur(32px) saturate(120%);
     -webkit-backdrop-filter: blur(32px) saturate(120%);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -120,7 +120,7 @@ const schema = {
     min-height: 100vh;
     min-height: 100svh;
     min-height: 100dvh;
-    justify-content: center;
+    justify-content: flex-start;
     gap: 1.5rem;
     padding-block: 1rem var(--chat-fab-clearance);
     box-sizing: border-box;
@@ -158,7 +158,8 @@ const schema = {
     position: relative;
     border-radius: 1.5rem;
     margin-inline: 1.25rem;
-    max-width: calc(100% - 2.5rem);
+    margin-bottom: 0.5rem;
+    max-width: min(18rem, calc(100% - 2.5rem));
     box-shadow: var(--portrait-aurora), var(--shadow-md);
   }
 
@@ -178,8 +179,8 @@ const schema = {
 
   .portrait::before {
     z-index: 0;
-    /* Phone: stay in the side gutter; do not grow into Get in touch. */
-    inset: 12% -10% -16% -10%;
+    /* Phone: stay in the side gutter; do not grow into Get in touch or the FAB. */
+    inset: 12% -10% 0 -10%;
     background:
       radial-gradient(ellipse 45% 85% at 0% 50%, var(--accent-light), transparent 72%),
       radial-gradient(ellipse 45% 85% at 100% 50%, var(--accent-regular), transparent 72%);
@@ -210,9 +211,8 @@ const schema = {
     position: relative;
     z-index: 1;
     display: block;
-    width: auto;
-    max-width: 100%;
-    max-height: 32svh;
+    width: 100%;
+    max-height: calc(100svh - var(--chat-fab-clearance) - 20rem);
     aspect-ratio: 5 / 4;
     object-fit: cover;
     object-position: top;
@@ -328,6 +328,10 @@ const schema = {
   }
 
   @media (min-width: 50em) {
+    .first-screen {
+      justify-content: center;
+    }
+
     .hero {
       display: grid;
       grid-template-columns: 6fr 4fr;
@@ -343,6 +347,7 @@ const schema = {
 
     .portrait {
       margin-inline: 0;
+      margin-bottom: 0;
       max-width: none;
       border-radius: 4.5rem;
     }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -121,8 +121,8 @@ const schema = {
     min-height: 100svh;
     min-height: 100dvh;
     justify-content: center;
-    gap: 2rem;
-    padding-block: 1rem 2rem;
+    gap: 1.5rem;
+    padding-block: 1rem var(--chat-fab-clearance);
     box-sizing: border-box;
   }
 
@@ -130,8 +130,8 @@ const schema = {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 2rem;
-    padding-bottom: 5.5rem;
+    gap: 1.25rem;
+    padding-bottom: 0;
   }
 
   .hero-actions {
@@ -210,11 +210,14 @@ const schema = {
     position: relative;
     z-index: 1;
     display: block;
-    width: 100%;
+    width: auto;
+    max-width: 100%;
+    max-height: 32svh;
     aspect-ratio: 5 / 4;
     object-fit: cover;
     object-position: top;
     border-radius: 1.5rem;
+    margin-inline: auto;
   }
 
   .proof-card {
@@ -349,6 +352,8 @@ const schema = {
     }
 
     .portrait img {
+      width: 100%;
+      max-height: none;
       aspect-ratio: 3 / 4;
       border-radius: 4.5rem;
     }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -153,20 +153,20 @@ const schema = {
 
   .portrait {
     --portrait-aurora:
-      0 0 20px 4px color-mix(in srgb, var(--accent-light) 55%, transparent),
-      0 0 48px 10px color-mix(in srgb, var(--accent-regular) 40%, transparent);
+      0 0 12px 3px color-mix(in srgb, var(--accent-light) 55%, transparent),
+      0 0 24px 6px color-mix(in srgb, var(--accent-regular) 40%, transparent);
     position: relative;
     border-radius: 1.5rem;
     margin-inline: 1.25rem;
-    margin-bottom: 0.5rem;
-    max-width: min(18rem, calc(100% - 2.5rem));
+    margin-bottom: var(--chat-fab-clearance);
+    max-width: min(10.5rem, calc(100% - 2.5rem));
     box-shadow: var(--portrait-aurora), var(--shadow-md);
   }
 
   :global(:root.theme-dark) .portrait {
     --portrait-aurora:
-      0 0 22px 5px color-mix(in srgb, var(--accent-light) 70%, transparent),
-      0 0 56px 14px color-mix(in srgb, var(--accent-regular) 50%, transparent);
+      0 0 14px 4px color-mix(in srgb, var(--accent-light) 70%, transparent),
+      0 0 28px 8px color-mix(in srgb, var(--accent-regular) 50%, transparent);
   }
 
   .portrait::before,
@@ -212,7 +212,7 @@ const schema = {
     z-index: 1;
     display: block;
     width: 100%;
-    max-height: calc(100svh - var(--chat-fab-clearance) - 20rem);
+    max-height: calc(100svh - var(--chat-fab-clearance) - 24rem);
     aspect-ratio: 5 / 4;
     object-fit: cover;
     object-position: top;
@@ -346,10 +346,19 @@ const schema = {
     }
 
     .portrait {
+      --portrait-aurora:
+        0 0 20px 4px color-mix(in srgb, var(--accent-light) 55%, transparent),
+        0 0 48px 10px color-mix(in srgb, var(--accent-regular) 40%, transparent);
       margin-inline: 0;
       margin-bottom: 0;
       max-width: none;
       border-radius: 4.5rem;
+    }
+
+    :global(:root.theme-dark) .portrait {
+      --portrait-aurora:
+        0 0 22px 5px color-mix(in srgb, var(--accent-light) 70%, transparent),
+        0 0 56px 14px color-mix(in srgb, var(--accent-regular) 50%, transparent);
     }
 
     .portrait::before {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -87,6 +87,13 @@
 
   /* Transitions */
   --theme-transition: 0.2s ease-in-out;
+
+  /* Chat FAB. Hire CTAs and the home portrait must clear this band on phones. */
+  --chat-fab-size: 3.5rem;
+  --chat-fab-offset: 2rem;
+  --chat-fab-clearance: calc(
+    var(--chat-fab-size) + var(--chat-fab-offset) + env(safe-area-inset-bottom, 0px) + 0.75rem
+  );
 }
 
 :root.theme-dark {
@@ -142,6 +149,10 @@ html,
 body {
   min-height: 100%;
   overflow-x: hidden;
+}
+
+html {
+  scroll-padding-bottom: var(--chat-fab-clearance);
 }
 
 @media (prefers-reduced-motion: no-preference) {


### PR DESCRIPTION
## Summary
- On ~375×812 the chat FAB was covering the home hero portrait (nav sits above a 100dvh first screen, FAB is viewport-fixed).
- Cap the phone portrait at 32svh and pad the first screen / ContactCTA by `--chat-fab-clearance` so Get in touch stays tappable.
- Hire path remains LinkedIn. Chat stays demoted. Desktop portrait unchanged.

## Test plan
- [ ] Worker preview at 375×812: Get in touch fully visible and tappable; hero portrait not under the FAB
- [ ] /work and /biography ContactCTA Get in touch not under the FAB
- [ ] Desktop layout unchanged
- [ ] LinkedIn only; no mailto/CV

Stay draft. Do not merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mobile homepage layout so content and portrait imagery fit more comfortably on smaller screens.
  - Prevented the chat button from obscuring homepage content and contact actions.
  - Added safer spacing for devices with screen-area insets.

- **Style**
  - Refined portrait glow effects and decorative spacing across mobile and desktop layouts.
  - Standardized chat button sizing and positioning for more consistent responsive behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->