### PR TITLE
feat: rewrite the not-found tagline for visitors

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -476,6 +476,8 @@ describe('identity copy', () => {
     expect(notFound).toContain('data-hire-event="hire_cta_click"');
     expect(notFound).toContain('data-hire-surface="404"');
     expect(content).toContain('title="Page not found"');
+    expect(content).toContain('tagline="This page isn\'t here."');
+    expect(notFound).not.toContain("Let's get you back on track.");
     expect(notFound).not.toContain('Lost in Orbit?');
     expect(page).toContain('title="Page not found | Product Manager, Developer Experience at IFS"');
     expect(page).toContain(

--- a/src/components/NotFoundContent.astro
+++ b/src/components/NotFoundContent.astro
@@ -8,10 +8,7 @@ const linkedinHref = 'https://www.linkedin.com/in/alehar/';
 
 <div class="stack gap-20">
   <main id="main-content" class="wrapper stack gap-8">
-    <Hero
-      title="Page not found"
-      tagline="The page you're looking for isn't here. Let's get you back on track."
-    />
+    <Hero title="Page not found" tagline="This page isn't here." />
     <div class="cta-container">
       <CallToAction href="/">
         Return to Homepage


### PR DESCRIPTION
## Summary
- Rewrites the not-found page tagline for visitors: **This page isn’t here.** (replaces “Let’s get you back on track.”).
- Keeps H1 **Page not found**, Product Manager / Developer Experience at IFS in the document title, Return to Homepage, and the LinkedIn hire CTA (`Get in touch` → https://www.linkedin.com/in/alehar/, `LinkedIn · replies from me`). No mailto. No gap-apology.

## Test plan
- [ ] Open a missing URL and confirm H1 is still Page not found
- [ ] Confirm tagline is “This page isn’t here.” and “Let’s get you back on track.” / “Lost in Orbit?” are gone
- [ ] Confirm Return to Homepage and Get in touch (LinkedIn) still work
- [ ] Confirm document title/og still include Product Manager, Developer Experience at IFS