### PR TITLE
feat: point share URLs at the live site

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -143,6 +143,18 @@ describe('identity copy', () => {
     expect(head).not.toContain('mailto:');
   });
 
+  it('points share URLs at the live site, not localhost', () => {
+    const head = readFileSync('src/components/MainHead.astro', 'utf8');
+    expect(head).toContain("liveOrigin = 'https://me.alehar.workers.dev'");
+    expect(head).toContain('new URL(Astro.url.pathname, liveOrigin)');
+    expect(head).toContain('property="og:url"');
+    expect(head).toContain('name="twitter:url"');
+    expect(head).toContain('content={shareUrl}');
+    expect(head).not.toContain('content={Astro.url}');
+    expect(head).not.toContain('localhost');
+    expect(head).not.toContain('harenstam.com');
+  });
+
   it('keeps the twin idle prompt as Ask about the work', () => {
     const chat = readFileSync('src/components/Chat.astro', 'utf8');
     expect(chat).toContain('placeholder="Ask about the work"');

--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -15,6 +15,8 @@ const {
 } = Astro.props;
 const shareTitle = ogTitle ?? title;
 const shareImage = 'https://me.alehar.workers.dev/assets/portrait.png';
+const liveOrigin = 'https://me.alehar.workers.dev';
+const shareUrl = new URL(Astro.url.pathname, liveOrigin).href;
 ---
 
 <meta charset="UTF-8" />
@@ -26,13 +28,13 @@ const shareImage = 'https://me.alehar.workers.dev/assets/portrait.png';
 
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="website" />
-<meta property="og:url" content={Astro.url} />
+<meta property="og:url" content={shareUrl} />
 <meta property="og:title" content={shareTitle} />
 <meta property="og:image" content={shareImage} />
 
 <!-- Twitter -->
 <meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:url" content={Astro.url} />
+<meta name="twitter:url" content={shareUrl} />
 <meta name="twitter:title" content={shareTitle} />
 <meta name="twitter:description" content={description} />
 <meta name="twitter:image" content={shareImage} />


### PR DESCRIPTION
## Summary
- `og:url` and `twitter:url` were SSGing as `http://localhost:4321/...` because they used `{Astro.url}`.
- Point them at `https://me.alehar.workers.dev` while keeping each page's pathname (trailing slash included). Do not invent a custom domain.
- JSON-LD, `og:image` / `twitter:image`, hire copy, and page copy are untouched.

## Test plan
- [ ] Identity test: MainHead `og:url` and `twitter:url` use `https://me.alehar.workers.dev`, not `localhost`, not `harenstam.com`.
- [ ] After merge, Home HTML has `og:url` / `twitter:url` = `https://me.alehar.workers.dev/`.
- [ ] `/work/` and `/biography/` share URLs keep their pathnames (origin swap only).
- [ ] Hire CTA is still LinkedIn (`https://www.linkedin.com/in/alehar/`). Title stays Product Manager, Developer Experience.