### PR TITLE
feat: work-case share preview includes PM/DevEx and LinkedIn

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -311,6 +311,17 @@ describe('identity copy', () => {
     expect(astro).not.toContain("'/about/': '/biography/'");
     expect(nav).not.toContain("'About'");
   });
+  it('lets a work-case share read Product Manager, Developer Experience at IFS and LinkedIn', () => {
+    const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
+    expect(slug).toContain('${entry.data.title} | Product Manager, Developer Experience at IFS');
+    expect(slug).toContain('ogTitle={workOgTitle}');
+    expect(slug).toContain('Get in touch on LinkedIn.');
+    expect(slug).toContain("title={entry ? entry.data.title : 'Not Found'}");
+    expect(slug).toContain("'404 Error — this page was not found'");
+    expect(slug).not.toContain('mailto:');
+    expect(slug).not.toContain('harenstam.com');
+  });
+
   it('lets a Home share read Product Manager, Developer Experience at IFS', () => {
     const head = readFileSync('src/components/MainHead.astro', 'utf8');
     const home = readFileSync('src/pages/index.astro', 'utf8');

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -311,13 +311,12 @@ describe('identity copy', () => {
     expect(astro).not.toContain("'/about/': '/biography/'");
     expect(nav).not.toContain("'About'");
   });
+
   it('lets a work-case share read Product Manager, Developer Experience at IFS and LinkedIn', () => {
     const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
-    expect(slug).toContain('${entry.data.title} | Product Manager, Developer Experience at IFS');
-    expect(slug).toContain('ogTitle={workOgTitle}');
+    expect(slug).toContain('Product Manager, Developer Experience at IFS');
     expect(slug).toContain('Get in touch on LinkedIn.');
-    expect(slug).toContain("title={entry ? entry.data.title : 'Not Found'}");
-    expect(slug).toContain("'404 Error — this page was not found'");
+    expect(slug).toContain('ogTitle={shareTitle}');
     expect(slug).not.toContain('mailto:');
     expect(slug).not.toContain('harenstam.com');
   });

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -88,11 +88,21 @@ const schema = entry
       ],
     }
   : null;
+
+const workOgTitle = entry
+  ? `${entry.data.title} | Product Manager, Developer Experience at IFS`
+  : undefined;
+const workDescription = (() => {
+  if (!entry) return '404 Error — this page was not found';
+  const trimmed = entry.data.description.trim();
+  return /linkedin/i.test(trimmed) ? trimmed : `${trimmed} Get in touch on LinkedIn.`;
+})();
 ---
 
 <BaseLayout
   title={entry ? entry.data.title : 'Not Found'}
-  description={entry ? entry.data.description : '404 Error — this page was not found'}
+  ogTitle={workOgTitle}
+  description={workDescription}
 >
   {schema && <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />}
   {

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -89,20 +89,18 @@ const schema = entry
     }
   : null;
 
-const workOgTitle = entry
+const shareTitle = entry
   ? `${entry.data.title} | Product Manager, Developer Experience at IFS`
   : undefined;
-const workDescription = (() => {
-  if (!entry) return '404 Error — this page was not found';
-  const trimmed = entry.data.description.trim();
-  return /linkedin/i.test(trimmed) ? trimmed : `${trimmed} Get in touch on LinkedIn.`;
-})();
+const shareDescription = entry
+  ? `${entry.data.description.trim()} Get in touch on LinkedIn.`
+  : '404 Error — this page was not found';
 ---
 
 <BaseLayout
   title={entry ? entry.data.title : 'Not Found'}
-  ogTitle={workOgTitle}
-  description={workDescription}
+  description={shareDescription}
+  ogTitle={shareTitle}
 >
   {schema && <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />}
   {


### PR DESCRIPTION
## Summary
- Work-case share preview (`og:title` / `twitter:title` and share description) now includes Product Manager, Developer Experience at IFS and Get in touch on LinkedIn, not only the case name.
- One change in `src/pages/work/[...slug].astro` so every work case gets it. Document `<title>` and Hero H1 stay the case name.
- Do not invent facts. Leave JSON-LD, og:url, og:image, Home, and 2x/30x out of share tags.

## Test plan
- [ ] Identity test: work slug passes ogTitle with Product Manager, Developer Experience at IFS; description includes Get in touch on LinkedIn; no mailto; no harenstam.com
- [ ] `/work/ifs-design-system/` og:title is `IFS Design System | Product Manager, Developer Experience at IFS`
- [ ] `/work/ai-coding-copilots/` og:title is `Internal AI coding copilots | Product Manager, Developer Experience at IFS`
- [ ] Share description is the trimmed case description plus ` Get in touch on LinkedIn.`
- [ ] JSON-LD name/description, og:url, og:image, Home, 404 branch, and 2x/30x in OG are untouched