### PR TITLE
feat: work-case browser titles include PM/DevEx

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -321,6 +321,16 @@ describe('identity copy', () => {
     expect(slug).not.toContain('harenstam.com');
   });
 
+  it('lets a work-case browser title read Product Manager, Developer Experience at IFS', () => {
+    const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
+    expect(slug).toContain("title={shareTitle ?? 'Not Found'}");
+    expect(slug).toContain('ogTitle={shareTitle}');
+    expect(slug).toContain('<Hero title={entry.data.title}');
+    expect(slug).not.toContain("title={entry ? entry.data.title : 'Not Found'}");
+    expect(slug).not.toContain('mailto:');
+    expect(slug).not.toContain('harenstam.com');
+  });
+
   it('lets a Home share read Product Manager, Developer Experience at IFS', () => {
     const head = readFileSync('src/components/MainHead.astro', 'utf8');
     const home = readFileSync('src/pages/index.astro', 'utf8');

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -98,7 +98,7 @@ const shareDescription = entry
 ---
 
 <BaseLayout
-  title={entry ? entry.data.title : 'Not Found'}
+  title={shareTitle ?? 'Not Found'}
   description={shareDescription}
   ogTitle={shareTitle}
 >

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -97,11 +97,7 @@ const shareDescription = entry
   : '404 Error — this page was not found';
 ---
 
-<BaseLayout
-  title={shareTitle ?? 'Not Found'}
-  description={shareDescription}
-  ogTitle={shareTitle}
->
+<BaseLayout title={shareTitle ?? 'Not Found'} description={shareDescription} ogTitle={shareTitle}>
   {schema && <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />}
   {
     entry ? (


### PR DESCRIPTION
## Summary
- Work-case document `<title>` is `{case} | Product Manager, Developer Experience at IFS`, not only the case name.
- `og:title` is unchanged from #505. Hero H1 stays the case name. LinkedIn hire stays in the share description.
- Does not invent facts. Does not inflate the title. Does not touch JSON-LD, og:url, or og:image.

## Test plan
- [ ] `/work/ifs-design-system/` tab title is `IFS Design System | Product Manager, Developer Experience at IFS`
- [ ] `/work/ai-coding-copilots/` tab title is `Internal AI coding copilots | Product Manager, Developer Experience at IFS`
- [ ] `og:title` still matches #505
- [ ] Page H1 is still the case name
- [ ] Hire path LinkedIn; no public email

Stay draft. Do not merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated work-case browser titles to consistently display “Product Manager, Developer Experience at IFS.”
  * Preserved page descriptions and Open Graph titles for accurate previews when sharing work-case pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->