### PR TITLE
feat: rewrite Contact in visitor voice

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -69,6 +69,10 @@ describe('identity copy', () => {
     expect(home).toContain('Get in touch');
     expect(cta).toContain('var(--chat-fab-clearance)');
     expect(cta).toContain('https://www.linkedin.com/in/alehar/');
+    expect(cta).toContain('Get in touch');
+    expect(cta).not.toContain('mailto:');
+    expect(cta).toContain('LinkedIn · replies from me');
+    expect(cta).not.toContain('high-impact');
   });
 
   it('keeps the chat FAB off Earlier work and the biography timeline on a phone', () => {
@@ -91,6 +95,9 @@ describe('identity copy', () => {
     expect(contact).toContain('https://www.linkedin.com/in/alehar/');
     expect(contact).toContain('Get in touch');
     expect(contact).not.toContain('mailto:');
+    expect(contact).toContain('Product Manager, Developer Experience');
+    expect(contact).not.toContain('Open to conversations');
+    expect(contact).toContain('LinkedIn · replies from me');
     expect(footer).toContain('padding: 3rem 2rem var(--chat-fab-clearance)');
   });
 

--- a/src/components/ContactCTA.astro
+++ b/src/components/ContactCTA.astro
@@ -4,7 +4,7 @@ import Icon from './Icon.astro';
 ---
 
 <aside>
-  <h2>Ready to collaborate on high-impact initiatives?</h2>
+  <h2>Get in touch on LinkedIn</h2>
   <div class="cta-stack">
     <CallToAction
       href="https://www.linkedin.com/in/alehar/"

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -12,9 +12,7 @@ const linkedinHref = 'https://www.linkedin.com/in/alehar/';
 >
   <main id="main-content" class="wrapper stack gap-8">
     <Hero title="Get in touch" align="start">
-      <p class="availability">
-        Product Manager, Developer Experience at IFS.
-      </p>
+      <p class="availability">Product Manager, Developer Experience at IFS.</p>
       <div class="actions">
         <CallToAction
           href={linkedinHref}

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -8,12 +8,12 @@ const linkedinHref = 'https://www.linkedin.com/in/alehar/';
 
 <BaseLayout
   title="Get in touch | Alexander Härenstam"
-  description="Open to conversations about product leadership, DevEx, and Industrial AI."
+  description="Product Manager, Developer Experience at IFS. Get in touch on LinkedIn."
 >
   <main id="main-content" class="wrapper stack gap-8">
     <Hero title="Get in touch" align="start">
       <p class="availability">
-        Open to conversations about product leadership, DevEx, and Industrial AI.
+        Product Manager, Developer Experience at IFS.
       </p>
       <div class="actions">
         <CallToAction


### PR DESCRIPTION
## Summary
- Visitor-facing Contact. Hire path LinkedIn only. No public email, no placeholder CV, no invented availability.
- Drop the high-impact consultant headline on ContactCTA. Title is Product Manager, Developer Experience.
- Keep LinkedIn · replies from me under Get in touch (same as Home). Twin Live/Not live unchanged. Chat stays demoted.

## Test plan
- [ ] /contact/ : Get in touch opens LinkedIn. No mailto. Hint is LinkedIn · replies from me.
- [ ] Sitewide ContactCTA headline is not high-impact initiatives.
- [ ] Phone FAB clearance CSS unchanged.