### PR TITLE
feat: drop Designed & Developed from the footer

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -181,6 +181,27 @@ describe('identity copy', () => {
     expect(footer).not.toContain('source-link');
   });
 
+  it('drops Designed & Developed from the footer and keeps LinkedIn hire', () => {
+    const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    const nav = readFileSync('src/components/Nav.astro', 'utf8');
+    expect(footer).not.toContain('Designed & Developed');
+    expect(footer).toContain('https://www.linkedin.com/in/alehar/');
+    expect(footer).toContain('https://github.com/alehar9320');
+    expect(footer).not.toContain('mailto:');
+    expect(footer).toContain('Stockholm');
+    expect(footer).toContain('Sweden');
+    expect(footer).toContain('href="https://astro.build/"');
+    expect(footer).not.toContain('instagram.com');
+    expect(footer).not.toContain('facebook.com');
+    expect(nav).toContain('https://www.instagram.com/alle12393');
+    expect(nav).toContain('https://www.facebook.com/alehar9320/');
+    expect(footer).not.toContain('Latest Updates');
+    expect(footer).not.toContain('Report an issue');
+    expect(footer).not.toContain('agentic engineering');
+    expect(footer).not.toContain('>Source</span>');
+    expect(footer).not.toContain('source-link');
+  });
+
   it('keeps the header terminal glyph and drops the competing footer rocket', () => {
     const nav = readFileSync('src/components/Nav.astro', 'utf8');
     const footer = readFileSync('src/components/Footer.astro', 'utf8');

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -5,7 +5,7 @@ const currentYear = new Date().getFullYear();
 <footer>
   <div class="group">
     <p>
-      Designed & Developed in 📍 <a
+      📍 <a
         href="https://www.google.com/maps/place/Stockholm/"
         target="_blank"
         rel="noopener noreferrer">Stockholm</a


### PR DESCRIPTION
## Summary
- Drop the footer "Designed & Developed" maker credit so visitors see hire, not a maker credit.
- Keep LinkedIn `https://www.linkedin.com/in/alehar/`, Stockholm/Sweden, Astro, GitHub profile `https://github.com/alehar9320`, and IFS Blog. No replacement maker copy.
- Title stays Product Manager, Developer Experience at IFS. No public email. Header Instagram/Facebook unchanged. Source, Latest Updates, Report an issue, agentic engineering, and footer IG/FB stay absent.

## Test plan
- [ ] Footer no longer contains `Designed & Developed`
- [ ] Footer still has LinkedIn `https://www.linkedin.com/in/alehar/` and GitHub profile `https://github.com/alehar9320`
- [ ] Footer still has Stockholm, Sweden, and Astro
- [ ] Footer has no `mailto:`
- [ ] Header Instagram and Facebook unchanged
- [ ] Source, Latest Updates, Report an issue, agentic engineering, and footer IG/FB stay absent from the footer
- [ ] Stay draft until Johan AND Vera PASS. Do not merge.