### PR TITLE
fix: keep chat FAB off Earlier work case body copy on phones

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -124,8 +124,8 @@ describe('identity copy', () => {
     expect(slug).toContain('user-behavior-analytics');
     expect(slug).toContain('master-thesis');
     expect(slug).toContain('lidkoping-stenhuggeri');
-    expect(slug).toContain('.earlier-case :global(.tldr-box)');
-    expect(slug).toContain('.earlier-case :global(ul)');
+    expect(slug).toContain('padding-bottom: calc(var(--chat-fab-clearance) + 1.5rem)');
+    expect(slug).not.toContain('.earlier-case :global(.tldr-box)');
     expect(slug).not.toContain('.earlier-case :global(p)');
     expect(slug).not.toContain('.earlier-case :global(li)');
     expect(slug).not.toMatch(/\.earlier-case\s*\{[^}]*padding-right:/s);

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -124,6 +124,7 @@ describe('identity copy', () => {
     expect(slug).toContain('user-behavior-analytics');
     expect(slug).toContain('master-thesis');
     expect(slug).toContain('lidkoping-stenhuggeri');
+    expect(slug).toContain('.earlier-case :global(.tldr-box)');
     expect(slug).toContain('.earlier-case :global(p)');
     expect(slug).toContain('.earlier-case :global(ul)');
     expect(slug).not.toContain('mailto:');

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -117,6 +117,26 @@ describe('identity copy', () => {
     expect(ds).toContain('**Zeroheight Design System Awards**');
   });
 
+  it('keeps the chat FAB off Earlier work case body copy on a phone', () => {
+    const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
+    expect(slug).toContain('earlier-case');
+    expect(slug).toContain('ai-coding-copilots');
+    expect(slug).toContain('user-behavior-analytics');
+    expect(slug).toContain('master-thesis');
+    expect(slug).toContain('lidkoping-stenhuggeri');
+    expect(slug).toContain('.earlier-case :global(p)');
+    expect(slug).toContain('.earlier-case :global(ul)');
+    expect(slug).not.toContain('mailto:');
+    const copilots = readFileSync('src/content/work/ai-coding-copilots.md', 'utf8');
+    const analytics = readFileSync('src/content/work/user-behavior-analytics.md', 'utf8');
+    const thesis = readFileSync('src/content/work/master-thesis.md', 'utf8');
+    const lidkoping = readFileSync('src/content/work/lidkoping-stenhuggeri.md', 'utf8');
+    expect(copilots).toContain('Internal AI coding copilots for');
+    expect(analytics).toContain('Usage telemetry so');
+    expect(thesis).toContain("Chalmers</strong> master's thesis, 2017");
+    expect(lidkoping).toContain('Early Android work, 2013');
+  });
+
   it('keeps only the IFS Design System on the main /work card grid', () => {
     const work = sources.find((s) => s.path.endsWith('work.astro'))!.text;
     expect(work).toContain("'lidkoping-stenhuggeri'");

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -125,8 +125,10 @@ describe('identity copy', () => {
     expect(slug).toContain('master-thesis');
     expect(slug).toContain('lidkoping-stenhuggeri');
     expect(slug).toContain('.earlier-case :global(.tldr-box)');
-    expect(slug).toContain('.earlier-case :global(p)');
     expect(slug).toContain('.earlier-case :global(ul)');
+    expect(slug).not.toContain('.earlier-case :global(p)');
+    expect(slug).not.toContain('.earlier-case :global(li)');
+    expect(slug).not.toMatch(/\.earlier-case\s*\{[^}]*padding-right:/s);
     expect(slug).not.toContain('mailto:');
     const copilots = readFileSync('src/content/work/ai-coding-copilots.md', 'utf8');
     const analytics = readFileSync('src/content/work/user-behavior-analytics.md', 'utf8');

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -125,10 +125,12 @@ describe('identity copy', () => {
     expect(slug).toContain('master-thesis');
     expect(slug).toContain('lidkoping-stenhuggeri');
     expect(slug).toContain('padding-bottom: calc(var(--chat-fab-clearance) + 1.5rem)');
-    expect(slug).not.toContain('.earlier-case :global(.tldr-box)');
+    expect(slug).toContain('.earlier-case :global(.tldr-box)');
+    expect(slug).toContain('min-height: calc(100svh - var(--chat-fab-clearance))');
     expect(slug).not.toContain('.earlier-case :global(p)');
     expect(slug).not.toContain('.earlier-case :global(li)');
     expect(slug).not.toMatch(/\.earlier-case\s*\{[^}]*padding-right:/s);
+    expect(slug).not.toMatch(/\.earlier-case :global\(\.tldr-box\)\s*\{[^}]*padding-right:/s);
     expect(slug).not.toContain('mailto:');
     const copilots = readFileSync('src/content/work/ai-coding-copilots.md', 'utf8');
     const analytics = readFileSync('src/content/work/user-behavior-analytics.md', 'utf8');

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -194,17 +194,11 @@ const schema = entry
   }
 
   .earlier-case {
-    /* Phone: full-width readable copy. FAB clearance sits below the text, not a right column. */
+    /* Phone: full-width copy. Clearance below the case so last glyphs sit above the FAB.
+       Do not pad TL;DR/lists: that shoves the next paragraph into the FAB at load. */
     max-width: 100%;
     box-sizing: border-box;
-    padding-bottom: var(--chat-fab-clearance);
-  }
-
-  .earlier-case :global(.tldr-box),
-  .earlier-case :global(ul),
-  .earlier-case :global(ol) {
-    /* When TL;DR or a list sits in the FAB vertical band at load, keep glyphs above it. */
-    padding-bottom: var(--chat-fab-clearance);
+    padding-bottom: calc(var(--chat-fab-clearance) + 1.5rem);
   }
 
   .content > :global(* + *) {
@@ -267,10 +261,7 @@ const schema = entry
       padding-right: 0;
     }
 
-    .earlier-case,
-    .earlier-case :global(.tldr-box),
-    .earlier-case :global(ul),
-    .earlier-case :global(ol) {
+    .earlier-case {
       padding-bottom: 0;
     }
 

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -194,27 +194,17 @@ const schema = entry
   }
 
   .earlier-case {
-    /* Phone: body at load and when copy sits at the bottom of the viewport. */
+    /* Phone: full-width readable copy. FAB clearance sits below the text, not a right column. */
     max-width: 100%;
     box-sizing: border-box;
     padding-bottom: var(--chat-fab-clearance);
-    padding-right: var(--chat-fab-clearance);
   }
 
   .earlier-case :global(.tldr-box),
-  .earlier-case :global(p),
-  .earlier-case :global(li) {
-    padding-right: var(--chat-fab-clearance);
-  }
-
-  .earlier-case :global(.tldr-box) {
-    padding-bottom: var(--chat-fab-clearance);
-  }
-
   .earlier-case :global(ul),
   .earlier-case :global(ol) {
+    /* When TL;DR or a list sits in the FAB vertical band at load, keep glyphs above it. */
     padding-bottom: var(--chat-fab-clearance);
-    padding-right: var(--chat-fab-clearance);
   }
 
   .content > :global(* + *) {
@@ -279,12 +269,9 @@ const schema = entry
 
     .earlier-case,
     .earlier-case :global(.tldr-box),
-    .earlier-case :global(p),
-    .earlier-case :global(li),
     .earlier-case :global(ul),
     .earlier-case :global(ol) {
       padding-bottom: 0;
-      padding-right: 0;
     }
 
     .back-link {

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -194,11 +194,18 @@ const schema = entry
   }
 
   .earlier-case {
-    /* Phone: full-width copy. Clearance below the case so last glyphs sit above the FAB.
-       Do not pad TL;DR/lists: that shoves the next paragraph into the FAB at load. */
+    /* Phone: full-width copy. Extra bottom clearance for page end. No right inset. */
     max-width: 100%;
     box-sizing: border-box;
     padding-bottom: calc(var(--chat-fab-clearance) + 1.5rem);
+  }
+
+  .earlier-case :global(.tldr-box) {
+    /* Phone load: stretch TL;DR so the next paragraph starts below the FAB band.
+       Glyphs stay full width. Empty padding occupies the FAB, not body copy. */
+    box-sizing: border-box;
+    min-height: calc(100svh - var(--chat-fab-clearance));
+    padding-bottom: var(--chat-fab-clearance);
   }
 
   .content > :global(* + *) {
@@ -262,6 +269,11 @@ const schema = entry
     }
 
     .earlier-case {
+      padding-bottom: 0;
+    }
+
+    .earlier-case :global(.tldr-box) {
+      min-height: 0;
       padding-bottom: 0;
     }
 

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -175,7 +175,9 @@ const schema = entry
   }
 
   .content {
-    max-width: 65ch;
+    max-width: min(65ch, 100%);
+    width: 100%;
+    box-sizing: border-box;
     margin-inline: auto;
   }
 
@@ -192,14 +194,21 @@ const schema = entry
   }
 
   .earlier-case {
-    /* Phone: keep Earlier work body copy out of the fixed chat FAB band. */
+    /* Phone: body at load and when copy sits at the bottom of the viewport. */
+    max-width: 100%;
+    box-sizing: border-box;
     padding-bottom: var(--chat-fab-clearance);
     padding-right: var(--chat-fab-clearance);
   }
 
+  .earlier-case :global(.tldr-box),
   .earlier-case :global(p),
   .earlier-case :global(li) {
     padding-right: var(--chat-fab-clearance);
+  }
+
+  .earlier-case :global(.tldr-box) {
+    padding-bottom: var(--chat-fab-clearance);
   }
 
   .earlier-case :global(ul),
@@ -269,6 +278,7 @@ const schema = entry
     }
 
     .earlier-case,
+    .earlier-case :global(.tldr-box),
     .earlier-case :global(p),
     .earlier-case :global(li),
     .earlier-case :global(ul),

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -24,6 +24,14 @@ export async function getStaticPaths() {
 }
 
 const { entry } = Astro.props;
+const earlierCase =
+  !!entry &&
+  [
+    'ai-coding-copilots',
+    'user-behavior-analytics',
+    'master-thesis',
+    'lidkoping-stenhuggeri',
+  ].includes(entry.id);
 
 if (!entry) {
   Astro.response.status = 404;
@@ -118,7 +126,12 @@ const schema = entry
                   decoding="async"
                 />
               )}
-              <div class:list={['content', { 'ds-proof': entry.id === 'ifs-design-system' }]}>
+              <div
+                class:list={[
+                  'content',
+                  { 'ds-proof': entry.id === 'ifs-design-system', 'earlier-case': earlierCase },
+                ]}
+              >
                 {Content && <Content />}
               </div>
             </div>
@@ -174,6 +187,23 @@ const schema = entry
 
   .ds-proof :global(ul) {
     /* Phone: when Metrics sits at the bottom of the viewport, not only page end. */
+    padding-bottom: var(--chat-fab-clearance);
+    padding-right: var(--chat-fab-clearance);
+  }
+
+  .earlier-case {
+    /* Phone: keep Earlier work body copy out of the fixed chat FAB band. */
+    padding-bottom: var(--chat-fab-clearance);
+    padding-right: var(--chat-fab-clearance);
+  }
+
+  .earlier-case :global(p),
+  .earlier-case :global(li) {
+    padding-right: var(--chat-fab-clearance);
+  }
+
+  .earlier-case :global(ul),
+  .earlier-case :global(ol) {
     padding-bottom: var(--chat-fab-clearance);
     padding-right: var(--chat-fab-clearance);
   }
@@ -234,6 +264,15 @@ const schema = entry
     }
 
     .ds-proof :global(ul) {
+      padding-bottom: 0;
+      padding-right: 0;
+    }
+
+    .earlier-case,
+    .earlier-case :global(p),
+    .earlier-case :global(li),
+    .earlier-case :global(ul),
+    .earlier-case :global(ol) {
       padding-bottom: 0;
       padding-right: 0;
     }


### PR DESCRIPTION
## Summary
- On phone at 375, the chat FAB must not cover body copy on the four Earlier work cases: Internal AI coding copilots, User behavior analytics, Chalmers master's thesis, Lidköping Stenhuggeri.
- Not the IFS Design System case (#481). Copy unchanged. Hire path LinkedIn. Twin stays Live/Not live, not Available.

## Test plan
- [ ] ~375×812: open each of /work/ai-coding-copilots/, /work/user-behavior-analytics/, /work/master-thesis/, /work/lidkoping-stenhuggeri/. FAB must not cover body copy, including when that copy sits at the bottom of the viewport.
- [ ] /work/ifs-design-system/ unchanged by this PR (ds-proof from #481).
- [ ] Desktop ≥50em: no extra earlier-case padding.
- [ ] Chat header still Live / Not live. No Available. Hire path LinkedIn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile layout and spacing for selected earlier work case studies.
  * Ensured case study content fits within the viewport and leaves room for floating action controls.
  * Updated content sizing and TL;DR sections for better readability on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->