### PR TITLE
feat: rewrite Biography in visitor voice

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -43,6 +43,10 @@ describe('identity copy', () => {
     expect(bio).toContain(
       'Explore the professional journey of Alexander Härenstam, Product Manager, Developer Experience at IFS.'
     );
+    expect(bio).not.toContain('No new numbered');
+    expect(bio).not.toContain('only numbered proof');
+    expect(bio.replace(/\s+/g, ' ')).toContain('up to 2x faster delivery');
+    expect(bio).toContain('up to 30x ROI');
     expect(twin).toContain('up to 2x faster delivery');
     expect(twin).toContain('up to 30x ROI');
   });

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -74,10 +74,7 @@ const schema = {
               <p class="when">Feb 2025 – present</p>
               <h3>Product Manager, Developer Experience</h3>
               <p class="where">IFS, Greater Stockholm</p>
-              <p>
-                Current work is Developer Experience, including AI coding copilots. No new numbered
-                metrics on that work.
-              </p>
+              <p>I work on Developer Experience at IFS, including internal AI coding copilots.</p>
             </li>
             <li>
               <p class="when">Eight years at IFS</p>

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -97,7 +97,7 @@ const schema = {
             </li>
           </ol>
           <p>
-            Get in touch on
+            Get in touch on{' '}
             <a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer"
               >LinkedIn</a
             >.


### PR DESCRIPTION
## Summary
- Visitor-facing Biography. No notes-to-self, no gap-apology, no invented facts.
- Current work line no longer says there are no metrics. IFS Design System uses up to 2x / up to 30x.
- Hire path LinkedIn. Title Product Manager, Developer Experience. Twin Live/Not live unchanged.

## Test plan
- [ ] /biography/ reads as a visitor page. No 'no new numbered metrics' / 'only numbered proof'.
- [ ] Timeline still: PM/DevEx, design systems/DevEx/Industrial AI, Chalmers M.Sc., Chalmers B.Sc.
- [ ] Get in touch is LinkedIn. No email.