### PR TITLE
feat: add a live sitemap for search

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const files = [
@@ -415,5 +415,20 @@ describe('identity copy', () => {
     expect(llms).toContain('Greater Stockholm');
     expect(llms).toContain('AI coding copilots');
     expect(llms).toContain('IFS Cloud');
+  });
+
+  it('ships a live sitemap at /sitemap.xml so search can find the pages', () => {
+    expect(existsSync('src/pages/sitemap.xml.ts')).toBe(true);
+    const sitemap = readFileSync('src/pages/sitemap.xml.ts', 'utf8');
+    expect(sitemap).toContain('https://me.alehar.workers.dev');
+    expect(sitemap).toContain("liveOrigin = 'https://me.alehar.workers.dev'");
+    expect(sitemap).toContain("'/'");
+    expect(sitemap).toContain("'/work/'");
+    expect(sitemap).toContain("'/biography/'");
+    expect(sitemap).toContain("'/contact/'");
+    expect(sitemap).toContain('ifs-design-system');
+    expect(sitemap).not.toContain('localhost');
+    expect(sitemap).not.toContain('harenstam.com');
+    expect(sitemap).not.toContain('mailto:');
   });
 });

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,0 +1,51 @@
+import type { APIRoute } from 'astro';
+import { getCollection } from 'astro:content';
+
+export const prerender = true;
+
+const liveOrigin = 'https://me.alehar.workers.dev';
+
+const staticPaths = [
+  '/',
+  '/work/',
+  '/biography/',
+  '/contact/',
+  '/whats-new',
+  '/experimental/manifesto/',
+  '/experimental/now/',
+  '/experimental/reading-list/',
+];
+
+function loc(path: string) {
+  return `${liveOrigin}${path}`;
+}
+
+function lastmod(date: Date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function urlXml(path: string, date?: Date) {
+  const lastmodTag = date ? `\n    <lastmod>${lastmod(date)}</lastmod>` : '';
+  return `  <url>\n    <loc>${loc(path)}</loc>${lastmodTag}\n  </url>`;
+}
+
+export const GET: APIRoute = async () => {
+  // Work loc is /work/<entry.id>/ matching [...slug].astro (e.g. /work/ifs-design-system/).
+  const work = await getCollection('work');
+  const urls = [
+    ...staticPaths.map((path) => urlXml(path)),
+    ...work.map((entry) => urlXml(`/work/${entry.id}/`, entry.data.publishDate)),
+  ];
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls.join('\n')}
+</urlset>
+`;
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/xml; charset=utf-8',
+    },
+  });
+};


### PR DESCRIPTION
- Adds /sitemap.xml (was 404)
- All loc URLs are https://me.alehar.workers.dev/…
- Hire LinkedIn
- Stay draft until Nick freeze + Johan PASS + Vera PASS
- #512 stays closed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a prerendered XML sitemap covering key site pages and published work.
  * Sitemap entries include publication dates when available.
  * Added safeguards to ensure sitemap links use the production domain and exclude invalid references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->