### PR TITLE
feat: make a Home share read Product Manager, Developer Experience at IFS

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -218,6 +218,22 @@ describe('identity copy', () => {
     expect(nav).toContain("href: '/biography/'");
     expect(astro).toContain("'/about': '/biography/'");
   });
+  it('lets a Home share read Product Manager, Developer Experience at IFS', () => {
+    const head = readFileSync('src/components/MainHead.astro', 'utf8');
+    const home = readFileSync('src/pages/index.astro', 'utf8');
+    const layout = readFileSync('src/layouts/BaseLayout.astro', 'utf8');
+    expect(home).toContain('ogTitle="Product Manager, Developer Experience at IFS"');
+    expect(home).toContain('description="Product Manager, Developer Experience at IFS."');
+    expect(home).toContain('Hero title="Product Manager, Developer Experience at IFS"');
+    expect(home).toContain('https://www.linkedin.com/in/alehar/');
+    expect(home).not.toContain('mailto:');
+    expect(layout).toContain('ogTitle={ogTitle}');
+    expect(head).toContain('content={shareTitle}');
+    expect(head).toContain('property="og:title"');
+    expect(head).not.toContain('Design systems, DevEx, and Industrial AI.');
+    expect(head).toContain("description = 'Product Manager, Developer Experience at IFS.'");
+  });
+
   it('grounds llms.txt with Chalmers education and recruiter keywords', () => {
     const llms = sources.find((s) => s.path.endsWith('llms.txt'))!.text;
     expect(llms).toContain('Chalmers B.Sc. Software Engineering');

--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -5,12 +5,15 @@ import PostHog from './PostHog.astro';
 interface Props {
   title?: string | undefined;
   description?: string | undefined;
+  ogTitle?: string | undefined;
 }
 
 const {
   title = 'Alexander Härenstam | Product Manager, Developer Experience',
-  description = 'Product Manager, Developer Experience at IFS. Design systems, DevEx, and Industrial AI.',
+  description = 'Product Manager, Developer Experience at IFS.',
+  ogTitle,
 } = Astro.props;
+const shareTitle = ogTitle ?? title;
 ---
 
 <meta charset="UTF-8" />
@@ -23,13 +26,13 @@ const {
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="website" />
 <meta property="og:url" content={Astro.url} />
-<meta property="og:title" content={title} />
+<meta property="og:title" content={shareTitle} />
 <meta property="og:image" content="https://harenstam.com/assets/portrait.png" />
 
 <!-- Twitter -->
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:url" content={Astro.url} />
-<meta name="twitter:title" content={title} />
+<meta name="twitter:title" content={shareTitle} />
 <meta name="twitter:description" content={description} />
 <meta name="twitter:image" content="https://harenstam.com/assets/portrait.png" />
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -11,14 +11,15 @@ import Nav from '../components/Nav.astro';
 interface Props {
   title?: string | undefined;
   description?: string | undefined;
+  ogTitle?: string | undefined;
 }
 
-const { title, description } = Astro.props;
+const { title, description, ogTitle } = Astro.props;
 ---
 
 <html lang="en">
   <head>
-    <MainHead title={title} description={description} />
+    <MainHead title={title} description={description} ogTitle={ogTitle} />
   </head>
   <body>
     <!-- Skip to content link for accessibility -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -66,6 +66,7 @@ const schema = {
 <BaseLayout
   title="Alexander Härenstam | Product Manager, Developer Experience"
   description="Product Manager, Developer Experience at IFS."
+  ogTitle="Product Manager, Developer Experience at IFS"
 >
   <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
   <main id="main-content" class="wrapper stack first-screen">


### PR DESCRIPTION
## Summary
- Open Graph and Twitter title on Home is the live H1: Product Manager, Developer Experience at IFS.
- Description matches live Home. No invented Design systems / DevEx / Industrial AI clause in the default meta description.
- Hire path LinkedIn. No public email. No placeholder CV.

## Test plan
- [ ] Sharing Home shows Product Manager, Developer Experience at IFS.
- [ ] Visible Home H1 and LinkedIn Get in touch unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated homepage sharing metadata with a clearer Open Graph title and description.
  * Improved social media previews by using a dedicated sharing title when provided.
  * Refined the default page description to remove outdated messaging.
* **Bug Fixes**
  * Corrected homepage title and description wiring so browser and social-sharing metadata display consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->