### PR TITLE
feat: drop Latest Updates from the footer

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -121,6 +121,17 @@ describe('identity copy', () => {
     expect(footer).not.toContain('mailto:');
   });
 
+  it('drops Latest Updates from the footer and keeps What’s New', () => {
+    const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    expect(footer).not.toContain('Latest Updates');
+    expect(footer).not.toContain('/whats-new');
+    expect(footer).toContain('https://www.linkedin.com/in/alehar/');
+    expect(footer).not.toContain('mailto:');
+    expect(existsSync('src/pages/whats-new.astro')).toBe(true);
+    const page = readFileSync('src/pages/whats-new.astro', 'utf8');
+    expect(page).toContain('A public changelog of this site.');
+  });
+
   it('keeps the header terminal glyph and drops the competing footer rocket', () => {
     const nav = readFileSync('src/components/Nav.astro', 'utf8');
     const footer = readFileSync('src/components/Footer.astro', 'utf8');

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -19,8 +19,6 @@ const currentYear = new Date().getFullYear();
     </p>
     <p>&copy; {currentYear} Alexander Härenstam</p>
     <p>
-      <a href="/whats-new" class="version-link" data-latest-version>Latest Updates</a>
-      <span class="separator" aria-hidden="true">&bull;</span>
       <a
         href="https://github.com/alehar9320/astro-cloudflare-personal-website/issues"
         class="version-link"
@@ -64,26 +62,12 @@ const currentYear = new Date().getFullYear();
 </div>
 
 <script>
-  import { fetchGitHubReleases } from '../utils/github-releases';
   import {
     formatPageviewCount,
     formatVisitGlance,
     shouldShowVisitCount,
     type VisitGlance,
   } from '../utils/visit-stats';
-
-  const versionLink = document.querySelector('[data-latest-version]');
-
-  if (versionLink instanceof HTMLAnchorElement) {
-    fetchGitHubReleases().then((releases) => {
-      if (releases[0]) {
-        versionLink.textContent = `Latest Updates (v${releases[0].version})`;
-        return;
-      }
-
-      versionLink.textContent = 'Latest Updates';
-    });
-  }
 
   const visitStats = document.querySelector('[data-visit-stats]');
 


### PR DESCRIPTION
## Summary
- Drop the footer **Latest Updates** link so visitors see hire and proof, not a site changelog.
- Keep the What’s New page at `/whats-new/` (direct URL still works). No replacement footer link.
- LinkedIn hire path stays `https://www.linkedin.com/in/alehar/`. Title stays Product Manager, Developer Experience at IFS. No public email.

## Test plan
- [ ] Footer no longer contains “Latest Updates” or a `/whats-new/` link
- [ ] `/whats-new/` still exists and still has the visitor changelog
- [ ] Footer still has LinkedIn, work/proof socials, Stockholm/Sweden, and “with Astro”
- [ ] Header `>_` unchanged
- [ ] Stay draft until Johan AND Vera PASS. Do not merge.