### PR TITLE
feat: drop stock photos on Earlier work pages

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -118,6 +118,12 @@ describe('identity copy', () => {
     expect(thesis).toContain("Chalmers</strong> master's thesis, 2017");
     expect(lidkoping).toContain('Early Android work, 2013');
     expect(lidkoping).not.toContain('management platform');
+    for (const page of [copilots, analytics, thesis, lidkoping]) {
+      expect(page).not.toContain('stock-1.jpg');
+      expect(page).not.toContain('stock-3.jpg');
+      expect(page).not.toContain('stock-4.jpg');
+      expect(page).not.toMatch(/^img:/m);
+    }
   });
 
   it('drops the /about/ duplicate in favor of /biography/', () => {

--- a/src/components/PortfolioPreview.astro
+++ b/src/components/PortfolioPreview.astro
@@ -20,13 +20,17 @@ const isShimmerEnabled = flagsEntry?.data.portfolio_shimmer_v1 ?? false;
   href={`/work/${id}`}
 >
   <span class="title">{data.title}</span>
-  <img
-    src={data.img}
-    alt={data.img_alt || ''}
-    loading={loading}
-    fetchpriority={fetchpriority}
-    decoding="async"
-  />
+  {
+    data.img && (
+      <img
+        src={data.img}
+        alt={data.img_alt || ''}
+        loading={loading}
+        fetchpriority={fetchpriority}
+        decoding="async"
+      />
+    )
+  }
 </a>
 
 <style>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -11,8 +11,8 @@ export const collections = {
       description: z.string(),
       publishDate: z.coerce.date(),
       tags: z.array(z.string()),
-      img: z.string(),
-      img_alt: z.string().min(1),
+      img: z.string().optional(),
+      img_alt: z.string().min(1).optional(),
     }),
   }),
   flags: defineCollection({

--- a/src/content/work/ai-coding-copilots.md
+++ b/src/content/work/ai-coding-copilots.md
@@ -1,8 +1,6 @@
 ---
 title: Internal AI coding copilots
 publishDate: 2025-02-01 00:00:00
-img: /assets/stock-1.jpg
-img_alt: Abstract technology presentation
 description: |
   Internal AI coding copilots for IFS engineering teams.
 tags:

--- a/src/content/work/lidkoping-stenhuggeri.md
+++ b/src/content/work/lidkoping-stenhuggeri.md
@@ -1,8 +1,6 @@
 ---
 title: Lidköping Stenhuggeri
 publishDate: 2013-09-01 00:00:00
-img: /assets/stock-4.jpg
-img_alt: Mobile app interface concept
 description: |
   Early Android work, 2013, for Lidköping Stenhuggeri.
 tags:

--- a/src/content/work/master-thesis.md
+++ b/src/content/work/master-thesis.md
@@ -1,8 +1,6 @@
 ---
 title: Chalmers master's thesis
 publishDate: 2017-06-01 00:00:00
-img: /assets/stock-1.jpg
-img_alt: Business structure concept
 description: |
   Chalmers master's thesis, 2017.
 tags:

--- a/src/content/work/user-behavior-analytics.md
+++ b/src/content/work/user-behavior-analytics.md
@@ -1,8 +1,6 @@
 ---
 title: User behavior analytics
 publishDate: 2023-01-01 00:00:00
-img: /assets/stock-3.jpg
-img_alt: Analytics graphs
 description: |
   Usage telemetry for IFS Cloud roadmap decisions.
 tags:


### PR DESCRIPTION
## Summary
- Earlier work pages (copilots, analytics, thesis, Lidköping) no longer use generic stock photos.
- img/img_alt are optional in the work schema. Design system card keeps its image.
- Honest H1s and ledes from #475 unchanged. No new metrics. Hire path LinkedIn.

## Test plan
- [ ] /work/ai-coding-copilots/, /work/user-behavior-analytics/, /work/master-thesis/, /work/lidkoping-stenhuggeri/ have no stock image
- [ ] IFS Design System card still has an image
- [ ] LinkedIn Get in touch

Stay draft. Do not merge.