### PR TITLE
feat: stop the footer rocket competing with the header glyph

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -121,6 +121,22 @@ describe('identity copy', () => {
     expect(footer).not.toContain('mailto:');
   });
 
+  it('keeps the header terminal glyph and drops the competing footer rocket', () => {
+    const nav = readFileSync('src/components/Nav.astro', 'utf8');
+    const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    expect(nav).toContain('icon="terminal-window"');
+    expect(nav).not.toContain('rocket-launch');
+    expect(footer).not.toContain('rocket-launch');
+    expect(footer).not.toContain('icon="rocket');
+    expect(footer).not.toContain('M94.1 184.6');
+    expect(footer).not.toContain('favicon.svg');
+    expect(footer).not.toContain('terminal-window');
+    expect(footer).toContain('href="https://astro.build/"');
+    expect(footer).toContain('>Astro</a>');
+    expect(footer).toContain('https://www.linkedin.com/in/alehar/');
+    expect(footer).not.toContain('mailto:');
+  });
+
   it('shows a Live / Not live signal on the chat header', () => {
     const chat = readFileSync('src/components/Chat.astro', 'utf8');
     expect(chat).toContain('chat-live-label');

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -16,7 +16,6 @@ const currentYear = new Date().getFullYear();
         target="_blank"
         rel="noopener noreferrer">Sweden</a
       > 🇸🇪 with <a href="https://astro.build/" target="_blank" rel="noopener noreferrer">Astro</a>
-      <Icon icon="rocket-launch" size="1.2em" />
     </p>
     <p>&copy; {currentYear} Alexander Härenstam</p>
     <p>


### PR DESCRIPTION
## Summary
- Remove the footer Astro rocket (`rocket-launch`) so it no longer competes with the header `>_` terminal glyph.
- Keep the header `terminal-window` mark exactly as it is. Footer stays text-only for that credit (name, Stockholm/Sweden, “with Astro” text, LinkedIn hire path). No third mark, no favicon.svg brand, no copy of `>_` into the footer.

## Test plan
- [x] `identity.test.ts`: header still uses `terminal-window`; footer rocket markup is gone; no invented footer mark; LinkedIn `https://www.linkedin.com/in/alehar/` remains; no `mailto:`
- [x] prettier check on changed files
- [ ] Stay draft until Johan AND Vera PASS. Do not merge.