### PR TITLE
fix: keep the docked chat FAB off footer text at 375

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -111,6 +111,16 @@ describe('identity copy', () => {
     expect(contact).not.toContain('Open to conversations');
     expect(contact).toContain('LinkedIn · replies from me');
     expect(footer).toContain('padding: 3rem 2rem var(--chat-fab-clearance)');
+    expect(footer).toContain('padding-right: var(--chat-fab-clearance)');
+  });
+
+  it('keeps the docked chat FAB off footer body text at 375', () => {
+    const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    expect(footer).toContain('padding-right: var(--chat-fab-clearance)');
+    expect(footer).toContain('Stockholm');
+    expect(footer).toContain('Härenstam');
+    expect(footer).toContain('https://www.linkedin.com/in/alehar/');
+    expect(footer).not.toContain('mailto:');
   });
 
   it('shows a Live / Not live signal on the chat header', () => {

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -213,6 +213,7 @@ const currentYear = new Date().getFullYear();
     gap: 3rem;
     margin-top: auto;
     padding: 3rem 2rem var(--chat-fab-clearance);
+    padding-right: var(--chat-fab-clearance);
     text-align: center;
     color: var(--gray-400);
     font-size: var(--text-sm);


### PR DESCRIPTION
## Summary
- At 375, footer body copy (“Stockholm,” / “Härenstam”) sat under the docked chat FAB.
- Phone footer now uses `padding-right: var(--chat-fab-clearance)` so that text wraps clear of the FAB.
- Does not revert the conversational fold. Does not change the 1280 footer socials row (GitHub/Facebook). Hire stays LinkedIn.

## Test plan
- [ ] 375 Home, scroll to footer: “Stockholm,” and “Härenstam” are not under the FAB
- [ ] Fold still works (prominent then dock)
- [ ] 1280 footer socials unchanged unless this same padding happens to help
- [ ] Hire LinkedIn; no public email

Stay draft. Do not merge.