### PR TITLE
feat: demote the Chalmers thesis off the /work card grid

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -14,7 +14,7 @@ Recruiter keywords (not a fake title): Product Management, Developer Experience,
 
 - [Home](https://me.alehar.workers.dev/): Product Manager, Developer Experience at IFS. One design-system proof card. Get in touch goes to LinkedIn.
 - [Contact](https://me.alehar.workers.dev/contact/): Hire path. LinkedIn only.
-- [Work](https://me.alehar.workers.dev/work/): Case list. IFS Design System and Business Model Innovation in the main grid. Copilots, analytics, and Lidköping are earlier work, not equal cards.
+- [Work](https://me.alehar.workers.dev/work/): Case list. IFS Design System is the only equal-weight card. Copilots, analytics, thesis, and Lidköping are earlier work.
 - [IFS Design System](https://me.alehar.workers.dev/work/ifs-design-system/): Numbered proof. 2x delivery, 30x ROI, Zeroheight runner-up.
 - [Biography](https://me.alehar.workers.dev/biography/): Experience timeline. Product Manager, Developer Experience at IFS. /about/ redirects here.
 
@@ -23,6 +23,6 @@ Recruiter keywords (not a fake title): Product Management, Developer Experience,
 - [AI Coding Copilots](https://me.alehar.workers.dev/work/ai-coding-copilots/): DevEx narrative. No numbered proof on this page.
 - [User Behavior Analytics](https://me.alehar.workers.dev/work/user-behavior-analytics/): Telemetry narrative. No numbered proof on this page.
 - [Lidköping Stenhuggeri](https://me.alehar.workers.dev/work/lidkoping-stenhuggeri/): Early Android work. Demoted.
-- [Master thesis](https://me.alehar.workers.dev/work/master-thesis/): Chalmers, business model innovation.
+- [Master thesis](https://me.alehar.workers.dev/work/master-thesis/): Chalmers, 2017. Earlier work, not an equal card.
 - [Latest updates](https://me.alehar.workers.dev/whats-new/): Changelog.
 - [GitHub](https://github.com/alehar9320/astro-cloudflare-personal-website): Source.

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -71,16 +71,18 @@ describe('identity copy', () => {
     expect(cta).toContain('https://www.linkedin.com/in/alehar/');
   });
 
-  it('keeps Lidköping, copilots, and analytics off the main /work card grid', () => {
+  it('keeps only the IFS Design System on the main /work card grid', () => {
     const work = sources.find((s) => s.path.endsWith('work.astro'))!.text;
     expect(work).toContain("'lidkoping-stenhuggeri'");
     expect(work).toContain("'ai-coding-copilots'");
     expect(work).toContain("'user-behavior-analytics'");
+    expect(work).toContain("'master-thesis'");
     expect(work).toContain('!demoted.has(project.id)');
     expect(work).toContain('Earlier work');
     expect(work).toContain('Early Android work, 2013.');
     expect(work).toContain('Internal AI coding copilots for IFS engineering teams.');
     expect(work).toContain('Usage telemetry for IFS Cloud roadmap decisions.');
+    expect(work).toContain("Chalmers master's thesis, 2017.");
     expect(work).not.toContain('multi-million');
   });
 

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -9,13 +9,19 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 const projects = (await getCollection('work')).sort(
   (a, b) => b.data.publishDate.valueOf() - a.data.publishDate.valueOf()
 );
-const demoted = new Set(['lidkoping-stenhuggeri', 'ai-coding-copilots', 'user-behavior-analytics']);
+const demoted = new Set([
+  'lidkoping-stenhuggeri',
+  'ai-coding-copilots',
+  'user-behavior-analytics',
+  'master-thesis',
+]);
 const featured = projects.filter((project) => !demoted.has(project.id));
 const earlier = projects.filter((project) => demoted.has(project.id));
 const earlierBlurb: Record<string, string> = {
   'lidkoping-stenhuggeri': 'Early Android work, 2013.',
   'ai-coding-copilots': 'Internal AI coding copilots for IFS engineering teams.',
   'user-behavior-analytics': 'Usage telemetry for IFS Cloud roadmap decisions.',
+  'master-thesis': "Chalmers master's thesis, 2017.",
 };
 
 const schema = {


### PR DESCRIPTION
## Summary
- Business Model Innovation (master-thesis.md, 2017 Chalmers) leaves the equal-weight /work card grid.
- IFS Design System is the only remaining PortfolioPreview card and the only numbered proof (2x/30x/Zeroheight).
- Earlier work text list: copilots, analytics, thesis, Lidköping. Honest one-liner. No new metrics.
- Hire path LinkedIn. No email or CV.

## Test plan
- [ ] /work: only IFS Design System as a card
- [ ] Earlier work includes Business Model Innovation as a text link
- [ ] No new numbered metrics
- [ ] LinkedIn Get in touch

Stay draft. Do not merge.