### PR TITLE
feat: frame Lidköping as earlier work, not a PM case

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -165,6 +165,10 @@ describe('identity copy', () => {
     expect(thesis).toContain("Chalmers</strong> master's thesis, 2017");
     expect(lidkoping).toContain('Early Android work, 2013');
     expect(lidkoping).not.toContain('management platform');
+    expect(lidkoping).toContain('This is earlier work');
+    expect(lidkoping).toContain('/work/ifs-design-system/');
+    expect(lidkoping).not.toContain('Product Manager');
+    expect(lidkoping).not.toContain('mailto:');
     for (const page of [copilots, analytics, thesis, lidkoping]) {
       expect(page).not.toContain('stock-1.jpg');
       expect(page).not.toContain('stock-3.jpg');

--- a/src/content/work/lidkoping-stenhuggeri.md
+++ b/src/content/work/lidkoping-stenhuggeri.md
@@ -13,4 +13,4 @@ tags:
   <p><strong>TL;DR:</strong> Early Android work, 2013, for <strong>Lidköping Stenhuggeri</strong>.</p>
 </div>
 
-In 2013 I built an Android app for Lidköping Stenhuggeri so they could track jobs on site instead of on paper.
+This is earlier work. In 2013 I built an Android app for Lidköping Stenhuggeri so they could track jobs on site instead of on paper. The featured case is the [IFS Design System](/work/ifs-design-system/).


### PR DESCRIPTION
## Summary
- Visitors meet Lidköping Stenhuggeri as earlier work, not a featured PM case.
- Published facts only: early Android, 2013, jobs on site instead of paper. Featured case stays the IFS Design System.
- Hire path LinkedIn. No public email. No inflation. Twin Live/Not live unchanged.

## Test plan
- [ ] /work/lidkoping-stenhuggeri/ says earlier work and links the design-system case.
- [ ] No Product Manager framing on that page. No mailto. No management-platform language.
- [ ] Still off the main /work card grid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the Lidköping Stenhuggeri project description to identify it as earlier work.
  * Added a featured link to the IFS Design System case study.
  * Removed outdated role and email references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->