### PR TITLE
feat: add PM/DevEx to work-case share description

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -316,7 +316,11 @@ describe('identity copy', () => {
     const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
     expect(slug).toContain('Product Manager, Developer Experience at IFS');
     expect(slug).toContain('Get in touch on LinkedIn.');
+    expect(slug).toContain(
+      'Product Manager, Developer Experience at IFS. ${entry.data.description.trim()} Get in touch on LinkedIn.'
+    );
     expect(slug).toContain('ogTitle={shareTitle}');
+    expect(slug).toContain("title={shareTitle ?? 'Not Found'}");
     expect(slug).not.toContain('mailto:');
     expect(slug).not.toContain('harenstam.com');
   });

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -93,7 +93,7 @@ const shareTitle = entry
   ? `${entry.data.title} | Product Manager, Developer Experience at IFS`
   : undefined;
 const shareDescription = entry
-  ? `${entry.data.description.trim()} Get in touch on LinkedIn.`
+  ? `Product Manager, Developer Experience at IFS. ${entry.data.description.trim()} Get in touch on LinkedIn.`
   : '404 Error — this page was not found';
 ---
 


### PR DESCRIPTION
## Summary
- Work-case `og:description` now starts with Product Manager, Developer Experience at IFS, then the honest case lede, then Get in touch on LinkedIn.
- `og:title` and document `<title>` are unchanged from #505/#506. Hero H1 stays the case name.
- Does not invent facts. Does not inflate the title. Does not add 2x/30x. Does not touch JSON-LD, og:url, or og:image.

## Test plan
- [ ] `/work/ifs-design-system/` og:description includes Product Manager, Developer Experience at IFS and Get in touch on LinkedIn
- [ ] `/work/ai-coding-copilots/` same
- [ ] og:title and `<title>` still `{case} | Product Manager, Developer Experience at IFS`
- [ ] Hire path LinkedIn; no public email

Stay draft. Do not merge.