### PR TITLE
feat: rewrite analytics page as a visitor PM story

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -162,6 +162,9 @@ describe('identity copy', () => {
     expect(analytics).not.toContain('not a standalone platform product');
     expect(analytics).not.toContain('User Behavior Analytics Platform');
     expect(analytics).not.toContain('Strategic Leadership');
+    expect(analytics).toContain('Product Manager, Developer Experience');
+    expect(analytics).not.toContain('mailto:');
+    expect(analytics).not.toContain('No new numbered');
     expect(thesis).toContain("Chalmers</strong> master's thesis, 2017");
     expect(lidkoping).toContain('Early Android work, 2013');
     expect(lidkoping).not.toContain('management platform');

--- a/src/content/work/user-behavior-analytics.md
+++ b/src/content/work/user-behavior-analytics.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 <div class="tldr-box">
-  <p><strong>TL;DR:</strong> Usage telemetry so <strong>IFS Cloud</strong> roadmap decisions rest on how people actually use the product.</p>
+  <p><strong>TL;DR:</strong> Usage telemetry so <strong>IFS Cloud</strong> roadmap decisions rest on how people actually use the product. I am <strong>Product Manager, Developer Experience</strong>.</p>
 </div>
 
-At IFS I worked on user behavior analytics for IFS Cloud: capturing usage so product teams can see what customers actually do.
+At IFS I worked on user behavior analytics for IFS Cloud: capturing usage so product teams can see what customers actually do. Roadmap decisions rest on that usage.


### PR DESCRIPTION
## Summary
- Visitor-facing PM story on /work/user-behavior-analytics/. Hire path LinkedIn only.
- Published facts only: usage telemetry for IFS Cloud roadmap decisions. Title Product Manager, Developer Experience. No new metrics. Not a platform product.
- Twin Live/Not live unchanged. Chat stays demoted.

## Test plan
- [ ] /work/user-behavior-analytics/ reads as a PM story for visitors.
- [ ] No mailto, no invented metrics, no Strategic Leadership, no Platform title.