### PR TITLE
feat: honest labels on Earlier work

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -20,9 +20,9 @@ Recruiter keywords (not a fake title): Product Management, Developer Experience,
 
 ## Optional
 
-- [AI Coding Copilots](https://me.alehar.workers.dev/work/ai-coding-copilots/): DevEx narrative. No numbered proof on this page.
-- [User Behavior Analytics](https://me.alehar.workers.dev/work/user-behavior-analytics/): Telemetry narrative. No numbered proof on this page.
+- [Internal AI coding copilots](https://me.alehar.workers.dev/work/ai-coding-copilots/): DevEx narrative. No numbered proof on this page.
+- [User behavior analytics](https://me.alehar.workers.dev/work/user-behavior-analytics/): Telemetry narrative. No numbered proof on this page.
 - [Lidköping Stenhuggeri](https://me.alehar.workers.dev/work/lidkoping-stenhuggeri/): Early Android work. Demoted.
-- [Master thesis](https://me.alehar.workers.dev/work/master-thesis/): Chalmers, 2017. Earlier work, not an equal card.
+- [Chalmers master's thesis](https://me.alehar.workers.dev/work/master-thesis/): Chalmers, 2017. Earlier work, not an equal card.
 - [Latest updates](https://me.alehar.workers.dev/whats-new/): Changelog.
 - [GitHub](https://github.com/alehar9320/astro-cloudflare-personal-website): Source.

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -95,6 +95,21 @@ describe('identity copy', () => {
     expect(nav).toContain("{ label: 'Work', href: '/work/' }");
   });
 
+  it('uses honest Earlier work labels, not Platform or copilots-as-product', () => {
+    const copilots = readFileSync('src/content/work/ai-coding-copilots.md', 'utf8');
+    const analytics = readFileSync('src/content/work/user-behavior-analytics.md', 'utf8');
+    const thesis = readFileSync('src/content/work/master-thesis.md', 'utf8');
+    const lidkoping = readFileSync('src/content/work/lidkoping-stenhuggeri.md', 'utf8');
+    expect(copilots).toContain('title: Internal AI coding copilots');
+    expect(copilots).not.toContain('title: AI Coding Copilots');
+    expect(analytics).toContain('title: User behavior analytics');
+    expect(analytics).not.toContain('title: User Behavior Analytics Platform');
+    expect(thesis).toContain("title: Chalmers master's thesis");
+    expect(thesis).not.toContain('title: Business Model Innovation');
+    expect(lidkoping).toContain('title: Lidköping Stenhuggeri');
+    expect(lidkoping).not.toContain('title: Lidköping Stenhuggeri App');
+  });
+
   it('drops the /about/ duplicate in favor of /biography/', () => {
     const nav = readFileSync('src/components/Nav.astro', 'utf8');
     const astro = readFileSync('astro.config.mjs', 'utf8');

--- a/src/content/work/ai-coding-copilots.md
+++ b/src/content/work/ai-coding-copilots.md
@@ -1,10 +1,10 @@
 ---
-title: AI Coding Copilots
+title: Internal AI coding copilots
 publishDate: 2025-02-01 00:00:00
 img: /assets/stock-1.jpg
 img_alt: Abstract technology presentation
 description: |
-  A strategic multi-million dollar initiative accelerating development via AI Coding Copilots for global engineering teams at IFS.
+  Internal AI coding copilots for IFS engineering teams.
 tags:
   - Developer Experience
   - AI Strategy

--- a/src/content/work/lidkoping-stenhuggeri.md
+++ b/src/content/work/lidkoping-stenhuggeri.md
@@ -1,5 +1,5 @@
 ---
-title: Lidköping Stenhuggeri App
+title: Lidköping Stenhuggeri
 publishDate: 2013-09-01 00:00:00
 img: /assets/stock-4.jpg
 img_alt: Mobile app interface concept

--- a/src/content/work/master-thesis.md
+++ b/src/content/work/master-thesis.md
@@ -1,10 +1,10 @@
 ---
-title: Business Model Innovation
+title: Chalmers master's thesis
 publishDate: 2017-06-01 00:00:00
 img: /assets/stock-1.jpg
 img_alt: Business structure concept
 description: |
-  A strategic roadmap for digital transformation—identifying how data-driven innovation unlocks scalable growth and competitive advantage.
+  Chalmers master's thesis, 2017.
 tags:
   - Research
   - Digitalization

--- a/src/content/work/user-behavior-analytics.md
+++ b/src/content/work/user-behavior-analytics.md
@@ -1,10 +1,10 @@
 ---
-title: User Behavior Analytics Platform
+title: User behavior analytics
 publishDate: 2023-01-01 00:00:00
 img: /assets/stock-3.jpg
 img_alt: Analytics graphs
 description: |
-  Spearheading a critical IFS Cloud capability that ensures roadmap decisions are grounded in telemetry, optimizing R&D resources and preventing over-engineering.
+  Usage telemetry for IFS Cloud roadmap decisions.
 tags:
   - Analytics
   - User Behavior


### PR DESCRIPTION
## Summary
- Earlier work titles are honest: Internal AI coding copilots, User behavior analytics, Chalmers master's thesis, Lidköping Stenhuggeri.
- No Platform. Copilots are not presented as a product.
- Design system remains the only /work card and the only numbered proof. No new metrics.
- Hire path LinkedIn. No email or CV.

## Test plan
- [ ] /work Earlier work list uses the new labels
- [ ] No User Behavior Analytics Platform
- [ ] No AI Coding Copilots product title
- [ ] LinkedIn Get in touch

Stay draft. Do not merge.