### PR TITLE
feat: add live rel=canonical for search and shares

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -156,6 +156,8 @@ describe('identity copy', () => {
     expect(head).toContain('property="og:url"');
     expect(head).toContain('name="twitter:url"');
     expect(head).toContain('content={shareUrl}');
+    expect(head).toContain('rel="canonical"');
+    expect(head).toContain('href={shareUrl}');
     expect(head).not.toContain('content={Astro.url}');
     expect(head).not.toContain('localhost');
     expect(head).not.toContain('harenstam.com');

--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -29,6 +29,7 @@ const shareUrl = new URL(Astro.url.pathname, liveOrigin).href;
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="website" />
 <meta property="og:url" content={shareUrl} />
+<link rel="canonical" href={shareUrl} />
 <meta property="og:title" content={shareTitle} />
 <meta property="og:image" content={shareImage} />
 


### PR DESCRIPTION
- Adds `<link rel="canonical">` using the existing live origin + pathname (`https://me.alehar.workers.dev/…`)
- Home currently has no canonical
- Does not redo og:url / JSON-LD
- Hire LinkedIn https://www.linkedin.com/in/alehar/
- Stay draft. Do not merge until Nick freeze + Johan PASS + Vera PASS
- #512 stays closed