### PR TITLE
👩‍🚀 Prism: Add performant Northern Lights wave background canvas

### DIFF
--- a/.jules/prism.md
+++ b/.jules/prism.md
@@ -1,0 +1,8 @@
+# Prism Journal
+
+## 2026-03-31 - Northern Lights Mathematical Waves Canvas
+
+- **Garbage Collection & Lifecycle:** Canvas context loop attached to `requestAnimationFrame` and `resize` passive listener. Full cleanup teardown bound to Astro's `astro:before-swap` transition event with `{ once: true }` listener, releasing frame handles and event hooks.
+- **Performance & Reduced Motion:** Dynamic animation loop respects `prefers-reduced-motion: reduce`. When active or enabled, static rendered wave slices are drawn once without continuous animation loop ticks.
+- **Math Logic & Superposition:** Multi-layered wave rendering using `Math.sin(x * frequency + time * speed)` combined with harmonic cosine terms `Math.cos(x * frequency * 0.5 + time * speed * 0.7)` for smooth, organic light refractions with marine blue, cyan, and emerald gradient stops.
+- **Mobile Adaptive Scaling:** Canvas resolution dynamically bound to device pixel ratio capped at 2 (`Math.min(window.devicePixelRatio || 1, 2)`) with responsive canvas sizing based on parent container dimensions.

--- a/src/components/AuroraCanvas.astro
+++ b/src/components/AuroraCanvas.astro
@@ -1,0 +1,120 @@
+---
+// Lightweight, math-driven Northern Lights background canvas component
+---
+
+<div class="aurora-canvas-container" aria-hidden="true">
+  <canvas id="aurora-canvas"></canvas>
+</div>
+
+<script>
+  function initAuroraCanvas() {
+    const canvas = document.getElementById('aurora-canvas') as HTMLCanvasElement | null;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext('2d', { alpha: true });
+    if (!ctx) return;
+
+    let animationFrameId: number;
+    let width = 0;
+    let height = 0;
+    let time = 0;
+
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+    const resize = () => {
+      const parent = canvas.parentElement;
+      if (!parent) return;
+      const dpr = Math.min(window.devicePixelRatio || 1, 2);
+      width = parent.clientWidth;
+      height = parent.clientHeight;
+      canvas.width = width * dpr;
+      canvas.height = height * dpr;
+      ctx.scale(dpr, dpr);
+    };
+
+    const drawWave = (
+      offsetY: number,
+      amplitude: number,
+      frequency: number,
+      speed: number,
+      color: string
+    ) => {
+      ctx.beginPath();
+      ctx.moveTo(0, height);
+
+      for (let x = 0; x <= width; x += 15) {
+        const y =
+          offsetY +
+          Math.sin(x * frequency + time * speed) * amplitude +
+          Math.cos(x * frequency * 0.5 + time * speed * 0.7) * (amplitude * 0.5);
+        ctx.lineTo(x, y);
+      }
+
+      ctx.lineTo(width, height);
+      ctx.closePath();
+
+      const gradient = ctx.createLinearGradient(0, offsetY - amplitude, 0, height);
+      gradient.addColorStop(0, color);
+      gradient.addColorStop(1, 'rgba(0, 0, 0, 0)');
+
+      ctx.fillStyle = gradient;
+      ctx.fill();
+    };
+
+    const render = () => {
+      ctx.clearRect(0, 0, width, height);
+
+      if (!prefersReducedMotion.matches) {
+        time += 0.008;
+      }
+
+      // Layer 1: Deep Cyan / Marine wave
+      drawWave(height * 0.2, 35, 0.003, 1.2, 'rgba(0, 210, 255, 0.12)');
+
+      // Layer 2: Subtle Blue / Emerald wave superposition
+      drawWave(height * 0.35, 45, 0.002, 0.8, 'rgba(0, 150, 255, 0.09)');
+
+      // Layer 3: High Northern Lights glow
+      drawWave(height * 0.15, 25, 0.004, 1.5, 'rgba(100, 245, 220, 0.08)');
+
+      if (!prefersReducedMotion.matches) {
+        animationFrameId = requestAnimationFrame(render);
+      }
+    };
+
+    window.addEventListener('resize', resize, { passive: true });
+    resize();
+    render();
+
+    const cleanup = () => {
+      if (animationFrameId) {
+        cancelAnimationFrame(animationFrameId);
+      }
+      window.removeEventListener('resize', resize);
+    };
+
+    document.addEventListener('astro:before-swap', cleanup, { once: true });
+  }
+
+  // Initialize on Astro page load and view transitions
+  document.addEventListener('astro:page-load', initAuroraCanvas);
+</script>
+
+<style>
+  .aurora-canvas-container {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    overflow: hidden;
+    z-index: 0;
+  }
+
+  canvas {
+    display: block;
+    width: 100%;
+    height: 100%;
+    opacity: 0.85;
+  }
+</style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 // Learn about using Astro layouts:
 // https://docs.astro.build/en/basics/layouts/
 
+import AuroraCanvas from '../components/AuroraCanvas.astro';
 import Chat from '../components/Chat.astro';
 import Footer from '../components/Footer.astro';
 // Component Imports
@@ -26,6 +27,7 @@ const { title, description } = Astro.props;
 
     <div class="stack backgrounds">
       <div class="aurora" aria-hidden="true">
+        <AuroraCanvas />
         <span class="aurora-wash aurora-wash-a"></span>
         <span class="aurora-wash aurora-wash-b"></span>
       </div>


### PR DESCRIPTION
Injected a math-driven, 60fps HTML5 canvas component (`AuroraCanvas.astro`) into `BaseLayout.astro`. Features sine wave superposition with cyan/marine gradients, DPR scaling, `prefers-reduced-motion` compliance, and Astro page transition cleanup.

---
*PR created automatically by Jules for task [13441485644729365519](https://jules.google.com/task/13441485644729365519) started by @alehar9320*