### PR TITLE
feat: fold About into Biography as one visitor page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -39,6 +39,7 @@ const codecovPlugin = /** @type {import('vite').PluginOption} */ (
 export default defineConfig({
   redirects: {
     '/about': '/biography/',
+    '/about/': '/biography/',
   },
   output: isRender ? 'server' : 'static',
   server: isRender

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -39,7 +39,6 @@ const codecovPlugin = /** @type {import('vite').PluginOption} */ (
 export default defineConfig({
   redirects: {
     '/about': '/biography/',
-    '/about/': '/biography/',
   },
   output: isRender ? 'server' : 'static',
   server: isRender

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -40,11 +40,11 @@ describe('identity copy', () => {
     expect(bio).toContain('https://www.linkedin.com/in/alehar/');
     expect(bio).toContain('class="timeline"');
     expect(work).toContain('Product Manager, Developer Experience');
-    expect(bio).toContain(
-      'Explore the professional journey of Alexander Härenstam, Product Manager, Developer Experience at IFS.'
-    );
+    expect(bio).toContain('Product Manager, Developer Experience at IFS.');
+    expect(bio).not.toContain('Explore the professional journey');
     expect(bio).not.toContain('No new numbered');
     expect(bio).not.toContain('only numbered proof');
+    expect(bio).toContain("Get in touch on{' '}");
     expect(bio.replace(/\s+/g, ' ')).toContain('up to 2x faster delivery');
     expect(bio).toContain('up to 30x ROI');
     expect(twin).toContain('up to 2x faster delivery');
@@ -251,6 +251,8 @@ describe('identity copy', () => {
     expect(nav).not.toContain("href: '/about/'");
     expect(nav).toContain("href: '/biography/'");
     expect(astro).toContain("'/about': '/biography/'");
+    expect(astro).toContain("'/about/': '/biography/'");
+    expect(nav).not.toContain("'About'");
   });
   it('lets a Home share read Product Manager, Developer Experience at IFS', () => {
     const head = readFileSync('src/components/MainHead.astro', 'utf8');

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -251,7 +251,7 @@ describe('identity copy', () => {
     expect(nav).not.toContain("href: '/about/'");
     expect(nav).toContain("href: '/biography/'");
     expect(astro).toContain("'/about': '/biography/'");
-    expect(astro).toContain("'/about/': '/biography/'");
+    expect(astro).not.toContain("'/about/': '/biography/'");
     expect(nav).not.toContain("'About'");
   });
   it('lets a Home share read Product Manager, Developer Experience at IFS', () => {

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -32,8 +32,7 @@ const schema = {
       url: 'https://harenstam.com/biography/',
       name: 'Biography | Alexander Härenstam',
       about: { '@id': 'https://harenstam.com/#person' },
-      description:
-        'Explore the professional journey of Alexander Härenstam, Product Manager, Developer Experience at IFS.',
+      description: 'Product Manager, Developer Experience at IFS.',
       breadcrumb: {
         '@type': 'BreadcrumbList',
         itemListElement: [
@@ -58,7 +57,7 @@ const schema = {
 
 <BaseLayout
   title="Biography | Alexander Härenstam"
-  description="Explore the professional journey of Alexander Härenstam, Product Manager, Developer Experience at IFS."
+  description="Product Manager, Developer Experience at IFS."
 >
   <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
 


### PR DESCRIPTION
## Summary
- One visitor-facing Biography. Simple experience timeline from published facts only.
- /about and /about/ redirect to /biography/. Nav stays Biography, not About.
- Hire path LinkedIn only. Title Product Manager, Developer Experience. Twin Live/Not live unchanged. No notes-to-self, no invented facts.

## Test plan
- [ ] /biography/ is the only about/bio page. Timeline is visitor-facing.
- [ ] /about and /about/ redirect to /biography/.
- [ ] Get in touch on LinkedIn. No mailto. No “No new numbered metrics”.
- [ ] Up to 2x / up to 30x / Zeroheight stay as published proof.