### PR TITLE
fix: give Earlier work more bottom clearance from the FAB

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -125,6 +125,7 @@ describe('identity copy', () => {
     expect(slug).toContain('master-thesis');
     expect(slug).toContain('lidkoping-stenhuggeri');
     expect(slug).toContain('padding-bottom: calc(var(--chat-fab-clearance) + 2.5rem)');
+    expect(slug).toContain('.earlier-case :global(:last-child)');
     expect(slug).toContain('.earlier-case :global(.tldr-box)');
     expect(slug).toContain('min-height: calc(100svh - var(--chat-fab-clearance))');
     expect(slug).not.toContain('.earlier-case :global(p)');

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -124,8 +124,8 @@ describe('identity copy', () => {
     expect(slug).toContain('user-behavior-analytics');
     expect(slug).toContain('master-thesis');
     expect(slug).toContain('lidkoping-stenhuggeri');
-    expect(slug).toContain('padding-bottom: calc(var(--chat-fab-clearance) + 2.5rem)');
-    expect(slug).toContain('.earlier-case :global(:last-child)');
+    expect(slug).toContain('.earlier-case > :global(:last-child)::before');
+    expect(slug).toContain('float: right');
     expect(slug).toContain('.earlier-case :global(.tldr-box)');
     expect(slug).toContain('min-height: calc(100svh - var(--chat-fab-clearance))');
     expect(slug).not.toContain('.earlier-case :global(p)');

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -124,7 +124,7 @@ describe('identity copy', () => {
     expect(slug).toContain('user-behavior-analytics');
     expect(slug).toContain('master-thesis');
     expect(slug).toContain('lidkoping-stenhuggeri');
-    expect(slug).toContain('padding-bottom: calc(var(--chat-fab-clearance) + 1.5rem)');
+    expect(slug).toContain('padding-bottom: calc(var(--chat-fab-clearance) + 2.5rem)');
     expect(slug).toContain('.earlier-case :global(.tldr-box)');
     expect(slug).toContain('min-height: calc(100svh - var(--chat-fab-clearance))');
     expect(slug).not.toContain('.earlier-case :global(p)');

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -194,8 +194,14 @@ const schema = entry
   }
 
   .earlier-case {
-    /* Phone: full-width copy. Extra bottom clearance for page end. No right inset. */
+    /* Phone: full-width copy. No right inset. */
     max-width: 100%;
+    box-sizing: border-box;
+  }
+
+  .earlier-case :global(:last-child) {
+    /* When the last paragraph sits at the bottom of the 375 viewport, keep glyphs above the FAB.
+       Clearance lives on that paragraph, not as page-end footer whitespace. */
     box-sizing: border-box;
     padding-bottom: calc(var(--chat-fab-clearance) + 2.5rem);
   }
@@ -268,7 +274,7 @@ const schema = entry
       padding-right: 0;
     }
 
-    .earlier-case {
+    .earlier-case :global(:last-child) {
       padding-bottom: 0;
     }
 

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -197,7 +197,7 @@ const schema = entry
     /* Phone: full-width copy. Extra bottom clearance for page end. No right inset. */
     max-width: 100%;
     box-sizing: border-box;
-    padding-bottom: calc(var(--chat-fab-clearance) + 1.5rem);
+    padding-bottom: calc(var(--chat-fab-clearance) + 2.5rem);
   }
 
   .earlier-case :global(.tldr-box) {

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -199,11 +199,13 @@ const schema = entry
     box-sizing: border-box;
   }
 
-  .earlier-case :global(:last-child) {
-    /* When the last paragraph sits at the bottom of the 375 viewport, keep glyphs above the FAB.
-       Clearance lives on that paragraph, not as page-end footer whitespace. */
-    box-sizing: border-box;
-    padding-bottom: calc(var(--chat-fab-clearance) + 2.5rem);
+  .earlier-case > :global(:last-child)::before {
+    /* When the last body paragraph sits at the bottom of the 375 viewport, wrap glyphs around the FAB.
+       Container stays full width. Not page-end padding. Not a stacked right inset. */
+    content: '';
+    float: right;
+    width: var(--chat-fab-clearance);
+    height: var(--chat-fab-clearance);
   }
 
   .earlier-case :global(.tldr-box) {
@@ -274,8 +276,11 @@ const schema = entry
       padding-right: 0;
     }
 
-    .earlier-case :global(:last-child) {
-      padding-bottom: 0;
+    .earlier-case > :global(:last-child)::before {
+      content: none;
+      float: none;
+      width: 0;
+      height: 0;
     }
 
     .earlier-case :global(.tldr-box) {


### PR DESCRIPTION
## Summary
- Follow-up to live #482 (de61d4e / 5c5e3b9). Vera FAIL: bottom FAB overlap on copilots, analytics, Lidköping (4.7–9.5px). Thesis bottom was clear. Load and full-width stay.
- Extra page-end padding on \`.earlier-case\` (\`+2.5rem\` instead of \`+1.5rem\`). No right inset. No squeezed column.

## Test plan
- [ ] At 375, all four Earlier work pages: full-width copy, FAB off body at load, FAB off body at bottom.
- [ ] No one-word-per-line squeeze.