### PR TITLE
feat: drop Report an issue from the footer

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -132,6 +132,17 @@ describe('identity copy', () => {
     expect(page).toContain('A public changelog of this site.');
   });
 
+  it('drops Report an issue from the footer and keeps LinkedIn hire', () => {
+    const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    expect(footer).not.toContain('Report an issue');
+    expect(footer).not.toMatch(/github\.com\/[^\s"']+\/issues/);
+    expect(footer).not.toContain('Latest Updates');
+    expect(footer).toContain('https://www.linkedin.com/in/alehar/');
+    expect(footer).not.toContain('mailto:');
+    expect(footer).toContain('https://github.com/alehar9320/astro-cloudflare-personal-website');
+    expect(footer).toContain('https://github.com/alehar9320');
+  });
+
   it('keeps the header terminal glyph and drops the competing footer rocket', () => {
     const nav = readFileSync('src/components/Nav.astro', 'utf8');
     const footer = readFileSync('src/components/Footer.astro', 'utf8');

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -18,14 +18,6 @@ const currentYear = new Date().getFullYear();
       > 🇸🇪 with <a href="https://astro.build/" target="_blank" rel="noopener noreferrer">Astro</a>
     </p>
     <p>&copy; {currentYear} Alexander Härenstam</p>
-    <p>
-      <a
-        href="https://github.com/alehar9320/astro-cloudflare-personal-website/issues"
-        class="version-link"
-      >
-        Report an issue
-      </a>
-    </p>
     <div class="colophon">
       Built and run with agentic engineering.<span class="visit-stats" data-visit-stats hidden>
         <span aria-hidden="true"> · </span>


### PR DESCRIPTION
## Summary
- Drop the footer **Report an issue** link so visitors see hire and proof, not a bug tracker.
- No replacement footer link. GitHub profile and source-repo credit stay.
- LinkedIn hire path stays `https://www.linkedin.com/in/alehar/`. Title stays Product Manager, Developer Experience at IFS. No public email.

## Test plan
- [ ] Footer no longer contains “Report an issue” or a `github.com/.../issues` tracker link
- [ ] Footer still has LinkedIn, GitHub profile, source credit, Stockholm/Sweden, and “with Astro”
- [ ] Latest Updates stays absent from the footer
- [ ] Header `>_` unchanged
- [ ] Stay draft until Johan AND Vera PASS. Do not merge.