### PR TITLE
fix: keep chat FAB off Earlier work and biography timeline on phones

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -71,6 +71,18 @@ describe('identity copy', () => {
     expect(cta).toContain('https://www.linkedin.com/in/alehar/');
   });
 
+  it('keeps the chat FAB off Earlier work and the biography timeline on a phone', () => {
+    const work = readFileSync('src/pages/work.astro', 'utf8');
+    const bio = readFileSync('src/pages/biography.astro', 'utf8');
+    expect(work).toContain('padding-bottom: var(--chat-fab-clearance)');
+    expect(work).toContain('padding-right: var(--chat-fab-clearance)');
+    expect(work).toContain('Earlier work');
+    expect(bio).toContain('padding-bottom: var(--chat-fab-clearance)');
+    expect(bio).toContain('padding-right: var(--chat-fab-clearance)');
+    expect(bio).toContain('class="timeline"');
+    expect(bio).toContain('https://www.linkedin.com/in/alehar/');
+  });
+
   it('keeps only the IFS Design System on the main /work card grid', () => {
     const work = sources.find((s) => s.path.endsWith('work.astro'))!.text;
     expect(work).toContain("'lidkoping-stenhuggeri'");

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -138,6 +138,9 @@ const schema = {
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
+    /* Phone: keep the experience timeline out of the fixed chat FAB band. */
+    padding-bottom: var(--chat-fab-clearance);
+    padding-right: var(--chat-fab-clearance);
   }
 
   .timeline {
@@ -177,6 +180,11 @@ const schema = {
   }
 
   @media (min-width: 50em) {
+    .content {
+      padding-bottom: 0;
+      padding-right: 0;
+    }
+
     .about {
       display: grid;
       grid-template-columns: 1fr 60% 1fr;

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -129,6 +129,9 @@ const schema = {
     flex-direction: column;
     gap: 0.75rem;
     color: var(--gray-300);
+    /* Phone: keep the list out of the fixed chat FAB band. */
+    padding-bottom: var(--chat-fab-clearance);
+    padding-right: var(--chat-fab-clearance);
   }
 
   .earlier h2 {
@@ -166,5 +169,12 @@ const schema = {
   .earlier p {
     margin: 0;
     font-size: var(--text-sm);
+  }
+
+  @media (min-width: 50em) {
+    .earlier {
+      padding-bottom: 0;
+      padding-right: 0;
+    }
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -88,7 +88,7 @@
   /* Transitions */
   --theme-transition: 0.2s ease-in-out;
 
-  /* Chat FAB. Hire CTAs and the home portrait must clear this band on phones. */
+  /* Chat FAB. Hire CTAs, home portrait, /work Earlier work, and /biography timeline must clear this band on phones. */
   --chat-fab-size: 3.5rem;
   --chat-fab-offset: 2rem;
   --chat-fab-clearance: calc(


### PR DESCRIPTION
## Summary
- On phone (~375), the chat FAB must not cover Earlier work on `/work` or the experience timeline on `/biography`. Same bar as #470 (FAB already off Get in touch and the home portrait).
- Uses `--chat-fab-clearance` as padding-bottom and padding-right on those two surfaces. Desktop unchanged.
- Hire path LinkedIn only. No email or CV. Design system stays the only `/work` card and the only numbered proof (2x/30x/Zeroheight). Chat stays demoted.

## Test plan
- [ ] Worker preview at ~375×812: `/work` Earlier work list is not under the FAB (including the last items).
- [ ] Worker preview at ~375×812: `/biography` experience timeline is not under the FAB.
- [ ] Home portrait and Get in touch still clear (no #470 regression).
- [ ] Hire path is LinkedIn (`https://www.linkedin.com/in/alehar/`). No mailto, no CV.

Stay draft. Do not merge.