### PR TITLE
feat: rewrite the not-found heading for visitors

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -475,7 +475,13 @@ describe('identity copy', () => {
     expect(notFound).toContain('LinkedIn · replies from me');
     expect(notFound).toContain('data-hire-event="hire_cta_click"');
     expect(notFound).toContain('data-hire-surface="404"');
-    expect(notFound).toContain('Lost in Orbit?');
+    expect(content).toContain('title="Page not found"');
+    expect(notFound).not.toContain('Lost in Orbit?');
+    expect(page).toContain('title="Page not found | Product Manager, Developer Experience at IFS"');
+    expect(page).toContain(
+      'ogTitle="Page not found | Product Manager, Developer Experience at IFS"'
+    );
+    expect(notFound).toContain('Product Manager, Developer Experience at IFS');
     expect(notFound).not.toContain('mailto:');
     expect(notFound).not.toContain('this is not on the site');
     expect(notFound).not.toContain("this isn't on the site yet");

--- a/src/components/NotFoundContent.astro
+++ b/src/components/NotFoundContent.astro
@@ -9,7 +9,7 @@ const linkedinHref = 'https://www.linkedin.com/in/alehar/';
 <div class="stack gap-20">
   <main id="main-content" class="wrapper stack gap-8">
     <Hero
-      title="Lost in Orbit?"
+      title="Page not found"
       tagline="The page you're looking for isn't here. Let's get you back on track."
     />
     <div class="cta-container">

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,6 +5,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 Astro.response.status = 404;
 ---
 
-<BaseLayout title="Not Found" description="404 Error — this page was not found">
+<BaseLayout
+  title="Page not found | Product Manager, Developer Experience at IFS"
+  ogTitle="Page not found | Product Manager, Developer Experience at IFS"
+  description="404 Error — this page was not found"
+>
   <NotFoundContent />
 </BaseLayout>


### PR DESCRIPTION
## Summary
- Replace the not-found H1 “Lost in Orbit?” with visitor-facing “Page not found”.
- Keep Return to Homepage and the LinkedIn hire CTA (`Get in touch` → https://www.linkedin.com/in/alehar/, `LinkedIn · replies from me`).
- Set the 404 document title and og:title to `Page not found | Product Manager, Developer Experience at IFS`.

## Test plan
- [ ] Missing URL still 404s; H1 is “Page not found”, not “Lost in Orbit?”
- [ ] LinkedIn hire CTA is still on the page; no mailto
- [ ] Browser title / og:title include Product Manager, Developer Experience at IFS
- [ ] `npx vitest run src/__tests__/identity.test.ts` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the 404 page heading to “Page not found” for clearer guidance.
  - Updated browser and social sharing titles to “Product Manager, Developer Experience at IFS.”
  - Removed the outdated “Lost in Orbit?” messaging while preserving the existing page description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->