### PR TITLE
feat: rewrite What’s New for visitors

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -525,4 +525,21 @@ describe('identity copy', () => {
     expect(now).not.toContain('<strong>Status:</strong>');
     expect(now).not.toContain('high-impact');
   });
+
+  it('rewrites What’s New for visitors, not a project log', () => {
+    const page = readFileSync('src/pages/whats-new.astro', 'utf8');
+    const cta = readFileSync('src/components/ContactCTA.astro', 'utf8');
+    expect(page).not.toContain('A real-time log of project milestones');
+    expect(page).toContain('A public changelog of this site.');
+    expect(page).toContain('Product Manager, Developer Experience');
+    expect(page).toContain('ContactCTA');
+    expect(page).not.toContain('mailto:');
+    expect(page).not.toContain('this is not on the site');
+    expect(page).not.toContain("this isn't on the site yet");
+    expect(page).not.toContain('stay blank rather than invented');
+    expect(cta).toContain('https://www.linkedin.com/in/alehar/');
+    expect(cta).toContain('Get in touch');
+    expect(cta).toContain('LinkedIn · replies from me');
+    expect(cta).not.toContain('mailto:');
+  });
 });

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -1,6 +1,8 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
+import { toVisitorChangelogTitle } from '../utils/visitor-changelog';
+
 const files = [
   'src/pages/biography.astro',
   'src/pages/work.astro',
@@ -531,7 +533,10 @@ describe('identity copy', () => {
     const cta = readFileSync('src/components/ContactCTA.astro', 'utf8');
     expect(page).not.toContain('A real-time log of project milestones');
     expect(page).toContain('A public changelog of this site.');
+    expect(page).toContain('title="What\'s New | Product Manager, Developer Experience at IFS"');
+    expect(page).toContain('ogTitle="What\'s New | Product Manager, Developer Experience at IFS"');
     expect(page).toContain('Product Manager, Developer Experience');
+    expect(page).toContain('toVisitorChangelogTitle');
     expect(page).toContain('ContactCTA');
     expect(page).not.toContain('mailto:');
     expect(page).not.toContain('this is not on the site');
@@ -541,5 +546,17 @@ describe('identity copy', () => {
     expect(cta).toContain('Get in touch');
     expect(cta).toContain('LinkedIn · replies from me');
     expect(cta).not.toContain('mailto:');
+    expect(
+      toVisitorChangelogTitle('41fe7ae feat: rewrite /experimental/now/ for visitors (#523)')
+    ).toBe('Now page rewritten for visitors');
+    expect(
+      toVisitorChangelogTitle('feat: rewrite /experimental/now/ for visitors (#523)')
+    ).not.toContain('feat: rewrite /experimental/now/');
+    expect(toVisitorChangelogTitle('feat: add a live RSS feed for the work (#520)')).toBe(
+      'RSS feed for the work'
+    );
+    expect(toVisitorChangelogTitle('fix: drop sitemap URLs that 404 (#521)')).toBe(
+      'Sitemap no longer lists pages that 404'
+    );
   });
 });

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-import { toVisitorChangelogTitle } from '../utils/visitor-changelog';
+import { toVisitorChangelogTitle, toVisitorRelease } from '../utils/visitor-changelog';
 
 const files = [
   'src/pages/biography.astro',
@@ -537,6 +537,7 @@ describe('identity copy', () => {
     expect(page).toContain('ogTitle="What\'s New | Product Manager, Developer Experience at IFS"');
     expect(page).toContain('Product Manager, Developer Experience');
     expect(page).toContain('toVisitorChangelogTitle');
+    expect(page).toContain('toVisitorRelease');
     expect(page).toContain('ContactCTA');
     expect(page).not.toContain('mailto:');
     expect(page).not.toContain('this is not on the site');
@@ -550,13 +551,104 @@ describe('identity copy', () => {
       toVisitorChangelogTitle('41fe7ae feat: rewrite /experimental/now/ for visitors (#523)')
     ).toBe('Now page rewritten for visitors');
     expect(
+      toVisitorChangelogTitle('41fe7ae feat: rewrite /experimental/now/ for visitors (#523)')
+    ).not.toMatch(/41fe7ae|feat:|\(#523\)/);
+    expect(
       toVisitorChangelogTitle('feat: rewrite /experimental/now/ for visitors (#523)')
     ).not.toContain('feat: rewrite /experimental/now/');
     expect(toVisitorChangelogTitle('feat: add a live RSS feed for the work (#520)')).toBe(
-      'RSS feed for the work'
+      'RSS feed of the work'
     );
     expect(toVisitorChangelogTitle('fix: drop sitemap URLs that 404 (#521)')).toBe(
       'Sitemap no longer lists pages that 404'
     );
+
+    const api = readFileSync('src/pages/api/releases.ts', 'utf8');
+    expect(api).toContain('toVisitorChangelogTitle');
+    expect(api).toContain('toVisitorRelease');
+
+    const rawNow = '- 41fe7ae feat: rewrite /experimental/now/ for visitors (#523)';
+    const visitorNow = toVisitorRelease({
+      body: rawNow,
+      publishedAt: '2026-08-16T21:12:02Z',
+      title: '2026.08.16.2111',
+      url: 'https://github.com/alehar9320/astro-cloudflare-personal-website/releases/tag/2026.08.16.2111',
+      version: '2026.08.16.2111',
+    });
+    expect(visitorNow.body).toBe('- Now page rewritten for visitors');
+    expect(visitorNow.body).not.toMatch(/41fe7ae|feat:|\(#523\)/);
+    expect(visitorNow.publishedAt).toBe('2026-08-16T21:12:02Z');
+    expect(visitorNow.url).toContain('/releases/tag/2026.08.16.2111');
+
+    const liveNames: Array<[string, string]> = [
+      [
+        '41fe7ae feat: rewrite /experimental/now/ for visitors (#523)',
+        'Now page rewritten for visitors',
+      ],
+      [
+        '8491e97 fix: drop experimental pages from the sitemap (#522)',
+        'Experimental pages removed from the sitemap',
+      ],
+      ['62dd4d6 fix: drop sitemap URLs that 404 (#521)', 'Sitemap no longer lists pages that 404'],
+      ['515bbf9 feat: add a live RSS feed for the work (#520)', 'RSS feed of the work'],
+      [
+        '8302a2a feat: offer LinkedIn hire on the not-found page (#519)',
+        'Get in touch on LinkedIn from the not-found page',
+      ],
+      ['56c8462 feat: add a working web app manifest (#518)', 'Web app manifest'],
+      ['75e03a6 feat: add a working apple-touch-icon (#517)', 'Home-screen icon'],
+      [
+        'e9ee7d1 feat: point robots.txt at the live sitemap (#516)',
+        'robots.txt points at the sitemap',
+      ],
+      ['4b300bf feat: add a live sitemap for search (#515)', 'Sitemap of the live site'],
+      [
+        '7a10476 feat: add live rel=canonical for search and shares (#514)',
+        'Canonical URL for the live site',
+      ],
+      ['467ba57 feat: make the twin the Home first-view (#513)', 'Chat is the first view on Home'],
+      ['54d9a30 feat: put the Home headshot in the twin (#511)', 'Home headshot in the chat'],
+      [
+        '0bae8a2 fix: keep the docked chat FAB off footer GitHub at 1280 (#510)',
+        'Chat button no longer covers the footer GitHub link',
+      ],
+      [
+        'b3ff946 feat: conversational fold for the twin (#508)',
+        'Conversational layout for the chat',
+      ],
+      [
+        '80084aa feat: add PM/DevEx to work-case share description (#507)',
+        'Work-case shares include Product Manager, Developer Experience',
+      ],
+      [
+        'cd9c5a9 feat: work-case browser titles include PM/DevEx (#506)',
+        'Work-case browser titles include Product Manager, Developer Experience',
+      ],
+      [
+        'eacddb0 feat: work-case share preview includes PM/DevEx and LinkedIn (#505)',
+        'Work-case share preview includes Product Manager, Developer Experience and LinkedIn',
+      ],
+      [
+        'a2414f6 feat: point share URLs at the live site (#504)',
+        'Share URLs point at the live site',
+      ],
+      [
+        '54a4f7c feat: point structured data at the live site (#503)',
+        'Structured data points at the live site',
+      ],
+      [
+        '6b610e5 feat: put IFS Design System first and Lidköping last on /work (#496)',
+        'IFS Design System first on Work, Lidköping last',
+      ],
+    ];
+    expect(liveNames).toHaveLength(20);
+    for (const [raw, visitor] of liveNames) {
+      expect(toVisitorChangelogTitle(raw)).toBe(visitor);
+      expect(toVisitorChangelogTitle(raw)).not.toMatch(/^[a-f0-9]{7}\s/i);
+      expect(toVisitorChangelogTitle(raw)).not.toMatch(
+        /^(feat|fix|chore|docs|refactor|test|style|perf|build|ci):/i
+      );
+      expect(toVisitorChangelogTitle(raw)).not.toMatch(/\(#\d+\)/);
+    }
   });
 });

--- a/src/pages/api/releases.ts
+++ b/src/pages/api/releases.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from 'astro';
 import { fetchGitHubReleases } from '../../utils/github-releases';
+import { toVisitorChangelogTitle, toVisitorRelease } from '../../utils/visitor-changelog';
 
 const jsonHeaders = {
   'content-type': 'application/json',
@@ -14,7 +15,20 @@ export const prerender = false;
 
 export const GET: APIRoute = async () => {
   try {
-    const releases = await fetchGitHubReleases();
+    const releases = (await fetchGitHubReleases()).map((release) => {
+      const visitor = toVisitorRelease(release);
+      return {
+        ...visitor,
+        body: visitor.body
+          .split('\n')
+          .map((line) => {
+            const bullet = line.match(/^([-*+]\s+)(.*)$/);
+            if (!bullet) return toVisitorChangelogTitle(line);
+            return `${bullet[1]}${toVisitorChangelogTitle(bullet[2])}`;
+          })
+          .join('\n'),
+      };
+    });
     return new Response(JSON.stringify(releases), { headers: jsonHeaders });
   } catch (error: unknown) {
     console.error({ event: 'releases_api_error', error: String(error) });

--- a/src/pages/whats-new.astro
+++ b/src/pages/whats-new.astro
@@ -10,7 +10,7 @@ const schema = {
       '@type': 'WebPage',
       '@id': 'https://me.alehar.workers.dev/whats-new/#webpage',
       url: 'https://me.alehar.workers.dev/whats-new/',
-      name: "What's New | Alexander Härenstam",
+      name: "What's New | Product Manager, Developer Experience at IFS",
       description: 'A public changelog of this site.',
       breadcrumb: {
         '@type': 'BreadcrumbList',
@@ -40,7 +40,8 @@ const schema = {
 ---
 
 <BaseLayout
-  title="What's New | Alexander Härenstam"
+  title="What's New | Product Manager, Developer Experience at IFS"
+  ogTitle="What's New | Product Manager, Developer Experience at IFS"
   description="A public changelog of this site. Product Manager, Developer Experience at IFS."
 >
   <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
@@ -76,6 +77,7 @@ const schema = {
     splitReleaseBody,
   } from '../utils/github-releases';
   import { groundedReleaseSummary, prepareReleaseSummary } from '../utils/release-summary';
+  import { toVisitorChangelogTitle } from '../utils/visitor-changelog';
 
   const releaseList = document.querySelector('[data-release-list]');
   const summaryContainer = document.querySelector('[data-release-summary]');
@@ -157,22 +159,7 @@ const schema = {
 
           bodyItems.forEach((item) => {
             const listItem = document.createElement('li');
-
-            if (item.hash && item.url) {
-              const code = document.createElement('code');
-              code.className = 'commit-hash';
-              const link = document.createElement('a');
-              link.href = item.url;
-              link.target = '_blank';
-              link.rel = 'noopener noreferrer';
-              link.textContent = item.hash;
-              code.appendChild(link);
-              listItem.appendChild(code);
-              listItem.appendChild(document.createTextNode(` ${item.message}`));
-            } else {
-              listItem.textContent = item.message;
-            }
-
+            listItem.textContent = toVisitorChangelogTitle(item.message);
             list.appendChild(listItem);
           });
 

--- a/src/pages/whats-new.astro
+++ b/src/pages/whats-new.astro
@@ -77,7 +77,7 @@ const schema = {
     splitReleaseBody,
   } from '../utils/github-releases';
   import { groundedReleaseSummary, prepareReleaseSummary } from '../utils/release-summary';
-  import { toVisitorChangelogTitle } from '../utils/visitor-changelog';
+  import { toVisitorChangelogTitle, toVisitorRelease } from '../utils/visitor-changelog';
 
   const releaseList = document.querySelector('[data-release-list]');
   const summaryContainer = document.querySelector('[data-release-summary]');
@@ -119,7 +119,8 @@ const schema = {
   }
 
   if (releaseList instanceof HTMLDivElement) {
-    fetchGitHubReleases().then((releases) => {
+    fetchGitHubReleases().then((rawReleases) => {
+      const releases = rawReleases.map(toVisitorRelease);
       if (summaryContainer instanceof HTMLElement && !summaryContainer.hasChildNodes()) {
         const latest = releases[0] ?? LATEST_RELEASE_SNAPSHOT;
         paintSummary(groundedReleaseSummary(latest.version, latest.body, latest.title));

--- a/src/pages/whats-new.astro
+++ b/src/pages/whats-new.astro
@@ -11,8 +11,7 @@ const schema = {
       '@id': 'https://me.alehar.workers.dev/whats-new/#webpage',
       url: 'https://me.alehar.workers.dev/whats-new/',
       name: "What's New | Alexander Härenstam",
-      description:
-        'A real-time log of project milestones, technical refinements, and portfolio updates.',
+      description: 'A public changelog of this site.',
       breadcrumb: {
         '@type': 'BreadcrumbList',
         itemListElement: [
@@ -40,20 +39,19 @@ const schema = {
 };
 ---
 
-<BaseLayout title="What's New | Alexander Härenstam" description="Changelog and recent updates">
+<BaseLayout
+  title="What's New | Alexander Härenstam"
+  description="A public changelog of this site. Product Manager, Developer Experience at IFS."
+>
   <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
   <div class="stack gap-20">
     <main id="main-content" class="wrapper stack gap-8">
-      <Hero
-        title="What's New"
-        tagline="A real-time log of project milestones, technical refinements, and portfolio updates."
-        align="start"
-      />
+      <Hero title="What's New" tagline="A public changelog of this site." align="start" />
 
       <div class="content">
         <div data-release-summary></div>
         <div class="release-list" data-release-list>
-          <p class="release-status">Fetching latest project updates...</p>
+          <p class="release-status">Loading the latest site updates...</p>
         </div>
         <noscript>
           <p class="release-status">
@@ -128,7 +126,7 @@ const schema = {
       if (releases.length === 0) {
         const empty = document.createElement('p');
         empty.className = 'release-status';
-        empty.textContent = 'Project history is currently unavailable.';
+        empty.textContent = 'Site updates are currently unavailable.';
         const link = document.createElement('a');
         link.href = RELEASES_PAGE_URL;
         link.textContent = 'View GitHub Releases';

--- a/src/utils/visitor-changelog.ts
+++ b/src/utils/visitor-changelog.ts
@@ -13,6 +13,11 @@ export type VisitorChangelogEntry = {
 /** Known shipped PRs on this site. Do not invent work that is not in the feed. */
 export const VISITOR_CHANGELOG: readonly VisitorChangelogEntry[] = [
   {
+    pr: 524,
+    subject: 'rewrite What’s New for visitors',
+    title: 'What’s New rewritten for visitors',
+  },
+  {
     pr: 523,
     subject: 'rewrite /experimental/now/ for visitors',
     title: 'Now page rewritten for visitors',
@@ -20,7 +25,7 @@ export const VISITOR_CHANGELOG: readonly VisitorChangelogEntry[] = [
   {
     pr: 522,
     subject: 'drop experimental pages from the sitemap',
-    title: 'Sitemap no longer lists experimental pages',
+    title: 'Experimental pages removed from the sitemap',
   },
   {
     pr: 521,
@@ -30,12 +35,12 @@ export const VISITOR_CHANGELOG: readonly VisitorChangelogEntry[] = [
   {
     pr: 520,
     subject: 'add a live RSS feed for the work',
-    title: 'RSS feed for the work',
+    title: 'RSS feed of the work',
   },
   {
     pr: 519,
     subject: 'offer LinkedIn hire on the not-found page',
-    title: 'LinkedIn hire on the not-found page',
+    title: 'Get in touch on LinkedIn from the not-found page',
   },
   {
     pr: 518,
@@ -45,22 +50,22 @@ export const VISITOR_CHANGELOG: readonly VisitorChangelogEntry[] = [
   {
     pr: 517,
     subject: 'add a working apple-touch-icon',
-    title: 'Apple touch icon for iOS',
+    title: 'Home-screen icon',
   },
   {
     pr: 516,
     subject: 'point robots.txt at the live sitemap',
-    title: 'robots.txt points at the live sitemap',
+    title: 'robots.txt points at the sitemap',
   },
   {
     pr: 515,
     subject: 'add a live sitemap for search',
-    title: 'Live sitemap for search',
+    title: 'Sitemap of the live site',
   },
   {
     pr: 514,
     subject: 'add live rel=canonical for search and shares',
-    title: 'Canonical URLs for search and shares',
+    title: 'Canonical URL for the live site',
   },
   {
     pr: 513,
@@ -192,8 +197,11 @@ function titleCaseFirst(text: string): string {
   return text.charAt(0).toUpperCase() + text.slice(1);
 }
 
+const INTERNAL_CHANGELOG_ITEM = /\bjules\b|\bagent[- ]farm\b|\bjohan nits\b/i;
+
 /**
  * Visitor sentence for a changelog item. Lookup known shipped PRs, else sanitize.
+ * Idempotent: already-visitor copy (no SHA / type / PR chrome) is returned as-is.
  */
 export function toVisitorChangelogTitle(raw: string): string {
   const trimmed = raw.trim();
@@ -209,6 +217,33 @@ export function toVisitorChangelogTitle(raw: string): string {
   const bySubject = BY_SUBJECT.get(subject.toLowerCase());
   if (bySubject) return bySubject;
 
+  if (subject === trimmed) return trimmed;
   if (!subject) return titleCaseFirst(trimmed.replace(SHA_PREFIX, '').trim());
   return titleCaseFirst(subject);
+}
+
+/**
+ * Rewrite a GitHub release body so list items are visitor copy, not SHA + feat + (#PR).
+ */
+export function toVisitorReleaseBody(body: string): string {
+  const items = body
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => /^[-*+]\s+/.test(line))
+    .map((line) => line.replace(/^[-*+]\s+/, ''))
+    .filter((message) => !INTERNAL_CHANGELOG_ITEM.test(message));
+
+  if (items.length === 0) {
+    const trimmed = body.trim();
+    return trimmed ? toVisitorChangelogTitle(trimmed) : '';
+  }
+
+  return items.map((message) => `- ${toVisitorChangelogTitle(message)}`).join('\n');
+}
+
+/**
+ * Keep dates, URLs, and versions. Replace changelog names with visitor sentences.
+ */
+export function toVisitorRelease<T extends { body: string }>(release: T): T {
+  return { ...release, body: toVisitorReleaseBody(release.body) };
 }

--- a/src/utils/visitor-changelog.ts
+++ b/src/utils/visitor-changelog.ts
@@ -1,0 +1,214 @@
+/**
+ * Visitor-facing changelog titles for What’s New.
+ * Maps known shipped conventional-commit lines to short sentences.
+ * Unknown items keep their meaning after SHA / type / PR chrome is stripped.
+ */
+
+export type VisitorChangelogEntry = {
+  pr: number;
+  subject: string;
+  title: string;
+};
+
+/** Known shipped PRs on this site. Do not invent work that is not in the feed. */
+export const VISITOR_CHANGELOG: readonly VisitorChangelogEntry[] = [
+  {
+    pr: 523,
+    subject: 'rewrite /experimental/now/ for visitors',
+    title: 'Now page rewritten for visitors',
+  },
+  {
+    pr: 522,
+    subject: 'drop experimental pages from the sitemap',
+    title: 'Sitemap no longer lists experimental pages',
+  },
+  {
+    pr: 521,
+    subject: 'drop sitemap URLs that 404',
+    title: 'Sitemap no longer lists pages that 404',
+  },
+  {
+    pr: 520,
+    subject: 'add a live RSS feed for the work',
+    title: 'RSS feed for the work',
+  },
+  {
+    pr: 519,
+    subject: 'offer LinkedIn hire on the not-found page',
+    title: 'LinkedIn hire on the not-found page',
+  },
+  {
+    pr: 518,
+    subject: 'add a working web app manifest',
+    title: 'Web app manifest',
+  },
+  {
+    pr: 517,
+    subject: 'add a working apple-touch-icon',
+    title: 'Apple touch icon for iOS',
+  },
+  {
+    pr: 516,
+    subject: 'point robots.txt at the live sitemap',
+    title: 'robots.txt points at the live sitemap',
+  },
+  {
+    pr: 515,
+    subject: 'add a live sitemap for search',
+    title: 'Live sitemap for search',
+  },
+  {
+    pr: 514,
+    subject: 'add live rel=canonical for search and shares',
+    title: 'Canonical URLs for search and shares',
+  },
+  {
+    pr: 513,
+    subject: 'make the twin the Home first-view',
+    title: 'Chat is the first view on Home',
+  },
+  {
+    pr: 511,
+    subject: 'put the Home headshot in the twin',
+    title: 'Home headshot in the chat',
+  },
+  {
+    pr: 510,
+    subject: 'keep the docked chat FAB off footer GitHub at 1280',
+    title: 'Chat button no longer covers the footer GitHub link',
+  },
+  {
+    pr: 508,
+    subject: 'conversational fold for the twin',
+    title: 'Conversational layout for the chat',
+  },
+  {
+    pr: 507,
+    subject: 'add PM/DevEx to work-case share description',
+    title: 'Work-case shares include Product Manager, Developer Experience',
+  },
+  {
+    pr: 506,
+    subject: 'work-case browser titles include PM/DevEx',
+    title: 'Work-case browser titles include Product Manager, Developer Experience',
+  },
+  {
+    pr: 505,
+    subject: 'work-case share preview includes PM/DevEx and LinkedIn',
+    title: 'Work-case share preview includes Product Manager, Developer Experience and LinkedIn',
+  },
+  {
+    pr: 504,
+    subject: 'point share URLs at the live site',
+    title: 'Share URLs point at the live site',
+  },
+  {
+    pr: 503,
+    subject: 'point structured data at the live site',
+    title: 'Structured data points at the live site',
+  },
+  {
+    pr: 496,
+    subject: 'put IFS Design System first and Lidköping last on /work',
+    title: 'IFS Design System first on Work, Lidköping last',
+  },
+  {
+    pr: 502,
+    subject: 'show the published design-system outcome on /work',
+    title: 'Published design-system outcome on Work',
+  },
+  {
+    pr: 501,
+    subject: 'point LinkedIn share photos at the live portrait',
+    title: 'LinkedIn share photos use the live portrait',
+  },
+  {
+    pr: 500,
+    subject: 'set the twin idle prompt to Ask about the work',
+    title: 'Chat prompt is Ask about the work',
+  },
+  {
+    pr: 499,
+    subject: 'let visitors clear the twin chat and drop the FAB portrait',
+    title: 'Visitors can clear the chat',
+  },
+  {
+    pr: 494,
+    subject: "frame the master's thesis as earlier work, not a PM case",
+    title: "Master's thesis framed as earlier work",
+  },
+  {
+    pr: 493,
+    subject: 'frame Lidköping as earlier work, not a PM case',
+    title: 'Lidköping framed as earlier work',
+  },
+  {
+    pr: 492,
+    subject: 'rewrite analytics page as a visitor PM story',
+    title: 'Analytics page rewritten for visitors',
+  },
+  {
+    pr: 491,
+    subject: 'rewrite copilots page as a visitor PM story',
+    title: 'Copilots page rewritten for visitors',
+  },
+  {
+    pr: 490,
+    subject: 'fold About into Biography as one visitor page',
+    title: 'About folded into Biography',
+  },
+  {
+    pr: 489,
+    subject: 'rewrite IFS Design System page as a visitor PM story',
+    title: 'IFS Design System page rewritten for visitors',
+  },
+];
+
+const BY_PR = new Map(VISITOR_CHANGELOG.map((entry) => [entry.pr, entry.title]));
+const BY_SUBJECT = new Map(
+  VISITOR_CHANGELOG.map((entry) => [entry.subject.toLowerCase(), entry.title])
+);
+
+const SHA_PREFIX = /^[a-f0-9]{7,40}\s+/i;
+const CONVENTIONAL_PREFIX =
+  /^(feat|fix|chore|docs|refactor|test|style|perf|build|ci)(\([^)]+\))?:\s*/i;
+const PR_SUFFIX = /\s*\(#(\d+)\)\s*$/;
+
+/**
+ * Strip SHA, conventional-commit type, and trailing (#123) from a changelog line.
+ */
+export function stripChangelogChrome(raw: string): string {
+  return raw
+    .trim()
+    .replace(SHA_PREFIX, '')
+    .replace(CONVENTIONAL_PREFIX, '')
+    .replace(PR_SUFFIX, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}
+
+function titleCaseFirst(text: string): string {
+  if (!text) return text;
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+/**
+ * Visitor sentence for a changelog item. Lookup known shipped PRs, else sanitize.
+ */
+export function toVisitorChangelogTitle(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return trimmed;
+
+  const prMatch = trimmed.match(/\(#(\d+)\)/);
+  if (prMatch) {
+    const mapped = BY_PR.get(Number(prMatch[1]));
+    if (mapped) return mapped;
+  }
+
+  const subject = stripChangelogChrome(trimmed);
+  const bySubject = BY_SUBJECT.get(subject.toLowerCase());
+  if (bySubject) return bySubject;
+
+  if (!subject) return titleCaseFirst(trimmed.replace(SHA_PREFIX, '').trim());
+  return titleCaseFirst(subject);
+}


### PR DESCRIPTION
## Summary
- Rewrite the What’s New intro so visitors see a public changelog of this site, not an internal project log.
- Keep the existing GitHub Releases feed, ContactCTA LinkedIn hire path, and `/whats-new` URL.
- Add identity tests that lock the visitor-facing wrapper and forbid the old owner-facing phrase, mailto, and gap-apology copy.

## Test plan
- [ ] `npx vitest run src/__tests__/identity.test.ts`
- [ ] Open `/whats-new/` and confirm the lede is “A public changelog of this site.”
- [ ] Confirm changelog cards still load from GitHub Releases
- [ ] Confirm Get in touch → LinkedIn (`https://www.linkedin.com/in/alehar/`) with “LinkedIn · replies from me”
- [ ] Stay draft until Johan AND Vera PASS. Do not merge.