### PR TITLE
feat: drop agentic engineering from the footer

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -143,6 +143,16 @@ describe('identity copy', () => {
     expect(footer).toContain('https://github.com/alehar9320');
   });
 
+  it('drops agentic engineering from the footer and keeps LinkedIn hire', () => {
+    const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    expect(footer).not.toContain('agentic engineering');
+    expect(footer).not.toContain('Built and run with');
+    expect(footer).not.toContain('Latest Updates');
+    expect(footer).not.toContain('Report an issue');
+    expect(footer).toContain('https://www.linkedin.com/in/alehar/');
+    expect(footer).not.toContain('mailto:');
+  });
+
   it('keeps the header terminal glyph and drops the competing footer rocket', () => {
     const nav = readFileSync('src/components/Nav.astro', 'utf8');
     const footer = readFileSync('src/components/Footer.astro', 'utf8');

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -19,8 +19,7 @@ const currentYear = new Date().getFullYear();
     </p>
     <p>&copy; {currentYear} Alexander Härenstam</p>
     <div class="colophon">
-      Built and run with agentic engineering.<span class="visit-stats" data-visit-stats hidden>
-        <span aria-hidden="true"> · </span>
+      <span class="visit-stats" data-visit-stats hidden>
         <button
           type="button"
           class="visit-trigger"


### PR DESCRIPTION
## Summary
- Drop the footer process note **Built and run with agentic engineering** so visitors see hire, not a process note.
- No replacement process copy. Visit count stays. LinkedIn hire path stays `https://www.linkedin.com/in/alehar/`.
- Title stays Product Manager, Developer Experience at IFS. No public email. Latest Updates and Report an issue stay absent.

## Test plan
- [ ] Footer no longer contains “agentic engineering” or “Built and run with”
- [ ] Footer still has LinkedIn, GitHub profile, source credit, Stockholm/Sweden, and “with Astro”
- [ ] Latest Updates and Report an issue stay absent from the footer
- [ ] Header `>_` unchanged
- [ ] Stay draft until Johan AND Vera PASS. Do not merge.