### PR TITLE
feat: demote copilots and analytics off the /work card grid

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -14,7 +14,7 @@ Recruiter keywords (not a fake title): Product Management, Developer Experience,
 
 - [Home](https://me.alehar.workers.dev/): Product Manager, Developer Experience at IFS. One design-system proof card. Get in touch goes to LinkedIn.
 - [Contact](https://me.alehar.workers.dev/contact/): Hire path. LinkedIn only.
-- [Work](https://me.alehar.workers.dev/work/): Case list. Design system and DevEx cases in the main grid. Lidköping is earlier work, not an equal card.
+- [Work](https://me.alehar.workers.dev/work/): Case list. IFS Design System and Business Model Innovation in the main grid. Copilots, analytics, and Lidköping are earlier work, not equal cards.
 - [IFS Design System](https://me.alehar.workers.dev/work/ifs-design-system/): Numbered proof. 2x delivery, 30x ROI, Zeroheight runner-up.
 - [Biography](https://me.alehar.workers.dev/biography/): Experience timeline. Product Manager, Developer Experience at IFS. /about/ redirects here.
 

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -71,11 +71,17 @@ describe('identity copy', () => {
     expect(cta).toContain('https://www.linkedin.com/in/alehar/');
   });
 
-  it('keeps Lidköping off the main /work card grid', () => {
+  it('keeps Lidköping, copilots, and analytics off the main /work card grid', () => {
     const work = sources.find((s) => s.path.endsWith('work.astro'))!.text;
-    expect(work).toContain("project.id !== 'lidkoping-stenhuggeri'");
+    expect(work).toContain("'lidkoping-stenhuggeri'");
+    expect(work).toContain("'ai-coding-copilots'");
+    expect(work).toContain("'user-behavior-analytics'");
+    expect(work).toContain('!demoted.has(project.id)');
     expect(work).toContain('Earlier work');
     expect(work).toContain('Early Android work, 2013.');
+    expect(work).toContain('Internal AI coding copilots for IFS engineering teams.');
+    expect(work).toContain('Usage telemetry for IFS Cloud roadmap decisions.');
+    expect(work).not.toContain('multi-million');
   });
 
   it('drops the /about/ duplicate in favor of /biography/', () => {

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -9,8 +9,14 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 const projects = (await getCollection('work')).sort(
   (a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf()
 );
-const featured = projects.filter((project) => project.id !== 'lidkoping-stenhuggeri');
-const earlier = projects.filter((project) => project.id === 'lidkoping-stenhuggeri');
+const demoted = new Set(['lidkoping-stenhuggeri', 'ai-coding-copilots', 'user-behavior-analytics']);
+const featured = projects.filter((project) => !demoted.has(project.id));
+const earlier = projects.filter((project) => demoted.has(project.id));
+const earlierBlurb: Record<string, string> = {
+  'lidkoping-stenhuggeri': 'Early Android work, 2013.',
+  'ai-coding-copilots': 'Internal AI coding copilots for IFS engineering teams.',
+  'user-behavior-analytics': 'Usage telemetry for IFS Cloud roadmap decisions.',
+};
 
 const schema = {
   '@context': 'https://schema.org',
@@ -104,7 +110,7 @@ const schema = {
             earlier.map((project) => (
               <li>
                 <a href={`/work/${project.id}/`}>{project.data.title}</a>
-                <p>Early Android work, 2013.</p>
+                <p>{earlierBlurb[project.id]}</p>
               </li>
             ))
           }


### PR DESCRIPTION
## Summary
- Same pattern as #469. Copilots and user-behavior analytics leave the equal-weight /work card grid.
- IFS Design System and Business Model Innovation stay as PortfolioPreview cards. Design system remains the only numbered proof (2x/30x/Zeroheight).
- Earlier work is a secondary text list: copilots, analytics, Lidköping. Honest one-liners. No new metrics.
- Hire path LinkedIn. No email or CV.

## Test plan
- [ ] /work: only IFS Design System and Business Model Innovation as cards
- [ ] Earlier work lists copilots, analytics, Lidköping as text links
- [ ] No new numbered metrics
- [ ] LinkedIn Get in touch

Stay draft. Do not merge.