### PR TITLE
fix: keep chat FAB off the LinkedIn hire CTA on /contact on phones

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -83,6 +83,17 @@ describe('identity copy', () => {
     expect(bio).toContain('https://www.linkedin.com/in/alehar/');
   });
 
+  it('keeps the chat FAB off the LinkedIn hire CTA on /contact on a phone', () => {
+    const contact = readFileSync('src/pages/contact.astro', 'utf8');
+    const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    expect(contact).toContain('padding-bottom: var(--chat-fab-clearance)');
+    expect(contact).toContain('padding-right: var(--chat-fab-clearance)');
+    expect(contact).toContain('https://www.linkedin.com/in/alehar/');
+    expect(contact).toContain('Get in touch');
+    expect(contact).not.toContain('mailto:');
+    expect(footer).toContain('padding: 3rem 2rem var(--chat-fab-clearance)');
+  });
+
   it('keeps only the IFS Design System on the main /work card grid', () => {
     const work = sources.find((s) => s.path.endsWith('work.astro'))!.text;
     expect(work).toContain("'lidkoping-stenhuggeri'");

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -212,7 +212,7 @@ const currentYear = new Date().getFullYear();
     flex-direction: column;
     gap: 3rem;
     margin-top: auto;
-    padding: 3rem 2rem 3rem;
+    padding: 3rem 2rem var(--chat-fab-clearance);
     text-align: center;
     color: var(--gray-400);
     font-size: var(--text-sm);

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -48,6 +48,9 @@ const linkedinHref = 'https://www.linkedin.com/in/alehar/';
     align-items: flex-start;
     gap: 0.4rem;
     margin-top: 0.5rem;
+    /* Phone: keep the LinkedIn hire CTA out of the fixed chat FAB band. */
+    padding-bottom: var(--chat-fab-clearance);
+    padding-right: var(--chat-fab-clearance);
   }
 
   .cta-hint {
@@ -55,5 +58,12 @@ const linkedinHref = 'https://www.linkedin.com/in/alehar/';
     font-size: var(--text-sm);
     color: var(--gray-300);
     font-weight: 400;
+  }
+
+  @media (min-width: 50em) {
+    .actions {
+      padding-bottom: 0;
+      padding-right: 0;
+    }
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -88,7 +88,7 @@
   /* Transitions */
   --theme-transition: 0.2s ease-in-out;
 
-  /* Chat FAB. Hire CTAs, home portrait, /work Earlier work, and /biography timeline must clear this band on phones. */
+  /* Chat FAB. Hire CTAs (home, /contact), home portrait, /work Earlier work, and /biography timeline must clear this band on phones. */
   --chat-fab-size: 3.5rem;
   --chat-fab-offset: 2rem;
   --chat-fab-clearance: calc(


### PR DESCRIPTION
## Summary
- On phone (~375), the chat FAB must not cover the LinkedIn hire CTA on `/contact`. Same bar as #470 (home) and #477 (/work Earlier work, /biography timeline).
- `--chat-fab-clearance` on the `/contact` hire actions, plus footer padding-bottom so the pinned LinkedIn row on this short page is not under the FAB.
- Hire path LinkedIn only. No email or CV. Design system stays the only numbered proof. Chat stays demoted.

## Test plan
- [ ] Worker preview at ~375×812: `/contact` Get in touch (LinkedIn) is not under the FAB.
- [ ] Footer LinkedIn on `/contact` is not under the FAB.
- [ ] Home / work / biography FAB clearance unchanged.
- [ ] Hire path is LinkedIn (`https://www.linkedin.com/in/alehar/`). No mailto, no CV.

Stay draft. Do not merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile spacing on the contact page to keep the LinkedIn hiring CTA clear of the chat button.
  * Updated footer spacing to prevent overlap with the chat button across supported layouts.

* **Tests**
  * Added coverage verifying contact-page CTA content, spacing, and chat button clearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->