### PR TITLE
feat: drop pin and flag emoji from the footer

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -225,6 +225,28 @@ describe('identity copy', () => {
     expect(footer).not.toContain('source-link');
   });
 
+  it('drops pin and flag emoji from the footer and keeps LinkedIn hire', () => {
+    const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    const nav = readFileSync('src/components/Nav.astro', 'utf8');
+    expect(footer).not.toContain('📍');
+    expect(footer).not.toContain('🇸🇪');
+    expect(footer).toContain('Stockholm');
+    expect(footer).toContain('Sweden');
+    expect(footer).toContain('https://www.linkedin.com/in/alehar/');
+    expect(footer).not.toContain('mailto:');
+    expect(nav).toContain('https://www.instagram.com/alle12393');
+    expect(nav).toContain('https://www.facebook.com/alehar9320/');
+    expect(footer).not.toContain('instagram.com');
+    expect(footer).not.toContain('facebook.com');
+    expect(footer).not.toContain('with Astro');
+    expect(footer).not.toContain('Designed & Developed');
+    expect(footer).not.toContain('Latest Updates');
+    expect(footer).not.toContain('Report an issue');
+    expect(footer).not.toContain('agentic engineering');
+    expect(footer).not.toContain('>Source</span>');
+    expect(footer).not.toContain('source-link');
+  });
+
   it('keeps the header terminal glyph and drops the competing footer rocket', () => {
     const nav = readFileSync('src/components/Nav.astro', 'utf8');
     const footer = readFileSync('src/components/Footer.astro', 'utf8');

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -5,7 +5,7 @@ const currentYear = new Date().getFullYear();
 <footer>
   <div class="group">
     <p>
-      📍 <a
+      <a
         href="https://www.google.com/maps/place/Stockholm/"
         target="_blank"
         rel="noopener noreferrer">Stockholm</a
@@ -13,7 +13,7 @@ const currentYear = new Date().getFullYear();
         href="https://www.google.com/maps/place/Sweden/"
         target="_blank"
         rel="noopener noreferrer">Sweden</a
-      > 🇸🇪
+      >
     </p>
     <p>&copy; {currentYear} Alexander Härenstam</p>
     <div class="colophon">


### PR DESCRIPTION
## Summary
- Drop the pin (📍) and Sweden flag (🇸🇪) from the footer so location reads as text: Stockholm, Sweden.
- Keep the existing Stockholm/Sweden geo links, LinkedIn `https://www.linkedin.com/in/alehar/`, and GitHub profile `https://github.com/alehar9320`. No invented facts or new URLs.
- Title stays Product Manager, Developer Experience at IFS. No public email. Header Instagram/Facebook unchanged. with Astro, Designed & Developed, Source, Latest Updates, Report an issue, agentic engineering, and footer IG/FB stay absent.

## Test plan
- [ ] Footer no longer contains 📍 or 🇸🇪
- [ ] Footer still has Stockholm and Sweden as text
- [ ] Footer still has LinkedIn `https://www.linkedin.com/in/alehar/`
- [ ] Footer has no `mailto:`
- [ ] Header Instagram and Facebook unchanged
- [ ] with Astro, Designed & Developed, Source, Latest Updates, Report an issue, agentic engineering, and footer IG/FB stay absent from the footer
- [ ] Stay draft until Johan AND Vera PASS. Do not merge.