### PR TITLE
feat: drop Instagram and Facebook from the footer

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -167,6 +167,20 @@ describe('identity copy', () => {
     expect(footer).not.toContain('mailto:');
   });
 
+  it('drops Instagram and Facebook from the footer and keeps LinkedIn hire', () => {
+    const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    expect(footer).not.toContain('instagram.com');
+    expect(footer).not.toContain('facebook.com');
+    expect(footer).toContain('https://www.linkedin.com/in/alehar/');
+    expect(footer).toContain('https://github.com/alehar9320');
+    expect(footer).not.toContain('mailto:');
+    expect(footer).not.toContain('Latest Updates');
+    expect(footer).not.toContain('Report an issue');
+    expect(footer).not.toContain('agentic engineering');
+    expect(footer).not.toContain('>Source</span>');
+    expect(footer).not.toContain('source-link');
+  });
+
   it('keeps the header terminal glyph and drops the competing footer rocket', () => {
     const nav = readFileSync('src/components/Nav.astro', 'utf8');
     const footer = readFileSync('src/components/Footer.astro', 'utf8');

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -32,8 +32,6 @@ const currentYear = new Date().getFullYear();
     <a href="https://www.linkedin.com/in/alehar/"> LinkedIn</a>
     <a href="https://blog.ifs.com/author/alexander-harenstam/"> IFS Blog</a>
     <a href="https://github.com/alehar9320"> GitHub</a>
-    <a href="https://www.instagram.com/alle12393"> Instagram</a>
-    <a href="https://www.facebook.com/alehar9320/"> Facebook</a>
   </p>
 </footer>
 <div class="visit-panel" id="visit-glance-panel" hidden>


### PR DESCRIPTION
## Summary
- Drop Instagram and Facebook from the footer so hire stays on LinkedIn.
- Keep LinkedIn `https://www.linkedin.com/in/alehar/`, GitHub profile `https://github.com/alehar9320`, and IFS Blog. No replacement socials.
- Title stays Product Manager, Developer Experience at IFS. No public email. Source, Latest Updates, Report an issue, and agentic engineering stay absent.

## Test plan
- [ ] Footer no longer contains `instagram.com` or `facebook.com`
- [ ] Footer still has LinkedIn `https://www.linkedin.com/in/alehar/` and GitHub profile `https://github.com/alehar9320`
- [ ] Footer has no `mailto:`
- [ ] Source, Latest Updates, Report an issue, and agentic engineering stay absent from the footer
- [ ] Header unchanged
- [ ] Stay draft until Johan AND Vera PASS. Do not merge.