### PR TITLE
feat: make the twin the Home first-view

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -220,6 +220,12 @@ describe('identity copy', () => {
     expect(home).toContain('Get in touch');
     expect(home).toContain('Hero title="Product Manager, Developer Experience at IFS"');
     expect(home).not.toContain('mailto:');
+    expect(chat).toContain('has-prominent-chat');
+    expect(chat).toContain('min(32rem, calc(50vw - 2rem))');
+    expect(chat).toContain('max-height: 42dvh');
+    expect(home).toContain('body.has-prominent-chat');
+    expect(home).toContain('proof-card');
+    expect(home).toContain('Hero title="Product Manager, Developer Experience at IFS"');
   });
 
   it('keeps the chat FAB off the 2x/30x/Zeroheight proof on the design system case on a phone', () => {

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -222,7 +222,11 @@ describe('identity copy', () => {
     expect(home).not.toContain('mailto:');
     expect(chat).toContain('has-prominent-chat');
     expect(chat).toContain('min(32rem, calc(50vw - 2rem))');
-    expect(chat).toContain('max-height: 42dvh');
+    expect(chat).toContain('--prominent-phone-top');
+    expect(chat).toContain('layoutProminentPhone');
+    expect(chat).toContain('cta-hint');
+    expect(home).toContain('Get in touch');
+    expect(home).toContain('LinkedIn · replies from me');
     expect(home).toContain('body.has-prominent-chat');
     expect(home).toContain('proof-card');
     expect(home).toContain('Hero title="Product Manager, Developer Experience at IFS"');

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -329,7 +329,7 @@
 
   @media (max-width: 49.99em) {
     .chat-container.is-prominent {
-      top: auto;
+      top: var(--prominent-phone-top, 52dvh);
       bottom: var(--chat-fab-offset);
       right: var(--chat-fab-offset);
       left: var(--chat-fab-offset);
@@ -337,8 +337,8 @@
 
     .chat-container.is-prominent .chat-window {
       width: 100%;
-      height: min(22rem, 42dvh);
-      max-height: 42dvh;
+      height: 100%;
+      max-height: none;
       bottom: 0;
     }
   }
@@ -728,10 +728,30 @@
     return path === '/' || path === '' || path === '/index';
   }
 
+  function layoutProminentPhone() {
+    if (!chatContainer?.classList.contains('is-prominent')) {
+      chatContainer?.style.removeProperty('--prominent-phone-top');
+      return;
+    }
+    if (window.matchMedia('(min-width: 50em)').matches) {
+      chatContainer.style.removeProperty('--prominent-phone-top');
+      return;
+    }
+    const hire = document.querySelector('.cta-hint') || document.querySelector('.hero-actions');
+    if (!(hire instanceof HTMLElement)) return;
+    const gap = 12;
+    const minTwin = 10 * 16; // keep a usable twin
+    const bottomLimit = window.innerHeight - 8;
+    const belowHire = Math.ceil(hire.getBoundingClientRect().bottom + gap);
+    const top = Math.min(belowHire, bottomLimit - minTwin);
+    chatContainer.style.setProperty('--prominent-phone-top', `${Math.max(top, 0)}px`);
+  }
+
   function dockChat() {
     chatContainer?.classList.remove('is-prominent');
     chatContainer?.classList.add('is-docked');
     document.body.classList.remove('has-prominent-chat');
+    chatContainer?.style.removeProperty('--prominent-phone-top');
     setChatExpanded(false);
     sessionStorage.setItem(FOLD_DISMISSED_KEY, '1');
   }
@@ -762,6 +782,9 @@
     chatContainer.classList.add('is-prominent');
     setChatExpanded(true);
     document.body.classList.add('has-prominent-chat');
+    layoutProminentPhone();
+    requestAnimationFrame(layoutProminentPhone);
+    window.addEventListener('resize', layoutProminentPhone);
     window.addEventListener(
       'scroll',
       () => {

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -313,10 +313,34 @@
     backdrop-filter: blur(16px) saturate(180%);
   }
 
+  .chat-container.is-prominent {
+    top: 5.5rem;
+    right: var(--chat-fab-offset);
+    bottom: var(--chat-fab-offset);
+    left: auto;
+  }
+
   .chat-container.is-prominent .chat-window {
     bottom: 0;
-    width: min(28rem, calc(100vw - 2rem));
-    height: min(36rem, 70vh);
+    width: min(32rem, calc(50vw - 2rem));
+    height: calc(100dvh - 7rem);
+    max-height: calc(100dvh - 7rem);
+  }
+
+  @media (max-width: 49.99em) {
+    .chat-container.is-prominent {
+      top: auto;
+      bottom: var(--chat-fab-offset);
+      right: var(--chat-fab-offset);
+      left: var(--chat-fab-offset);
+    }
+
+    .chat-container.is-prominent .chat-window {
+      width: 100%;
+      height: min(22rem, 42dvh);
+      max-height: 42dvh;
+      bottom: 0;
+    }
   }
 
   @media (prefers-reduced-motion: no-preference) {
@@ -707,6 +731,7 @@
   function dockChat() {
     chatContainer?.classList.remove('is-prominent');
     chatContainer?.classList.add('is-docked');
+    document.body.classList.remove('has-prominent-chat');
     setChatExpanded(false);
     sessionStorage.setItem(FOLD_DISMISSED_KEY, '1');
   }
@@ -721,9 +746,13 @@
   }
 
   function initConversationalFold() {
-    if (!isHomePath() || !chatContainer) return;
+    if (!isHomePath() || !chatContainer) {
+      document.body.classList.remove('has-prominent-chat');
+      return;
+    }
     if (sessionStorage.getItem(FOLD_DISMISSED_KEY) === '1') {
       chatContainer.classList.add('is-docked');
+      document.body.classList.remove('has-prominent-chat');
       return;
     }
     if (window.scrollY > 160) {
@@ -732,6 +761,7 @@
     }
     chatContainer.classList.add('is-prominent');
     setChatExpanded(true);
+    document.body.classList.add('has-prominent-chat');
     window.addEventListener(
       'scroll',
       () => {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -244,7 +244,11 @@ const schema = {
 
   @media (max-width: 49.99em) {
     :global(body.has-prominent-chat) .first-screen {
-      padding-bottom: calc(min(22rem, 42dvh) + var(--chat-fab-offset) + 1rem);
+      padding-bottom: var(--chat-fab-offset);
+      gap: 0.75rem;
+    }
+    :global(body.has-prominent-chat) .hero-copy {
+      gap: 0.75rem;
     }
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -235,4 +235,16 @@ const schema = {
       padding: 2.5rem;
     }
   }
+
+  @media (min-width: 50em) {
+    :global(body.has-prominent-chat) .first-screen {
+      padding-right: min(34rem, 48vw);
+    }
+  }
+
+  @media (max-width: 49.99em) {
+    :global(body.has-prominent-chat) .first-screen {
+      padding-bottom: calc(min(22rem, 42dvh) + var(--chat-fab-offset) + 1rem);
+    }
+  }
 </style>


### PR DESCRIPTION
- Twin is the primary first-view on Home (large open panel), not a corner overlay / FAB
- LinkedIn hire stays: Get in touch https://www.linkedin.com/in/alehar/
- Phone panel is shorter so H1 + hire stay on screen
- #508 fold/dock, #511 headshot, #510 footer clearance stand
- Stay draft. Do not merge until Nick freeze + Johan PASS + Vera PASS