### PR TITLE
feat: honest H1s and ledes on Earlier work pages

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -108,6 +108,16 @@ describe('identity copy', () => {
     expect(thesis).not.toContain('title: Business Model Innovation');
     expect(lidkoping).toContain('title: Lidköping Stenhuggeri');
     expect(lidkoping).not.toContain('title: Lidköping Stenhuggeri App');
+    expect(copilots).toContain('Internal AI coding copilots for');
+    expect(copilots).toContain('not a customer product');
+    expect(copilots).not.toContain('multi-million');
+    expect(analytics).toContain('Usage telemetry so');
+    expect(analytics).toContain('not a standalone platform product');
+    expect(analytics).not.toContain('User Behavior Analytics Platform');
+    expect(analytics).not.toContain('Strategic Leadership');
+    expect(thesis).toContain("Chalmers</strong> master's thesis, 2017");
+    expect(lidkoping).toContain('Early Android work, 2013');
+    expect(lidkoping).not.toContain('management platform');
   });
 
   it('drops the /about/ duplicate in favor of /biography/', () => {

--- a/src/content/work/ai-coding-copilots.md
+++ b/src/content/work/ai-coding-copilots.md
@@ -12,9 +12,7 @@ tags:
 ---
 
 <div class="tldr-box">
-  <p><strong>TL;DR:</strong> Spearheading a <strong>multi-million dollar AI initiative</strong> at <strong>IFS</strong>, accelerating global development cycles and driving <strong>autonomous workflows</strong> across the Cloud portfolio.</p>
+  <p><strong>TL;DR:</strong> Internal AI coding copilots for <strong>IFS</strong> engineering teams. I am <strong>Product Manager, Developer Experience</strong>.</p>
 </div>
 
-As Product Manager for Developer Experience at IFS, I set the strategy for the tools and platforms that empower internal engineering teams, global partners, and customers. The work translates to increased efficiency and accelerated time-to-market for the company's offerings.
-
-One key pillar has been the strategic rollout of AI Coding Copilots—an initiative delivering multi-million dollar business value. By integrating autonomous AI capabilities into the developer workflow, we've significantly accelerated the development lifecycle and improved time-to-market for the entire IFS Cloud portfolio.
+As Product Manager, Developer Experience at IFS, I work on internal AI coding copilots for engineering teams. This is tooling for people who already work at IFS, not a customer product.

--- a/src/content/work/lidkoping-stenhuggeri.md
+++ b/src/content/work/lidkoping-stenhuggeri.md
@@ -4,7 +4,7 @@ publishDate: 2013-09-01 00:00:00
 img: /assets/stock-4.jpg
 img_alt: Mobile app interface concept
 description: |
-  Strategic digitalization of onsite workflows for a Swedish masonry firm, replacing manual processes with a high-efficiency Android-based job management platform.
+  Early Android work, 2013, for Lidköping Stenhuggeri.
 tags:
   - Android
   - Java
@@ -12,9 +12,7 @@ tags:
 ---
 
 <div class="tldr-box">
-  <p><strong>TL;DR:</strong> Modernized onsite operations for <strong>Lidköping Stenhuggeri</strong> by delivering an <strong>Android-based management platform</strong>, replacing manual workflows with high-efficiency digital tracking.</p>
+  <p><strong>TL;DR:</strong> Early Android work, 2013, for <strong>Lidköping Stenhuggeri</strong>.</p>
 </div>
 
-Developed a high-efficiency Android application for Lidköpings Stenhuggeri, a masonry firm. The platform eliminated manual paperwork, streamlining onsite data entry and enabling real-time operational tracking.
-
-By digitizing their workflows into a mobile interface, the company was able to track jobs, materials, and schedules far more effectively than their previous manual processes allowed.
+An Android app I built in 2013 for a masonry firm in Lidköping so they could track jobs on site instead of on paper.

--- a/src/content/work/master-thesis.md
+++ b/src/content/work/master-thesis.md
@@ -12,15 +12,13 @@ tags:
 ---
 
 <div class="tldr-box">
-  <p><strong>TL;DR:</strong> Conducted a <strong>Master Thesis</strong> at <strong>Chalmers</strong> on <strong>Business Model Innovation</strong>, identifying how digitalization enables scalability and data-driven decision-making while uncovering organizational barriers to change.</p>
+  <p><strong>TL;DR:</strong> <strong>Chalmers</strong> master's thesis, 2017, on business model innovation and digitalization.</p>
 </div>
 
-Digital transformation has fundamentally reshaped the competitive landscape, making strategic business model innovation a critical requirement for sustained success. This research explores how organizations can strategically re-arrange their activities to capture new value and maintain a competitive edge in a digital-first economy.
-
-My thesis was conducted at [Chalmers University of Technology](https://www.chalmers.se/en/) and revolved around business model innovation, and the opportunities and barriers that digitalization creates. This was done by:
+Master's thesis at [Chalmers University of Technology](https://www.chalmers.se/en/) in 2017. It mapped what digitalization does to business models, studied one case, and compared that to the literature.
 
 1. Academically mapping out what it means to transform a business with the help of digitalization.
 2. Studying a specific business case where digitalization was part of changing the business model.
 3. Identifying the gap between what theory stipulates and the business case at hand.
 
-The thesis captured key drivers of business model innovation in the context of digitalization, noting that opportunities are primarily identified through an increased reach, scalability, and decision-support based on data collection. Barriers are often related to the organizational inability to implement digital changes on a business level.
+Opportunities showed up as reach, scale, and data for decisions. Barriers were mostly organizational.

--- a/src/content/work/user-behavior-analytics.md
+++ b/src/content/work/user-behavior-analytics.md
@@ -12,9 +12,7 @@ tags:
 ---
 
 <div class="tldr-box">
-  <p><strong>TL;DR:</strong> Empowering data-driven roadmaps at <strong>IFS</strong> through granular telemetry, optimizing R&D investment and eliminating product waste.</p>
+  <p><strong>TL;DR:</strong> Usage telemetry so <strong>IFS Cloud</strong> roadmap decisions rest on how people actually use the product.</p>
 </div>
 
-Strategic Leadership of the User Behavior Analytics Platform: This core capability for IFS Cloud ensures that every feature is grounded in genuine customer needs. By implementing this platform, we've optimized development resources and ensured that our R&D efforts are laser-focused on high-value functionality.
-
-Understanding how users navigate complex enterprise software allowed us to make data-driven decisions that align with global business objectives. By capturing granular telemetry, we've enabled product teams to iterate with confidence, directly impacting the quality and adoption of the IFS Cloud ecosystem.
+At IFS I worked on user behavior analytics for IFS Cloud: capturing usage so product teams can see what customers actually do. It is telemetry, not a standalone platform product.


### PR DESCRIPTION
## Summary
- Earlier work pages match the /work index labels in H1, description, TL;DR, and lede.
- Internal AI coding copilots, User behavior analytics, Chalmers master's thesis, Lidköping Stenhuggeri.
- No Platform, no copilots-as-product, no minted metrics. Design system remains the only /work card and the only numbered proof.
- Hire path LinkedIn. No email or CV.

## Test plan
- [ ] Each Earlier work page H1 matches the index label
- [ ] TLDRs and ledes are honest, no multi-million / Platform product frame
- [ ] LinkedIn Get in touch

Stay draft. Do not merge.