### PR TITLE
feat: drop Source from the footer

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -139,7 +139,7 @@ describe('identity copy', () => {
     expect(footer).not.toContain('Latest Updates');
     expect(footer).toContain('https://www.linkedin.com/in/alehar/');
     expect(footer).not.toContain('mailto:');
-    expect(footer).toContain('https://github.com/alehar9320/astro-cloudflare-personal-website');
+    expect(footer).not.toContain('https://github.com/alehar9320/astro-cloudflare-personal-website');
     expect(footer).toContain('https://github.com/alehar9320');
   });
 
@@ -149,6 +149,20 @@ describe('identity copy', () => {
     expect(footer).not.toContain('Built and run with');
     expect(footer).not.toContain('Latest Updates');
     expect(footer).not.toContain('Report an issue');
+    expect(footer).toContain('https://www.linkedin.com/in/alehar/');
+    expect(footer).not.toContain('mailto:');
+  });
+
+  it('drops Source from the footer and keeps LinkedIn hire', () => {
+    const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    expect(footer).not.toContain('>Source</span>');
+    expect(footer).not.toContain('source-link');
+    expect(footer).not.toContain('View source code for this site');
+    expect(footer).not.toContain('https://github.com/alehar9320/astro-cloudflare-personal-website');
+    expect(footer).toContain('https://github.com/alehar9320');
+    expect(footer).not.toContain('Latest Updates');
+    expect(footer).not.toContain('Report an issue');
+    expect(footer).not.toContain('agentic engineering');
     expect(footer).toContain('https://www.linkedin.com/in/alehar/');
     expect(footer).not.toContain('mailto:');
   });

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,4 @@
 ---
-import Icon from './Icon.astro';
-
 const currentYear = new Date().getFullYear();
 ---
 
@@ -36,14 +34,6 @@ const currentYear = new Date().getFullYear();
     <a href="https://github.com/alehar9320"> GitHub</a>
     <a href="https://www.instagram.com/alle12393"> Instagram</a>
     <a href="https://www.facebook.com/alehar9320/"> Facebook</a>
-    <a
-      href="https://github.com/alehar9320/astro-cloudflare-personal-website"
-      aria-label="View source code for this site"
-      class="source-link"
-    >
-      <Icon icon="github-logo" />
-      <span class="sr-only">Source</span>
-    </a>
   </p>
 </footer>
 <div class="visit-panel" id="visit-glance-panel" hidden>
@@ -311,56 +301,6 @@ const currentYear = new Date().getFullYear();
 
   .visit-panel[hidden] {
     display: none !important;
-  }
-
-  /* Source icon link styling: keep visual weight minimal */
-  .source-link {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.375rem;
-    font-size: var(--text-sm);
-    color: var(--gray-400);
-    text-decoration: none;
-    transform: translateY(0) scale(1);
-    transition:
-      transform var(--theme-transition),
-      color var(--theme-transition);
-  }
-
-  .source-link:hover,
-  .source-link:focus-visible {
-    color: var(--gray-200);
-    transform: translateY(-0.125rem) scale(1.05);
-  }
-
-  .source-link:focus-visible {
-    outline: 2px solid var(--accent-regular);
-    outline-offset: 0.25rem;
-    border-radius: 0.375rem;
-  }
-
-  .source-link .sr-only {
-    position: absolute !important;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .source-link {
-      transform: none;
-      transition: color var(--theme-transition);
-    }
-
-    .source-link:hover,
-    .source-link:focus-visible {
-      transform: none;
-    }
   }
 
   @media (min-width: 50em) {


### PR DESCRIPTION
## Summary
- Drop the footer **Source** repo credit so visitors see hire, not the repo.
- No replacement repo/source link. GitHub profile hire/proof stays `https://github.com/alehar9320`. LinkedIn hire path stays `https://www.linkedin.com/in/alehar/`.
- Title stays Product Manager, Developer Experience at IFS. No public email. Latest Updates, Report an issue, and agentic engineering stay absent.

## Test plan
- [ ] Footer no longer contains a “Source” label linking to the repo
- [ ] Footer does not link to `github.com/alehar9320/astro-cloudflare-personal-website`
- [ ] Footer still has LinkedIn, GitHub profile, Stockholm/Sweden, and “with Astro”
- [ ] Latest Updates, Report an issue, and agentic engineering stay absent from the footer
- [ ] Header `>_` unchanged
- [ ] Stay draft until Johan AND Vera PASS. Do not merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the source-code repository link from the footer.
  * Simplified footer content while retaining the short GitHub link, LinkedIn call-to-action, and other existing footer elements.
  * Removed unused styling associated with the deleted source link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->