### PR TITLE
feat: set the twin idle prompt to Ask about the work

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -123,6 +123,16 @@ describe('identity copy', () => {
     expect(chat).not.toContain('.chat-toggle .status-dot');
   });
 
+  it('keeps the twin idle prompt as Ask about the work', () => {
+    const chat = readFileSync('src/components/Chat.astro', 'utf8');
+    expect(chat).toContain('placeholder="Ask about the work"');
+    expect(chat).not.toContain('Ask me something');
+    expect(chat).not.toContain('chat-toggle-portrait');
+    expect(chat).not.toContain('mailto:');
+    expect(chat).toContain("idle: 'Live'");
+    expect(chat).toContain("error: 'Not live'");
+  });
+
   it('lets a visitor clear the twin chat and keeps identity in the header, not the FAB', () => {
     const chat = readFileSync('src/components/Chat.astro', 'utf8');
     expect(chat).toContain('aria-label="Clear conversation"');

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -82,7 +82,7 @@
       <input
         type="text"
         id="chat-input"
-        placeholder="Ask me something..."
+        placeholder="Ask about the work"
         required
         autocomplete="off"
       />


### PR DESCRIPTION
## Summary
- Twin input idle prompt is Ask about the work.
- FAB portrait stays off. Header identity and Live/Not live unchanged. Hire path LinkedIn.

## Test plan
- [ ] Closed and open chat: placeholder reads Ask about the work.
- [ ] FAB is still a chat icon, not a portrait.