### PR TITLE
fix: keep chat FAB off Metrics at the bottom of a phone viewport

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -109,6 +109,7 @@ describe('identity copy', () => {
     const ds = readFileSync('src/content/work/ifs-design-system.md', 'utf8');
     expect(slug).toContain('ifs-design-system');
     expect(slug).toContain('ds-proof');
+    expect(slug).toContain('.ds-proof :global(ul)');
     expect(slug).toContain('padding-bottom: var(--chat-fab-clearance)');
     expect(slug).toContain('padding-right: var(--chat-fab-clearance)');
     expect(ds).toContain('**2x faster**');

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -172,6 +172,12 @@ const schema = entry
     padding-right: var(--chat-fab-clearance);
   }
 
+  .ds-proof :global(ul) {
+    /* Phone: when Metrics sits at the bottom of the viewport, not only page end. */
+    padding-bottom: var(--chat-fab-clearance);
+    padding-right: var(--chat-fab-clearance);
+  }
+
   .content > :global(* + *) {
     margin-top: 1rem;
   }
@@ -223,6 +229,11 @@ const schema = entry
 
   @media (min-width: 50em) {
     .ds-proof {
+      padding-bottom: 0;
+      padding-right: 0;
+    }
+
+    .ds-proof :global(ul) {
       padding-bottom: 0;
       padding-right: 0;
     }


### PR DESCRIPTION
## Summary
- Follow-up to #479 (live 556b745). Johan FAIL at 375×812: when the Metrics list on /work/ifs-design-system/ sits at the bottom of the viewport, the chat FAB covers the tail of 30x ROI and Zeroheight. Load position with Outcome below was not the fail frame.
- Pad `.ds-proof ul` with `--chat-fab-clearance` (bottom + right) on phones. Do not revert #479. Copy unchanged. Hire path LinkedIn. Twin stays Live/Not live, not Available.

## Test plan
- [ ] Phone ~375×812: scroll until Metrics (2x / 30x / Zeroheight) sits at the bottom of the viewport. FAB must not cover those three lines.
- [ ] Load position still clear. Outcome copy unchanged.
- [ ] Desktop ≥50em: no extra Metrics padding.
- [ ] Chat header still Live / Not live. No Available. No FAB hire-dot.