### PR TITLE
fix: keep the docked chat FAB off footer GitHub at 1280

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -113,6 +113,15 @@ describe('identity copy', () => {
     expect(footer).toContain('padding: 3rem 2rem var(--chat-fab-clearance)');
   });
 
+  it('keeps the docked chat FAB off the footer GitHub link at 1280', () => {
+    const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    expect(footer).toContain('padding: 2.5rem 5rem var(--chat-fab-clearance)');
+    expect(footer).toContain('padding-right: var(--chat-fab-clearance)');
+    expect(footer).toContain('https://github.com/alehar9320');
+    expect(footer).toContain('https://www.linkedin.com/in/alehar/');
+    expect(footer).not.toContain('mailto:');
+  });
+
   it('shows a Live / Not live signal on the chat header', () => {
     const chat = readFileSync('src/components/Chat.astro', 'utf8');
     expect(chat).toContain('chat-live-label');

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -393,7 +393,8 @@ const currentYear = new Date().getFullYear();
     footer {
       flex-direction: row;
       justify-content: space-between;
-      padding: 2.5rem 5rem;
+      padding: 2.5rem 5rem var(--chat-fab-clearance);
+      padding-right: var(--chat-fab-clearance);
     }
 
     .group {


### PR DESCRIPTION
## Summary
- At 1280, the docked chat FAB covered the footer GitHub link.
- Wide footer now uses `padding-right` and `padding-bottom: var(--chat-fab-clearance)`.
- Does not ship the withdrawn 375 clearance (#509 stays draft). Does not revert the conversational fold. Hire stays LinkedIn.

## Test plan
- [ ] 1280 Home, scroll to footer: GitHub link is not under the FAB
- [ ] Fold still works (prominent then dock)
- [ ] 375 footer unchanged vs #508 live
- [ ] Hire LinkedIn; no public email

Stay draft. Do not merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop footer spacing to keep the docked chat button clear of the GitHub link.
  * Preserved expected footer links and layout behavior across desktop widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->