### PR TITLE
feat: rewrite Earlier work pages in visitor voice

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -155,10 +155,11 @@ describe('identity copy', () => {
     expect(lidkoping).toContain('title: Lidköping Stenhuggeri');
     expect(lidkoping).not.toContain('title: Lidköping Stenhuggeri App');
     expect(copilots).toContain('Internal AI coding copilots for');
-    expect(copilots).toContain('not a customer product');
+    expect(copilots).not.toContain('not a customer product');
+    expect(copilots).not.toContain('customer product');
     expect(copilots).not.toContain('multi-million');
     expect(analytics).toContain('Usage telemetry so');
-    expect(analytics).toContain('not a standalone platform product');
+    expect(analytics).not.toContain('not a standalone platform product');
     expect(analytics).not.toContain('User Behavior Analytics Platform');
     expect(analytics).not.toContain('Strategic Leadership');
     expect(thesis).toContain("Chalmers</strong> master's thesis, 2017");

--- a/src/content/work/ai-coding-copilots.md
+++ b/src/content/work/ai-coding-copilots.md
@@ -13,4 +13,4 @@ tags:
   <p><strong>TL;DR:</strong> Internal AI coding copilots for <strong>IFS</strong> engineering teams. I am <strong>Product Manager, Developer Experience</strong>.</p>
 </div>
 
-As Product Manager, Developer Experience at IFS, I work on internal AI coding copilots for engineering teams. This is tooling for people who already work at IFS, not a customer product.
+As Product Manager, Developer Experience at IFS, I work on internal AI coding copilots for engineering teams.

--- a/src/content/work/lidkoping-stenhuggeri.md
+++ b/src/content/work/lidkoping-stenhuggeri.md
@@ -13,4 +13,4 @@ tags:
   <p><strong>TL;DR:</strong> Early Android work, 2013, for <strong>Lidköping Stenhuggeri</strong>.</p>
 </div>
 
-An Android app I built in 2013 for a masonry firm in Lidköping so they could track jobs on site instead of on paper.
+In 2013 I built an Android app for Lidköping Stenhuggeri so they could track jobs on site instead of on paper.

--- a/src/content/work/master-thesis.md
+++ b/src/content/work/master-thesis.md
@@ -15,8 +15,8 @@ tags:
 
 Master's thesis at [Chalmers University of Technology](https://www.chalmers.se/en/) in 2017. It mapped what digitalization does to business models, studied one case, and compared that to the literature.
 
-1. Academically mapping out what it means to transform a business with the help of digitalization.
-2. Studying a specific business case where digitalization was part of changing the business model.
-3. Identifying the gap between what theory stipulates and the business case at hand.
+1. What digitalization does to a business model.
+2. A case where digitalization was part of changing the model.
+3. Where that case differed from the literature.
 
 Opportunities showed up as reach, scale, and data for decisions. Barriers were mostly organizational.

--- a/src/content/work/user-behavior-analytics.md
+++ b/src/content/work/user-behavior-analytics.md
@@ -13,4 +13,4 @@ tags:
   <p><strong>TL;DR:</strong> Usage telemetry so <strong>IFS Cloud</strong> roadmap decisions rest on how people actually use the product.</p>
 </div>
 
-At IFS I worked on user behavior analytics for IFS Cloud: capturing usage so product teams can see what customers actually do. It is telemetry, not a standalone platform product.
+At IFS I worked on user behavior analytics for IFS Cloud: capturing usage so product teams can see what customers actually do.


### PR DESCRIPTION
## Summary
- Visitor-facing rewrite of the four Earlier work case pages. No consultant frame, no gap-apology, no invented facts.
- Copilots, analytics, thesis, Lidköping. Hire path LinkedIn. Title Product Manager, Developer Experience.
- Twin Live/Not live unchanged. #482 left in bounce.

## Test plan
- [ ] Each of the four /work/… pages reads as a visitor page, not a note to Alexander about what is not a product.
- [ ] No new metrics. No email. No placeholder CV.
- [ ] Titles unchanged: Internal AI coding copilots, User behavior analytics, Chalmers master's thesis, Lidköping Stenhuggeri.