### PR TITLE
feat: drop What’s New from the sitemap

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -574,9 +574,14 @@ describe('identity copy', () => {
     expect(sitemap).not.toContain('/experimental/manifesto');
     expect(sitemap).not.toContain('/experimental/now');
     expect(sitemap).not.toContain('/experimental/reading-list');
+    expect(sitemap).not.toContain('/whats-new');
     expect(sitemap).not.toContain('localhost');
     expect(sitemap).not.toContain('harenstam.com');
     expect(sitemap).not.toContain('mailto:');
+    expect(existsSync('src/pages/whats-new.astro')).toBe(true);
+    const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    expect(footer).toContain('https://www.linkedin.com/in/alehar/');
+    expect(footer).not.toContain('mailto:');
   });
 
   it('points robots.txt at the live sitemap so search can find it', () => {

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -5,7 +5,7 @@ export const prerender = true;
 
 const liveOrigin = 'https://me.alehar.workers.dev';
 
-const staticPaths = ['/', '/work/', '/biography/', '/contact/', '/whats-new'];
+const staticPaths = ['/', '/work/', '/biography/', '/contact/'];
 
 function loc(path: string) {
   return `${liveOrigin}${path}`;


### PR DESCRIPTION
## Summary
- Drop `/whats-new` from `sitemap.xml` so hiring visitors land on proof, not the changelog.
- Keep `src/pages/whats-new.astro`; `/whats-new/` still works by direct URL.
- Remaining sitemap locs stay `https://me.alehar.workers.dev`. LinkedIn hire path unchanged.

## Test plan
- [x] `identity.test.ts`: sitemap generator does not include `/whats-new`
- [x] `whats-new.astro` still exists
- [x] LinkedIn still `https://www.linkedin.com/in/alehar/`
- [x] no `mailto:`
- [x] remaining sitemap locs still use `https://me.alehar.workers.dev`
- [ ] Confirm `/whats-new/` still 200 after deploy
- [ ] Confirm live `/sitemap.xml` no longer lists `/whats-new`

Stay draft until Johan PASS and Vera PASS on the freeze SHA.