### PR TITLE
feat: drop the Strategic Portfolio frame on /work

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -14,7 +14,7 @@ Recruiter keywords (not a fake title): Product Management, Developer Experience,
 
 - [Home](https://me.alehar.workers.dev/): Product Manager, Developer Experience at IFS. One design-system proof card. Get in touch goes to LinkedIn.
 - [Contact](https://me.alehar.workers.dev/contact/): Hire path. LinkedIn only.
-- [Work](https://me.alehar.workers.dev/work/): Case list. IFS Design System is the only equal-weight card. Copilots, analytics, thesis, and Lidköping are earlier work.
+- [Work](https://me.alehar.workers.dev/work/): Work. IFS Design System is the only card, then earlier work. Not titled Strategic Portfolio.
 - [IFS Design System](https://me.alehar.workers.dev/work/ifs-design-system/): Numbered proof. 2x delivery, 30x ROI, Zeroheight runner-up.
 - [Biography](https://me.alehar.workers.dev/biography/): Experience timeline. Product Manager, Developer Experience at IFS. /about/ redirects here.
 

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -84,6 +84,15 @@ describe('identity copy', () => {
     expect(work).toContain('Usage telemetry for IFS Cloud roadmap decisions.');
     expect(work).toContain("Chalmers master's thesis, 2017.");
     expect(work).not.toContain('multi-million');
+    expect(work).not.toContain('Strategic Portfolio');
+    expect(work).toContain('title="Work"');
+    expect(work).toContain('The IFS Design System case, then earlier work.');
+  });
+
+  it('drops the Strategic Portfolio consultant frame from nav', () => {
+    const nav = readFileSync('src/components/Nav.astro', 'utf8');
+    expect(nav).not.toContain('Strategic Portfolio');
+    expect(nav).toContain("{ label: 'Work', href: '/work/' }");
   });
 
   it('drops the /about/ duplicate in favor of /biography/', () => {

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -10,7 +10,7 @@ const isLogoWobbleEnabled = flagsEntry?.data.enable_logo_wobble_v1 ?? false;
 /** Main menu items */
 const textLinks: { label: string; href: string; event?: string; surface?: string }[] = [
   { label: 'Home', href: '/' },
-  { label: 'Strategic Portfolio', href: '/work/' },
+  { label: 'Work', href: '/work/' },
   { label: 'Biography', href: '/biography/' },
   { label: 'Contact', href: '/contact/', event: 'hire_cta_click', surface: 'nav' },
 ];

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -31,9 +31,9 @@ const schema = {
       '@type': 'WebPage',
       '@id': 'https://harenstam.com/work/#webpage',
       url: 'https://harenstam.com/work/',
-      name: 'Strategic Portfolio | Alexander Härenstam',
+      name: 'Work | Alexander Härenstam',
       description:
-        "Explore Alexander Härenstam's strategic portfolio of high-impact initiatives, featuring Industrial AI, Developer Experience, and Digital Transformation.",
+        'Product Manager, Developer Experience at IFS. The IFS Design System case, then earlier work.',
       breadcrumb: {
         '@type': 'BreadcrumbList',
         itemListElement: [
@@ -46,7 +46,7 @@ const schema = {
           {
             '@type': 'ListItem',
             position: 2,
-            name: 'Strategic Portfolio',
+            name: 'Work',
             item: 'https://harenstam.com/work/',
           },
         ],
@@ -59,9 +59,9 @@ const schema = {
     },
     {
       '@type': 'ItemList',
-      name: 'Strategic Portfolio | Alexander Härenstam',
+      name: 'Work | Alexander Härenstam',
       description:
-        "Explore Alexander Härenstam's strategic portfolio of high-impact initiatives, featuring Industrial AI, Developer Experience, and Digital Transformation.",
+        'Product Manager, Developer Experience at IFS. The IFS Design System case, then earlier work.',
       numberOfItems: projects.length,
       itemListElement: projects.map((project, index) => ({
         '@type': 'ListItem',
@@ -76,17 +76,13 @@ const schema = {
 ---
 
 <BaseLayout
-  title="Strategic Portfolio | Alexander Härenstam"
-  description="Explore Alexander Härenstam's strategic product portfolio and recent initiatives."
+  title="Work | Alexander Härenstam"
+  description="Product Manager, Developer Experience at IFS. The IFS Design System case, then earlier work."
 >
   <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
   <div class="stack gap-20">
     <main id="main-content" class="wrapper stack gap-8">
-      <Hero
-        title="Strategic Portfolio"
-        tagline="A curated selection of initiatives transforming complex enterprise challenges into scalable product solutions."
-        align="start"
-      />
+      <Hero title="Work" tagline="The IFS Design System case, then earlier work." align="start" />
       <div class="tldr-box">
         <p>
           <strong>TL;DR:</strong>


### PR DESCRIPTION
## Summary
- /work is no longer titled Strategic Portfolio. Honest Work chrome: H1, nav, schema, meta.
- Tagline: The IFS Design System case, then earlier work.
- Design system remains the only numbered proof (2x/30x/Zeroheight). No new metrics.
- Hire path LinkedIn. No email or CV.

## Test plan
- [ ] /work H1 is Work, not Strategic Portfolio
- [ ] Nav label is Work
- [ ] One card: IFS Design System, then Earlier work
- [ ] LinkedIn Get in touch

Stay draft. Do not merge.