### PR TITLE
feat: frame the master's thesis as earlier work, not a PM case

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -163,6 +163,10 @@ describe('identity copy', () => {
     expect(analytics).not.toContain('User Behavior Analytics Platform');
     expect(analytics).not.toContain('Strategic Leadership');
     expect(thesis).toContain("Chalmers</strong> master's thesis, 2017");
+    expect(thesis).toContain('This is earlier work');
+    expect(thesis).toContain('/work/ifs-design-system/');
+    expect(thesis).not.toContain('Product Manager');
+    expect(thesis).not.toContain('mailto:');
     expect(lidkoping).toContain('Early Android work, 2013');
     expect(lidkoping).not.toContain('management platform');
     for (const page of [copilots, analytics, thesis, lidkoping]) {

--- a/src/content/work/master-thesis.md
+++ b/src/content/work/master-thesis.md
@@ -13,10 +13,10 @@ tags:
   <p><strong>TL;DR:</strong> <strong>Chalmers</strong> master's thesis, 2017, on business model innovation and digitalization.</p>
 </div>
 
-Master's thesis at [Chalmers University of Technology](https://www.chalmers.se/en/) in 2017. It mapped what digitalization does to business models, studied one case, and compared that to the literature.
+This is earlier work. Master's thesis at [Chalmers University of Technology](https://www.chalmers.se/en/) in 2017. It mapped what digitalization does to business models, studied one case, and compared that to the literature.
 
 1. What digitalization does to a business model.
 2. A case where digitalization was part of changing the model.
 3. Where that case differed from the literature.
 
-Opportunities showed up as reach, scale, and data for decisions. Barriers were mostly organizational.
+Opportunities showed up as reach, scale, and data for decisions. Barriers were mostly organizational. The featured case is the [IFS Design System](/work/ifs-design-system/).


### PR DESCRIPTION
## Summary
- Visitors meet the Chalmers master's thesis as earlier work, not a featured PM case.
- Published facts only: 2017, business model innovation and digitalization. Featured case stays the IFS Design System.
- Hire path LinkedIn. No public email. No inflation. Twin Live/Not live unchanged.

## Test plan
- [ ] /work/master-thesis/ says earlier work and links the design-system case.
- [ ] No Product Manager framing on that page. No mailto.
- [ ] Still off the main /work card grid.