### PR TITLE
feat: rewrite IFS Design System page as a visitor PM story

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -115,6 +115,11 @@ describe('identity copy', () => {
     expect(ds).toContain('**Up to 2x faster**');
     expect(ds).toContain('**Up to 30x ROI**');
     expect(ds).toContain('**Zeroheight Design System Awards**');
+    expect(ds).toContain('Product Manager, Developer Experience');
+    expect(ds).not.toContain('This page is the proof');
+    expect(ds).not.toContain('Decisions and tradeoffs');
+    expect(ds).not.toContain('inception');
+    expect(ds).not.toContain('mailto:');
   });
 
   it('keeps only the IFS Design System on the main /work card grid', () => {

--- a/src/content/work/ifs-design-system.md
+++ b/src/content/work/ifs-design-system.md
@@ -4,24 +4,20 @@ publishDate: 2022-04-01 00:00:00
 img: /assets/stock-2.jpg
 img_alt: Design components
 description: |
-  Product work to take the IFS Design System from inception to IFS Cloud.
+  From the first version to IFS Cloud.
 tags:
   - Design System
   - Product Experience
   - Scaling
 ---
 
-## Context
+<div class="tldr-box">
+  <p><strong>TL;DR:</strong> The <strong>IFS Design System</strong>, from the first version to IFS Cloud. I am <strong>Product Manager, Developer Experience</strong>.</p>
+</div>
 
-IFS Cloud is IFS’s enterprise product platform. I was Product Manager for the design system that now sits under that platform. The work started at inception: there was no Cloud-scale system to inherit.
+As Product Manager, Developer Experience at IFS, I took the design system from the first version to IFS Cloud. IFS Cloud is IFS's enterprise product platform. There was no Cloud-scale system to inherit.
 
-## Problem
-
-Product teams needed a shared way to ship UI across Cloud, for faster feature delivery and a consistent experience.
-
-## Decisions and tradeoffs
-
-I treated the design system as a product: start from nothing, make it usable across Cloud, and keep it coherent enough to stand up in a public awards process.
+Product teams needed a shared way to ship UI across Cloud, so feature work could move faster and the experience stayed consistent.
 
 ## Metrics
 
@@ -29,6 +25,4 @@ I treated the design system as a product: start from nothing, make it usable acr
 - **Up to 30x ROI** on the initial investment
 - **Zeroheight Design System Awards** runner-up
 
-## Outcome
-
-The system now runs at IFS Cloud scale. Developers and designers use it to ship a consistent experience across the Cloud ecosystem. This page is the proof behind the homepage card.
+The system now runs at IFS Cloud scale. Developers and designers use it to ship a consistent experience across Cloud.


### PR DESCRIPTION
## Summary
- Visitor-facing PM story on /work/ifs-design-system/. Hire path LinkedIn only.
- Only published proof: up to 2x faster delivery, up to 30x ROI, Zeroheight Design System Awards runner-up.
- Drop consultant headings and the homepage-card note-to-self. Title Product Manager, Developer Experience. Twin Live/Not live unchanged.

## Test plan
- [ ] /work/ifs-design-system/ reads as a PM story for visitors, not a case-study template.
- [ ] Metrics list still shows Up to 2x / Up to 30x / Zeroheight runner-up.
- [ ] No mailto, no invented facts, no inception/gap-apology.
- [ ] Phone FAB clearance on the Metrics list unchanged (ds-proof).