### PR TITLE
feat: let visitors clear the twin chat and drop the FAB portrait

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -116,6 +116,18 @@ describe('identity copy', () => {
     expect(chat).not.toContain('.chat-toggle .status-dot');
   });
 
+  it('lets a visitor clear the twin chat and keeps identity in the header, not the FAB', () => {
+    const chat = readFileSync('src/components/Chat.astro', 'utf8');
+    expect(chat).toContain('aria-label="Clear conversation"');
+    expect(chat).toContain('clearConversation');
+    expect(chat).toContain('chat-header-avatar');
+    expect(chat).toContain('Ask Alexander');
+    expect(chat).not.toContain('chat-toggle-portrait');
+    expect(chat).not.toContain('mailto:');
+    expect(chat).toContain("idle: 'Live'");
+    expect(chat).toContain("error: 'Not live'");
+  });
+
   it('keeps the chat FAB off the 2x/30x/Zeroheight proof on the design system case on a phone', () => {
     const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
     const ds = readFileSync('src/content/work/ifs-design-system.md', 'utf8');

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -11,7 +11,20 @@
     aria-controls="chat-window"
     aria-describedby="status-tooltip"
   >
-    <img src="/assets/portrait.png" alt="" class="chat-toggle-portrait" width="56" height="56" />
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"></path>
+    </svg>
     <span role="tooltip" id="status-tooltip" class="status-tooltip">Ask about the work</span>
   </button>
 
@@ -27,19 +40,24 @@
           </span>
         </span>
       </div>
-      <button id="chat-close" class="chat-close" aria-label="Close chat">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg
-        >
-      </button>
+      <div class="chat-header-actions">
+        <button type="button" id="chat-clear" class="chat-clear" aria-label="Clear conversation">
+          Clear
+        </button>
+        <button id="chat-close" class="chat-close" aria-label="Close chat">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg
+          >
+        </button>
+      </div>
     </div>
     <div id="status-announcer" class="sr-only" aria-live="polite" role="status"></div>
     <div id="chat-messages" class="chat-messages" aria-live="polite">
@@ -113,12 +131,9 @@
     -webkit-backdrop-filter: blur(16px);
   }
 
-  .chat-toggle-portrait {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    object-position: top;
-    border-radius: 50%;
+  .chat-toggle svg {
+    width: 1.5rem;
+    height: 1.5rem;
     display: block;
   }
 
@@ -293,6 +308,30 @@
     border-bottom: 1px solid var(--gray-800);
   }
 
+  .chat-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  .chat-clear {
+    background: none;
+    border: none;
+    color: var(--gray-400);
+    cursor: pointer;
+    padding: 0.25rem 0.4rem;
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 500;
+  }
+
+  .chat-clear:hover,
+  .chat-clear:focus-visible,
+  .chat-close:hover,
+  .chat-close:focus-visible {
+    color: var(--gray-0);
+  }
+
   .chat-close {
     background: none;
     border: none;
@@ -428,6 +467,7 @@
   const chatToggle = document.getElementById('chat-toggle');
   const chatWindow = document.getElementById('chat-window');
   const chatClose = document.getElementById('chat-close');
+  const chatClear = document.getElementById('chat-clear');
   const chatForm = document.getElementById('chat-form');
   const chatInput = document.getElementById('chat-input') as HTMLInputElement;
   const chatMessages = document.getElementById('chat-messages');
@@ -486,6 +526,15 @@
 
   function saveMessages() {
     sessionStorage.setItem('chat-history', JSON.stringify(messages));
+  }
+
+  function clearConversation() {
+    messages.splice(0, messages.length);
+    sessionStorage.removeItem('chat-history');
+    chatMessages?.querySelectorAll('.message:not(.welcome-message)').forEach((el) => el.remove());
+    chatSuggestions?.classList.remove('hidden');
+    setStatus('idle');
+    chatInput?.focus();
   }
 
   interface Message {
@@ -571,6 +620,10 @@
   chatClose?.addEventListener('click', () => {
     setChatExpanded(false);
     (chatToggle as HTMLElement)?.focus();
+  });
+
+  chatClear?.addEventListener('click', () => {
+    clearConversation();
   });
 
   document.addEventListener('keydown', (e) => {


### PR DESCRIPTION
## Summary
- Visitors can Clear the twin conversation. Welcome and suggestions come back. Focus stays on the input.
- FAB is a chat icon, not a second floating portrait. Header still has Ask Alexander, the avatar, and Live/Not live.
- Hire path LinkedIn. No public email. No invented facts.

## Test plan
- [ ] Open chat: header identity stays, FAB is not a photo, input is focused.
- [ ] Clear removes the thread and restores chips. Live/Not live unchanged.