### PR TITLE
feat: dock the twin to easy access on scroll

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -112,8 +112,10 @@ describe('identity copy', () => {
 
   it('keeps the docked chat FAB off the footer GitHub link at 1280', () => {
     const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    const global = readFileSync('src/styles/global.css', 'utf8');
     expect(footer).toContain('padding: 2.5rem 5rem var(--chat-fab-clearance)');
-    expect(footer).toContain('padding-right: var(--chat-fab-clearance)');
+    expect(footer).toContain('padding-right: var(--chat-dock-clearance)');
+    expect(global).toContain('--chat-dock-clearance');
     expect(footer).toContain('https://github.com/alehar9320');
     expect(footer).toContain('https://www.linkedin.com/in/alehar/');
     expect(footer).not.toContain('mailto:');
@@ -216,6 +218,10 @@ describe('identity copy', () => {
     expect(chat).not.toContain('harenstam.com');
     expect(chat).toContain('M7.9 20A9 9 0 1 0 4 16.1L2 22Z');
     expect(chat).not.toContain('chat-toggle-portrait');
+    expect(chat).toContain('chat-dock-avatar');
+    expect(chat).toContain('chat-dock-label');
+    expect(chat).toContain('chat-dock-label-rest');
+    expect(chat).toContain('Ask<span class="chat-dock-label-rest"> about the work</span>');
     expect(home).toContain('https://www.linkedin.com/in/alehar/');
     expect(home).toContain('Get in touch');
     expect(home).toContain('Hero title="Product Manager, Developer Experience at IFS"');

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -2,7 +2,7 @@
 
 ---
 
-<div id="chat-container" class="chat-container">
+<div id="chat-container" class="chat-container is-docked">
   <button
     id="chat-toggle"
     class="chat-toggle"
@@ -25,6 +25,9 @@
     >
       <path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"></path>
     </svg>
+    <img src="/assets/portrait.png" alt="" class="chat-dock-avatar" width="40" height="40" />
+    <span class="chat-dock-label">Ask<span class="chat-dock-label-rest"> about the work</span></span
+    >
     <span role="tooltip" id="status-tooltip" class="status-tooltip">Ask about the work</span>
   </button>
 
@@ -152,6 +155,57 @@
 
   .chat-container.is-prominent .chat-toggle {
     display: none;
+  }
+
+  .chat-dock-avatar,
+  .chat-dock-label {
+    display: none;
+  }
+
+  .chat-container.is-docked .chat-toggle {
+    width: auto;
+    min-width: var(--chat-fab-size);
+    height: var(--chat-fab-size);
+    padding: 0 0.85rem 0 0.35rem;
+    border-radius: 999px;
+    gap: 0.5rem;
+    justify-content: flex-start;
+  }
+
+  .chat-container.is-docked .chat-toggle svg {
+    display: none;
+  }
+
+  .chat-container.is-docked .chat-dock-avatar {
+    display: block;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    object-fit: cover;
+    object-position: top;
+    flex-shrink: 0;
+  }
+
+  .chat-container.is-docked .chat-dock-label {
+    display: block;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--gray-0);
+    white-space: nowrap;
+  }
+
+  .chat-container.is-docked .status-tooltip {
+    display: none;
+  }
+
+  .chat-container.is-docked:has(#chat-window:not(.hidden)) .chat-toggle {
+    display: none;
+  }
+
+  @media (max-width: 49.99em) {
+    .chat-dock-label-rest {
+      display: none;
+    }
   }
 
   /* Tooltip */
@@ -730,6 +784,7 @@
       dockChat();
       return;
     }
+    chatContainer.classList.remove('is-docked');
     chatContainer.classList.add('is-prominent');
     setChatExpanded(true);
     window.addEventListener(

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -394,7 +394,7 @@ const currentYear = new Date().getFullYear();
       flex-direction: row;
       justify-content: space-between;
       padding: 2.5rem 5rem var(--chat-fab-clearance);
-      padding-right: var(--chat-fab-clearance);
+      padding-right: var(--chat-dock-clearance);
     }
 
     .group {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -94,6 +94,8 @@
   --chat-fab-clearance: calc(
     var(--chat-fab-size) + var(--chat-fab-offset) + env(safe-area-inset-bottom, 0px) + 0.75rem
   );
+  /* Desktop docked launcher width (labeled Ask about the work), not a custom domain / not a second FAB portrait. */
+  --chat-dock-clearance: calc(13.5rem + var(--chat-fab-offset) + 0.75rem);
 }
 
 :root.theme-dark {


### PR DESCRIPTION
## Summary
- After the Home fold docks, the launcher is a labeled easy-access control (`Ask about the work`), not a round lucide FAB toggle.
- Phone keeps compact **Ask** so existing `--chat-fab-clearance` still protects 375 layouts. Desktop shows the full phrase; footer GitHub at 1280 uses `--chat-dock-clearance`.
- Not a redo of #508 conversational fold, #511 Home headshot-in-twin, or #510 375-vs-1280 beyond that one desktop footer `padding-right`.
- Hire stays LinkedIn: https://www.linkedin.com/in/alehar/. No public email. No invented facts.

## Test plan
- [ ] Home first-view still prominent; scroll/close docks to the labeled control
- [ ] Docked desktop: portrait + **Ask about the work**; lucide SVG stays in markup but hidden
- [ ] Phone dock shows **Ask** only; 375 hire/footer still clear
- [ ] Footer GitHub at 1280 clears the wider dock
- [ ] No `chat-toggle-portrait`; welcome portrait and header avatar unchanged
- [ ] Identity tests / Quality format:check

Stay draft. Do not merge until Nick freeze SHA + Johan PASS + Vera PASS.

Preview: Worker preview is typically `https://feat-dock-chat-easy-access-me.alehar.workers.dev/` once Cloudflare comments the deploy.