### PR TITLE
feat: point LinkedIn share photos at the live portrait

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -123,6 +123,15 @@ describe('identity copy', () => {
     expect(chat).not.toContain('.chat-toggle .status-dot');
   });
 
+  it('points LinkedIn share photos at the live portrait, not a 404', () => {
+    const head = readFileSync('src/components/MainHead.astro', 'utf8');
+    expect(head).toContain("shareImage = 'https://me.alehar.workers.dev/assets/portrait.png'");
+    expect(head).toContain('property="og:image"');
+    expect(head).toContain('content={shareImage}');
+    expect(head).not.toContain('https://harenstam.com/assets/portrait.png');
+    expect(head).not.toContain('mailto:');
+  });
+
   it('keeps the twin idle prompt as Ask about the work', () => {
     const chat = readFileSync('src/components/Chat.astro', 'utf8');
     expect(chat).toContain('placeholder="Ask about the work"');

--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -14,6 +14,7 @@ const {
   ogTitle,
 } = Astro.props;
 const shareTitle = ogTitle ?? title;
+const shareImage = 'https://me.alehar.workers.dev/assets/portrait.png';
 ---
 
 <meta charset="UTF-8" />
@@ -27,14 +28,14 @@ const shareTitle = ogTitle ?? title;
 <meta property="og:type" content="website" />
 <meta property="og:url" content={Astro.url} />
 <meta property="og:title" content={shareTitle} />
-<meta property="og:image" content="https://harenstam.com/assets/portrait.png" />
+<meta property="og:image" content={shareImage} />
 
 <!-- Twitter -->
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:url" content={Astro.url} />
 <meta name="twitter:title" content={shareTitle} />
 <meta name="twitter:description" content={description} />
-<meta name="twitter:image" content="https://harenstam.com/assets/portrait.png" />
+<meta name="twitter:image" content={shareImage} />
 
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <link rel="icon" href="/favicon.ico" />


### PR DESCRIPTION
## Summary
- og:image and twitter:image use the live portrait at https://me.alehar.workers.dev/assets/portrait.png (200).
- Drop the harenstam.com image URL, which 404s. Same photo as the site. No invented image.

## Test plan
- [ ] LinkedIn preview of Home shows the portrait, not a broken image.