### PR TITLE
fix: keep chat FAB off the 2x/30x/Zeroheight proof on phones

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -104,6 +104,18 @@ describe('identity copy', () => {
     expect(chat).not.toContain('.chat-toggle .status-dot');
   });
 
+  it('keeps the chat FAB off the 2x/30x/Zeroheight proof on the design system case on a phone', () => {
+    const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
+    const ds = readFileSync('src/content/work/ifs-design-system.md', 'utf8');
+    expect(slug).toContain('ifs-design-system');
+    expect(slug).toContain('ds-proof');
+    expect(slug).toContain('padding-bottom: var(--chat-fab-clearance)');
+    expect(slug).toContain('padding-right: var(--chat-fab-clearance)');
+    expect(ds).toContain('**2x faster**');
+    expect(ds).toContain('**30x ROI**');
+    expect(ds).toContain('**Zeroheight Design System Awards**');
+  });
+
   it('keeps only the IFS Design System on the main /work card grid', () => {
     const work = sources.find((s) => s.path.endsWith('work.astro'))!.text;
     expect(work).toContain("'lidkoping-stenhuggeri'");

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -118,7 +118,11 @@ const schema = entry
                   decoding="async"
                 />
               )}
-              <div class="content">{Content && <Content />}</div>
+              <div
+                class:list={['content', { 'ds-proof': entry.id === 'ifs-design-system' }]}
+              >
+                {Content && <Content />}
+              </div>
             </div>
           </main>
         </div>
@@ -162,6 +166,12 @@ const schema = entry
   .content {
     max-width: 65ch;
     margin-inline: auto;
+  }
+
+  .ds-proof {
+    /* Phone: keep 2x/30x/Zeroheight out of the fixed chat FAB band. */
+    padding-bottom: var(--chat-fab-clearance);
+    padding-right: var(--chat-fab-clearance);
   }
 
   .content > :global(* + *) {
@@ -214,6 +224,11 @@ const schema = entry
   }
 
   @media (min-width: 50em) {
+    .ds-proof {
+      padding-bottom: 0;
+      padding-right: 0;
+    }
+
     .back-link {
       display: block;
       align-self: flex-start;

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -118,9 +118,7 @@ const schema = entry
                   decoding="async"
                 />
               )}
-              <div
-                class:list={['content', { 'ds-proof': entry.id === 'ifs-design-system' }]}
-              >
+              <div class:list={['content', { 'ds-proof': entry.id === 'ifs-design-system' }]}>
                 {Content && <Content />}
               </div>
             </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -88,7 +88,7 @@
   /* Transitions */
   --theme-transition: 0.2s ease-in-out;
 
-  /* Chat FAB. Hire CTAs (home, /contact), home portrait, /work Earlier work, and /biography timeline must clear this band on phones. */
+  /* Chat FAB. Hire CTAs (home, /contact), home portrait, /work Earlier work, /biography timeline, and the design system 2x/30x/Zeroheight proof must clear this band on phones. */
   --chat-fab-size: 3.5rem;
   --chat-fab-offset: 2rem;
   --chat-fab-clearance: calc(


### PR DESCRIPTION
## Summary
- On phone (~375), the chat FAB must not cover the 2x/30x/Zeroheight proof on `/work/ifs-design-system/`. Same `--chat-fab-clearance` band as #470/#477/#478.
- Copy unchanged. Those three numbers remain the only numbered proof.
- Hire path LinkedIn only. No email or CV. Chat stays demoted.

## Test plan
- [ ] Worker preview at ~375×812: `/work/ifs-design-system/` Metrics (2x / 30x / Zeroheight) are not under the FAB.
- [ ] Proof copy is unchanged.
- [ ] Hire path is LinkedIn (`https://www.linkedin.com/in/alehar/`). No mailto, no CV.

Stay draft. Do not merge.