### PR TITLE
feat: drop Instagram and Facebook from site socials

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -193,8 +193,8 @@ describe('identity copy', () => {
     expect(footer).not.toContain('href="https://astro.build/"');
     expect(footer).not.toContain('instagram.com');
     expect(footer).not.toContain('facebook.com');
-    expect(nav).toContain('https://www.instagram.com/alle12393');
-    expect(nav).toContain('https://www.facebook.com/alehar9320/');
+    expect(nav).not.toContain('instagram.com');
+    expect(nav).not.toContain('facebook.com');
     expect(footer).not.toContain('Latest Updates');
     expect(footer).not.toContain('Report an issue');
     expect(footer).not.toContain('agentic engineering');
@@ -215,8 +215,8 @@ describe('identity copy', () => {
     expect(footer).toContain('Sweden');
     expect(footer).not.toContain('instagram.com');
     expect(footer).not.toContain('facebook.com');
-    expect(nav).toContain('https://www.instagram.com/alle12393');
-    expect(nav).toContain('https://www.facebook.com/alehar9320/');
+    expect(nav).not.toContain('instagram.com');
+    expect(nav).not.toContain('facebook.com');
     expect(footer).not.toContain('Designed & Developed');
     expect(footer).not.toContain('Latest Updates');
     expect(footer).not.toContain('Report an issue');
@@ -234,8 +234,8 @@ describe('identity copy', () => {
     expect(footer).toContain('Sweden');
     expect(footer).toContain('https://www.linkedin.com/in/alehar/');
     expect(footer).not.toContain('mailto:');
-    expect(nav).toContain('https://www.instagram.com/alle12393');
-    expect(nav).toContain('https://www.facebook.com/alehar9320/');
+    expect(nav).not.toContain('instagram.com');
+    expect(nav).not.toContain('facebook.com');
     expect(footer).not.toContain('instagram.com');
     expect(footer).not.toContain('facebook.com');
     expect(footer).not.toContain('with Astro');
@@ -245,6 +245,27 @@ describe('identity copy', () => {
     expect(footer).not.toContain('agentic engineering');
     expect(footer).not.toContain('>Source</span>');
     expect(footer).not.toContain('source-link');
+  });
+
+  it('drops Instagram and Facebook from site socials and keeps LinkedIn hire', () => {
+    const nav = readFileSync('src/components/Nav.astro', 'utf8');
+    const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    expect(nav).not.toContain('instagram.com');
+    expect(nav).not.toContain('facebook.com');
+    expect(footer).not.toContain('instagram.com');
+    expect(footer).not.toContain('facebook.com');
+    expect(nav).toContain('https://www.linkedin.com/in/alehar');
+    expect(footer).toContain('https://www.linkedin.com/in/alehar/');
+    expect(nav).toContain('https://github.com/alehar9320');
+    expect(footer).toContain('https://github.com/alehar9320');
+    expect(nav).not.toContain('mailto:');
+    expect(footer).not.toContain('mailto:');
+    expect(nav.toLowerCase()).not.toContain('alexander-harenstam-cv');
+    expect(footer.toLowerCase()).not.toContain('alexander-harenstam-cv');
+    expect(nav).not.toContain('.pdf');
+    expect(footer).not.toContain('.pdf');
+    expect(nav).not.toContain('instagram-logo');
+    expect(nav).not.toContain('facebook-logo');
   });
 
   it('keeps the header terminal glyph and drops the competing footer rocket', () => {

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -39,16 +39,6 @@ const iconLinks: {
     href: 'https://github.com/alehar9320',
     icon: 'github-logo',
   },
-  {
-    label: 'Instagram',
-    href: 'https://www.instagram.com/alle12393',
-    icon: 'instagram-logo',
-  },
-  {
-    label: 'Facebook',
-    href: 'https://www.facebook.com/alehar9320/',
-    icon: 'facebook-logo',
-  },
 ];
 
 /** Test if a link is pointing to the current page. */


### PR DESCRIPTION
## Summary
- Drop Instagram and Facebook from header/Nav site socials. Footer IG/FB already gone.
- Keep LinkedIn `https://www.linkedin.com/in/alehar/`, GitHub profile `https://github.com/alehar9320`, and IFS Blog. No replacement socials.
- Title stays Product Manager, Developer Experience at IFS. No public email or CV. Source, Latest Updates, Report an issue, agentic engineering, Designed & Developed, with Astro, and pin/flag stay absent.

## Test plan
- [ ] Nav/header no longer contains `instagram.com` or `facebook.com`
- [ ] Footer still does not contain `instagram.com` or `facebook.com`
- [ ] LinkedIn still `https://www.linkedin.com/in/alehar/`
- [ ] GitHub profile `https://github.com/alehar9320` kept
- [ ] No `mailto:` and no invented email or CV PDF
- [ ] Stay draft until Johan AND Vera PASS a freeze SHA. Do not merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed Instagram and Facebook links from the site navigation.
  * Retained LinkedIn, IFS Blog, and GitHub links in navigation and footer areas.
  * Confirmed navigation and footer no longer display email, CV/PDF, or social-logo references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->