### PR TITLE
feat: point structured data at the live site

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -123,6 +123,17 @@ describe('identity copy', () => {
     expect(chat).not.toContain('.chat-toggle .status-dot');
   });
 
+  it('points structured data at the live site, not harenstam.com', () => {
+    const home = readFileSync('src/pages/index.astro', 'utf8');
+    expect(home).toContain("'@id': 'https://me.alehar.workers.dev/#person'");
+    expect(home).toContain("url: 'https://me.alehar.workers.dev/'");
+    expect(home).toContain("url: 'https://me.alehar.workers.dev/assets/portrait.png'");
+    expect(home).not.toContain('https://harenstam.com/');
+    expect(home).toContain('https://www.linkedin.com/in/alehar/');
+    expect(home).toContain('Product Manager, Developer Experience');
+    expect(home).not.toContain('mailto:');
+  });
+
   it('points LinkedIn share photos at the live portrait, not a 404', () => {
     const head = readFileSync('src/components/MainHead.astro', 'utf8');
     expect(head).toContain("shareImage = 'https://me.alehar.workers.dev/assets/portrait.png'");

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -8,12 +8,12 @@ const schema = {
   '@graph': [
     {
       '@type': 'Person',
-      '@id': 'https://harenstam.com/#person',
+      '@id': 'https://me.alehar.workers.dev/#person',
       name: 'Alexander Härenstam',
       jobTitle: 'Product Manager, Developer Experience',
       description:
         'Product Manager, Developer Experience at IFS. Design systems, DevEx, and Industrial AI.',
-      url: 'https://harenstam.com/',
+      url: 'https://me.alehar.workers.dev/',
       sameAs: ['https://www.linkedin.com/in/alehar/'],
       worksFor: {
         '@type': 'Organization',
@@ -28,10 +28,10 @@ const schema = {
     },
     {
       '@type': 'WebPage',
-      '@id': 'https://harenstam.com/biography/#webpage',
-      url: 'https://harenstam.com/biography/',
+      '@id': 'https://me.alehar.workers.dev/biography/#webpage',
+      url: 'https://me.alehar.workers.dev/biography/',
       name: 'Biography | Alexander Härenstam',
-      about: { '@id': 'https://harenstam.com/#person' },
+      about: { '@id': 'https://me.alehar.workers.dev/#person' },
       description: 'Product Manager, Developer Experience at IFS.',
       breadcrumb: {
         '@type': 'BreadcrumbList',
@@ -40,13 +40,13 @@ const schema = {
             '@type': 'ListItem',
             position: 1,
             name: 'Home',
-            item: 'https://harenstam.com/',
+            item: 'https://me.alehar.workers.dev/',
           },
           {
             '@type': 'ListItem',
             position: 2,
             name: 'Biography',
-            item: 'https://harenstam.com/biography/',
+            item: 'https://me.alehar.workers.dev/biography/',
           },
         ],
       },

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,12 +10,12 @@ const schema = {
   '@graph': [
     {
       '@type': 'Person',
-      '@id': 'https://harenstam.com/#person',
+      '@id': 'https://me.alehar.workers.dev/#person',
       name: 'Alexander Härenstam',
       jobTitle: 'Product Manager, Developer Experience',
       description:
         'Product Manager, Developer Experience at IFS. Design systems, DevEx, and Industrial AI.',
-      url: 'https://harenstam.com/',
+      url: 'https://me.alehar.workers.dev/',
       sameAs: [
         'https://www.linkedin.com/in/alehar/',
         'https://github.com/alehar9320',
@@ -41,22 +41,22 @@ const schema = {
     },
     {
       '@type': 'WebSite',
-      '@id': 'https://harenstam.com/#website',
-      url: 'https://harenstam.com/',
+      '@id': 'https://me.alehar.workers.dev/#website',
+      url: 'https://me.alehar.workers.dev/',
       name: 'Alexander Härenstam | Product Manager, Developer Experience',
-      publisher: { '@id': 'https://harenstam.com/#person' },
+      publisher: { '@id': 'https://me.alehar.workers.dev/#person' },
       description: 'Product Manager, Developer Experience at IFS.',
     },
     {
       '@type': 'WebPage',
-      '@id': 'https://harenstam.com/#webpage',
-      url: 'https://harenstam.com/',
+      '@id': 'https://me.alehar.workers.dev/#webpage',
+      url: 'https://me.alehar.workers.dev/',
       name: 'Alexander Härenstam | Product Manager, Developer Experience',
-      about: { '@id': 'https://harenstam.com/#person' },
+      about: { '@id': 'https://me.alehar.workers.dev/#person' },
       description: 'Product Manager, Developer Experience at IFS.',
       primaryImageOfPage: {
         '@type': 'ImageObject',
-        url: 'https://harenstam.com/assets/portrait.png',
+        url: 'https://me.alehar.workers.dev/assets/portrait.png',
       },
     },
   ],

--- a/src/pages/whats-new.astro
+++ b/src/pages/whats-new.astro
@@ -8,8 +8,8 @@ const schema = {
   '@graph': [
     {
       '@type': 'WebPage',
-      '@id': 'https://harenstam.com/whats-new/#webpage',
-      url: 'https://harenstam.com/whats-new/',
+      '@id': 'https://me.alehar.workers.dev/whats-new/#webpage',
+      url: 'https://me.alehar.workers.dev/whats-new/',
       name: "What's New | Alexander Härenstam",
       description:
         'A real-time log of project milestones, technical refinements, and portfolio updates.',
@@ -20,19 +20,19 @@ const schema = {
             '@type': 'ListItem',
             position: 1,
             name: 'Home',
-            item: 'https://harenstam.com/',
+            item: 'https://me.alehar.workers.dev/',
           },
           {
             '@type': 'ListItem',
             position: 2,
             name: "What's New",
-            item: 'https://harenstam.com/whats-new/',
+            item: 'https://me.alehar.workers.dev/whats-new/',
           },
         ],
       },
       publisher: {
         '@type': 'Person',
-        '@id': 'https://harenstam.com/#person',
+        '@id': 'https://me.alehar.workers.dev/#person',
         name: 'Alexander Härenstam',
       },
     },

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -27,8 +27,8 @@ const schema = {
   '@graph': [
     {
       '@type': 'WebPage',
-      '@id': 'https://harenstam.com/work/#webpage',
-      url: 'https://harenstam.com/work/',
+      '@id': 'https://me.alehar.workers.dev/work/#webpage',
+      url: 'https://me.alehar.workers.dev/work/',
       name: 'Work | Alexander Härenstam',
       description:
         'Product Manager, Developer Experience at IFS. The IFS Design System case, then earlier work.',
@@ -39,19 +39,19 @@ const schema = {
             '@type': 'ListItem',
             position: 1,
             name: 'Home',
-            item: 'https://harenstam.com/',
+            item: 'https://me.alehar.workers.dev/',
           },
           {
             '@type': 'ListItem',
             position: 2,
             name: 'Work',
-            item: 'https://harenstam.com/work/',
+            item: 'https://me.alehar.workers.dev/work/',
           },
         ],
       },
       publisher: {
         '@type': 'Person',
-        '@id': 'https://harenstam.com/#person',
+        '@id': 'https://me.alehar.workers.dev/#person',
         name: 'Alexander Härenstam',
       },
     },
@@ -65,7 +65,7 @@ const schema = {
         '@type': 'ListItem',
         position: index + 1,
         name: project.data.title,
-        url: `https://harenstam.com/work/${project.id}/`,
+        url: `https://me.alehar.workers.dev/work/${project.id}/`,
         description: project.data.description,
       })),
     },

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -46,8 +46,8 @@ const schema = entry
       '@graph': [
         {
           '@type': 'WebPage',
-          '@id': `https://harenstam.com/work/${entry.id}/#webpage`,
-          url: `https://harenstam.com/work/${entry.id}/`,
+          '@id': `https://me.alehar.workers.dev/work/${entry.id}/#webpage`,
+          url: `https://me.alehar.workers.dev/work/${entry.id}/`,
           name: `${entry.data.title} | Alexander Härenstam`,
           description: entry.data.description,
           breadcrumb: {
@@ -57,19 +57,19 @@ const schema = entry
                 '@type': 'ListItem',
                 position: 1,
                 name: 'Home',
-                item: 'https://harenstam.com/',
+                item: 'https://me.alehar.workers.dev/',
               },
               {
                 '@type': 'ListItem',
                 position: 2,
                 name: 'Work',
-                item: 'https://harenstam.com/work/',
+                item: 'https://me.alehar.workers.dev/work/',
               },
               {
                 '@type': 'ListItem',
                 position: 3,
                 name: entry.data.title,
-                item: `https://harenstam.com/work/${entry.id}/`,
+                item: `https://me.alehar.workers.dev/work/${entry.id}/`,
               },
             ],
           },
@@ -80,9 +80,9 @@ const schema = entry
           description: entry.data.description,
           datePublished: entry.data.publishDate.toISOString(),
           author: {
-            '@id': 'https://harenstam.com/#person',
+            '@id': 'https://me.alehar.workers.dev/#person',
           },
-          image: entry.data.img ? `https://harenstam.com${entry.data.img}` : undefined,
+          image: entry.data.img ? `https://me.alehar.workers.dev${entry.data.img}` : undefined,
           keywords: entry.data.tags.join(', '),
         },
       ],


### PR DESCRIPTION
## Summary
- JSON-LD Person, WebSite, and WebPage `@id`/`url` (Home, Work, Biography, What’s new, case pages) now use `https://me.alehar.workers.dev/`, the live origin.
- `primaryImageOfPage` and case images point at `https://me.alehar.workers.dev/assets/portrait.png` (and the matching live asset paths) instead of `https://harenstam.com/assets/portrait.png`, which 404s.
- Does not invent a custom domain. Does not change `og:url`. Hire path stays LinkedIn. Title stays Product Manager, Developer Experience.

## Test plan
- [ ] Home JSON-LD: Person/WebSite/WebPage `@id` and `url` are `https://me.alehar.workers.dev/…`
- [ ] Home `primaryImageOfPage` is `https://me.alehar.workers.dev/assets/portrait.png` (200)
- [ ] Work, Biography, What’s new, and case-page schema use the same origin
- [ ] `og:url` still `{Astro.url}` (this PR does not expand that)
- [ ] LinkedIn `sameAs` unchanged; no public email; no invented domain

Stay draft. Do not merge.