### PR TITLE
feat: rewrite copilots page as a visitor PM story

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -157,6 +157,10 @@ describe('identity copy', () => {
     expect(copilots).toContain('Internal AI coding copilots for');
     expect(copilots).not.toContain('not a customer product');
     expect(copilots).not.toContain('customer product');
+    expect(copilots).toContain('Product Manager, Developer Experience');
+    expect(copilots).toContain('Greater Stockholm');
+    expect(copilots).not.toContain('mailto:');
+    expect(copilots).not.toContain('No new numbered');
     expect(copilots).not.toContain('multi-million');
     expect(analytics).toContain('Usage telemetry so');
     expect(analytics).not.toContain('not a standalone platform product');

--- a/src/content/work/ai-coding-copilots.md
+++ b/src/content/work/ai-coding-copilots.md
@@ -13,4 +13,4 @@ tags:
   <p><strong>TL;DR:</strong> Internal AI coding copilots for <strong>IFS</strong> engineering teams. I am <strong>Product Manager, Developer Experience</strong>.</p>
 </div>
 
-As Product Manager, Developer Experience at IFS, I work on internal AI coding copilots for engineering teams.
+As Product Manager, Developer Experience at IFS in Greater Stockholm, I work on internal AI coding copilots for engineering teams. I have been in this role since February 2025.


### PR DESCRIPTION
## Summary
- Visitor-facing PM story on /work/ai-coding-copilots/. Hire path LinkedIn only.
- Published facts only: internal copilots for IFS engineering, Product Manager, Developer Experience, Greater Stockholm, February 2025. Not a customer product. No new metrics.
- Twin Live/Not live unchanged. Chat stays demoted.

## Test plan
- [ ] /work/ai-coding-copilots/ reads as a PM story for visitors.
- [ ] No mailto, no invented metrics, no notes-to-self.
- [ ] Title stays Internal AI coding copilots.