### PR TITLE
fix: drop sitemap URLs that 404

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -427,6 +427,7 @@ describe('identity copy', () => {
     expect(sitemap).toContain("'/biography/'");
     expect(sitemap).toContain("'/contact/'");
     expect(sitemap).toContain('ifs-design-system');
+    expect(sitemap).not.toContain('/experimental/manifesto');
     expect(sitemap).not.toContain('localhost');
     expect(sitemap).not.toContain('harenstam.com');
     expect(sitemap).not.toContain('mailto:');

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -11,7 +11,6 @@ const staticPaths = [
   '/biography/',
   '/contact/',
   '/whats-new',
-  '/experimental/manifesto/',
   '/experimental/now/',
   '/experimental/reading-list/',
 ];


### PR DESCRIPTION
- Live sitemap listed /experimental/manifesto/ which 404s
- Removed only locs that 404; remaining URLs stay https://me.alehar.workers.dev
- Hire LinkedIn; no invented facts
- Does not touch #520 or #512
- Stay draft until Johan PASS + Vera PASS