### PR TITLE
feat: drop gap-apology copy and say up to 2x / up to 30x

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -6,7 +6,7 @@ Title on this site is Product Manager, Developer Experience at IFS. Do not infla
 
 Education: Chalmers B.Sc. Software Engineering (2012–2015); Chalmers M.Sc. Management and Economics of Innovation (2015–2017). Eight years at IFS.
 
-The IFS Design System case is the only numbered proof (2x faster delivery, 30x ROI, Zeroheight runner-up). AI coding copilots is current DevEx work with no numbered proof. Other work pages are narrative; do not mint new metrics.
+The IFS Design System case: up to 2x faster delivery, up to 30x ROI, Zeroheight runner-up. Other work pages are narrative; do not mint new metrics.
 
 Recruiter keywords (not a fake title): Product Management, Developer Experience, DevEx, AI coding copilots, design systems, Industrial AI, IFS Cloud, platform, product strategy.
 
@@ -15,13 +15,13 @@ Recruiter keywords (not a fake title): Product Management, Developer Experience,
 - [Home](https://me.alehar.workers.dev/): Product Manager, Developer Experience at IFS. One design-system proof card. Get in touch goes to LinkedIn.
 - [Contact](https://me.alehar.workers.dev/contact/): Hire path. LinkedIn only.
 - [Work](https://me.alehar.workers.dev/work/): Work. IFS Design System is the only card, then earlier work. Not titled Strategic Portfolio.
-- [IFS Design System](https://me.alehar.workers.dev/work/ifs-design-system/): Numbered proof. 2x delivery, 30x ROI, Zeroheight runner-up.
+- [IFS Design System](https://me.alehar.workers.dev/work/ifs-design-system/): Numbered proof. up to 2x delivery, up to 30x ROI, Zeroheight runner-up.
 - [Biography](https://me.alehar.workers.dev/biography/): Experience timeline. Product Manager, Developer Experience at IFS. /about/ redirects here.
 
 ## Optional
 
-- [Internal AI coding copilots](https://me.alehar.workers.dev/work/ai-coding-copilots/): DevEx narrative. No numbered proof on this page.
-- [User behavior analytics](https://me.alehar.workers.dev/work/user-behavior-analytics/): Telemetry narrative. No numbered proof on this page.
+- [Internal AI coding copilots](https://me.alehar.workers.dev/work/ai-coding-copilots/): DevEx narrative.
+- [User behavior analytics](https://me.alehar.workers.dev/work/user-behavior-analytics/): Telemetry narrative.
 - [Lidköping Stenhuggeri](https://me.alehar.workers.dev/work/lidkoping-stenhuggeri/): Early Android work. Demoted.
 - [Chalmers master's thesis](https://me.alehar.workers.dev/work/master-thesis/): Chalmers, 2017. Earlier work, not an equal card.
 - [Latest updates](https://me.alehar.workers.dev/whats-new/): Changelog.

--- a/src/__tests__/chat-api.test.ts
+++ b/src/__tests__/chat-api.test.ts
@@ -107,8 +107,8 @@ describe('chat API', () => {
     expect(systemMessage.content).toContain('Greater Stockholm');
     expect(systemMessage.content).toContain('Eight years at IFS');
     expect(systemMessage.content).toContain('AI coding copilots is current DevEx work');
-    expect(systemMessage.content).toContain('2x faster delivery');
-    expect(systemMessage.content).toContain('30x ROI');
+    expect(systemMessage.content).toContain('up to 2x faster delivery');
+    expect(systemMessage.content).toContain('up to 30x ROI');
     expect(systemMessage.content).toContain('Zeroheight runner-up');
     expect(systemMessage.content).toContain('Write the digits 2 and 30');
     expect(systemMessage.content).not.toContain('Strategic Product Leader');
@@ -126,8 +126,8 @@ describe('chat API', () => {
     expect(response.status).toBe(200);
     expect(ai.run).not.toHaveBeenCalled();
     const body = await response.text();
-    expect(body).toContain('2x faster delivery');
-    expect(body).toContain('30x ROI');
+    expect(body).toContain('up to 2x faster delivery');
+    expect(body).toContain('up to 30x ROI');
     expect(body).toContain('Zeroheight runner-up');
     expect(body).toContain(DESIGN_SYSTEM_PROOF);
   });
@@ -144,8 +144,8 @@ describe('chat API', () => {
     const body = await response.text();
     expect(body).toContain('2x');
     expect(body).toContain('30x');
-    expect(body).toContain('2x faster delivery');
-    expect(body).toContain('30x ROI');
+    expect(body).toContain('up to 2x faster delivery');
+    expect(body).toContain('up to 30x ROI');
     expect(body).toContain('Zeroheight runner-up');
   });
 

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -43,8 +43,8 @@ describe('identity copy', () => {
     expect(bio).toContain(
       'Explore the professional journey of Alexander Härenstam, Product Manager, Developer Experience at IFS.'
     );
-    expect(twin).toContain('2x faster delivery');
-    expect(twin).toContain('30x ROI');
+    expect(twin).toContain('up to 2x faster delivery');
+    expect(twin).toContain('up to 30x ROI');
   });
 
   it('keeps spaces around TL;DR strong terms (Astro drops newline-only spaces)', () => {
@@ -112,8 +112,8 @@ describe('identity copy', () => {
     expect(slug).toContain('.ds-proof :global(ul)');
     expect(slug).toContain('padding-bottom: var(--chat-fab-clearance)');
     expect(slug).toContain('padding-right: var(--chat-fab-clearance)');
-    expect(ds).toContain('**2x faster**');
-    expect(ds).toContain('**30x ROI**');
+    expect(ds).toContain('**Up to 2x faster**');
+    expect(ds).toContain('**Up to 30x ROI**');
     expect(ds).toContain('**Zeroheight Design System Awards**');
   });
 

--- a/src/content/work/ifs-design-system.md
+++ b/src/content/work/ifs-design-system.md
@@ -17,20 +17,16 @@ IFS Cloud is IFS’s enterprise product platform. I was Product Manager for the 
 
 ## Problem
 
-Product teams needed a shared way to ship UI across Cloud. This site does not publish a detailed pre-system baseline. What it does record is the job the system was hired to do: faster feature delivery and a consistent experience across IFS Cloud.
+Product teams needed a shared way to ship UI across Cloud, for faster feature delivery and a consistent experience.
 
 ## Decisions and tradeoffs
 
 I treated the design system as a product: start from nothing, make it usable across Cloud, and keep it coherent enough to stand up in a public awards process.
 
-The specific tradeoffs (what we chose not to build, how we rolled it out, which source of truth we used) are not on this site. Until those are documented, they stay blank rather than invented after the fact.
-
 ## Metrics
 
-These are the only figures published on this site.
-
-- **2x faster** feature delivery
-- **30x ROI** on the initial investment
+- **Up to 2x faster** feature delivery
+- **Up to 30x ROI** on the initial investment
 - **Zeroheight Design System Awards** runner-up
 
 ## Outcome

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -92,9 +92,9 @@ const UNAVAILABLE = 'Chat is currently unavailable. Please try again later.';
 const systemPrompt = `You are Alexander Härenstam's digital twin. Speak in the first person as his twin.
 Current title: Product Manager, Developer Experience at IFS (Feb 2025-present, Greater Stockholm).
 Education: Chalmers B.Sc. Software Engineering; Chalmers M.Sc. Management and Economics of Innovation. Eight years at IFS.
-The IFS Design System case is the only numbered proof. When asked about it, answer with this exact proof: 2x faster delivery, 30x ROI, Zeroheight runner-up.
-Write the digits 2 and 30. Say twice as fast (2x) and thirty times ROI (30x). Never say "x faster" or "x ROI". Do not mint new ROI.
-AI coding copilots is current DevEx work with no numbered proof. Do not invent copilots metrics.
+When asked about the IFS Design System, answer with this exact proof: up to 2x faster delivery, up to 30x ROI, Zeroheight runner-up.
+Write the digits 2 and 30. Say up to twice as fast (up to 2x) and up to thirty times ROI (up to 30x). Never say "x faster" or "x ROI". Do not mint new ROI.
+AI coding copilots is current DevEx work. Do not invent copilots metrics.
 Hire path is LinkedIn only: https://www.linkedin.com/in/alehar/. Do not invent email, a résumé, or availability. Do not tell the UI to add a Get in touch button.
 Recruiter keywords (not a fake title): Product Management, Developer Experience, DevEx, AI coding copilots, design systems, Industrial AI, IFS Cloud, platform, product strategy.
 Keep answers brief (2-3 sentences). If asked something not in this prompt or the listed pages, say it is not on this site.

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -84,8 +84,8 @@ const schema = {
               <h3>Design systems, DevEx, and Industrial AI</h3>
               <p class="where">IFS Cloud</p>
               <p>
-                The <a href="/work/ifs-design-system/">IFS Design System</a> is the only numbered proof:
-                2x faster delivery, 30x ROI, Zeroheight runner-up.
+                The <a href="/work/ifs-design-system/">IFS Design System</a>:
+                up to 2x faster delivery, up to 30x ROI, Zeroheight runner-up.
               </p>
             </li>
             <li>

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -84,8 +84,8 @@ const schema = {
               <h3>Design systems, DevEx, and Industrial AI</h3>
               <p class="where">IFS Cloud</p>
               <p>
-                The <a href="/work/ifs-design-system/">IFS Design System</a>:
-                up to 2x faster delivery, up to 30x ROI, Zeroheight runner-up.
+                The <a href="/work/ifs-design-system/">IFS Design System</a>: up to 2x
+                faster delivery, up to 30x ROI, Zeroheight runner-up.
               </p>
             </li>
             <li>

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -84,8 +84,8 @@ const schema = {
               <h3>Design systems, DevEx, and Industrial AI</h3>
               <p class="where">IFS Cloud</p>
               <p>
-                The <a href="/work/ifs-design-system/">IFS Design System</a>: up to 2x
-                faster delivery, up to 30x ROI, Zeroheight runner-up.
+                The <a href="/work/ifs-design-system/">IFS Design System</a>: up to 2x faster
+                delivery, up to 30x ROI, Zeroheight runner-up.
               </p>
             </li>
             <li>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -103,9 +103,9 @@ const schema = {
         <p class="proof-eyebrow">IFS Design System</p>
         <p class="proof-outcome">Scaled from inception to IFS Cloud.</p>
         <p class="proof-chips">
-          <span>2x faster delivery</span>
+          <span>Up to 2x faster delivery</span>
           <span aria-hidden="true">·</span>
-          <span>30x ROI</span>
+          <span>Up to 30x ROI</span>
           <span aria-hidden="true">·</span>
           <span>Zeroheight runner-up</span>
         </p>

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -88,8 +88,7 @@ const schema = {
           <strong>TL;DR:</strong>
           {' '}<strong>Product Manager, Developer Experience</strong> at
           {' '}<strong>IFS</strong>. Work across <strong>Industrial AI</strong>,{' '}
-          <strong>Developer Experience (DevEx)</strong>, and <strong>design systems</strong>. The
-          IFS Design System case is the only numbered proof.
+          <strong>Developer Experience (DevEx)</strong>, and <strong>design systems</strong>.
         </p>
       </div>
       <Grid variant="offset">

--- a/src/utils/chat-logic.ts
+++ b/src/utils/chat-logic.ts
@@ -47,7 +47,7 @@ export function pruneMessages(messages: ChatMessage[]): ChatMessage[] {
 export const DESIGN_SYSTEM_CHIP = 'What did the IFS design system change?';
 
 export const DESIGN_SYSTEM_PROOF =
-  'The IFS Design System delivered 2x faster delivery and 30x ROI, and was a Zeroheight runner-up.';
+  'The IFS Design System delivered up to 2x faster delivery and up to 30x ROI, and was a Zeroheight runner-up.';
 
 export function groundedDesignSystemAnswer(lastUserMessage: string): string | null {
   const question = lastUserMessage.trim().toLowerCase();

--- a/src/utils/release-summary.ts
+++ b/src/utils/release-summary.ts
@@ -26,7 +26,7 @@ export function releaseSummaryPrompt(tag: string, notes: string): string {
   return `Write exactly three plain-English sentences for a hiring manager about this GitHub release.
 Say what a visitor can now see or do. Use only facts in the notes.
 Do not invent metrics, visitor counts, titles, or outcomes.
-The IFS Design System 2x faster delivery / 30x ROI line is allowed if the notes mention it.
+The IFS Design System up to 2x faster delivery / up to 30x ROI line is allowed if the notes mention it.
 Do not name agents, Palettes, Oracles, Scribes, Sentinels, Vantage, Bolt, or Jules.
 Do not include git SHAs, issue numbers, or feat/fix prefixes.
 No bullets, headings, or quotation marks around the whole answer.


### PR DESCRIPTION
## Summary
- Visitor-facing copy. Omit gap-apology sentences (nothing to insert, gaps stay blank, only figures).
- Soften published 2x/30x to up to, sitewide. No invented facts.
- Hire path LinkedIn. Title Product Manager, Developer Experience. Twin Live/Not live, not Available.

## Test plan
- [ ] /work/ifs-design-system/ has no 'only figures' / 'stay blank' / 'not on this site' apology. Metrics say Up to 2x / Up to 30x.
- [ ] Home chips: Up to 2x faster delivery, Up to 30x ROI.
- [ ] /biography and /work TL;DR do not say only numbered proof / only figures.
- [ ] Twin proof uses up to 2x / up to 30x. Still Live / Not live. LinkedIn hire path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated IFS Design System metrics to use “up to 2x faster delivery” and “up to 30x ROI.”
  * Applied consistent qualified wording across the homepage, work page, biography, and AI-assisted responses.
  * Simplified related case-study descriptions and removed outdated numbered-proof disclaimers.

* **Bug Fixes**
  * Updated automated checks and release-summary guidance to reflect the revised metric language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->