### PR TITLE
fix: drop experimental pages from the sitemap

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -428,6 +428,8 @@ describe('identity copy', () => {
     expect(sitemap).toContain("'/contact/'");
     expect(sitemap).toContain('ifs-design-system');
     expect(sitemap).not.toContain('/experimental/manifesto');
+    expect(sitemap).not.toContain('/experimental/now');
+    expect(sitemap).not.toContain('/experimental/reading-list');
     expect(sitemap).not.toContain('localhost');
     expect(sitemap).not.toContain('harenstam.com');
     expect(sitemap).not.toContain('mailto:');

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -5,15 +5,7 @@ export const prerender = true;
 
 const liveOrigin = 'https://me.alehar.workers.dev';
 
-const staticPaths = [
-  '/',
-  '/work/',
-  '/biography/',
-  '/contact/',
-  '/whats-new',
-  '/experimental/now/',
-  '/experimental/reading-list/',
-];
+const staticPaths = ['/', '/work/', '/biography/', '/contact/', '/whats-new'];
 
 function loc(path: string) {
   return `${liveOrigin}${path}`;


### PR DESCRIPTION
- Live sitemap still lists /experimental/now/ and /experimental/reading-list/
- Dropped those locs only; pages not deleted
- Remaining URLs stay https://me.alehar.workers.dev
- Hire LinkedIn
- Does not touch #521 or #512
- Stay draft until Johan PASS + Vera PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the sitemap to list only the currently supported public pages.
  - Removed experimental “Now” and “Reading List” pages from sitemap results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->