### PR TITLE
feat: drop Instagram and Facebook from the header

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -193,8 +193,8 @@ describe('identity copy', () => {
     expect(footer).not.toContain('href="https://astro.build/"');
     expect(footer).not.toContain('instagram.com');
     expect(footer).not.toContain('facebook.com');
-    expect(nav).toContain('https://www.instagram.com/alle12393');
-    expect(nav).toContain('https://www.facebook.com/alehar9320/');
+    expect(nav).not.toContain('instagram.com');
+    expect(nav).not.toContain('facebook.com');
     expect(footer).not.toContain('Latest Updates');
     expect(footer).not.toContain('Report an issue');
     expect(footer).not.toContain('agentic engineering');
@@ -215,8 +215,8 @@ describe('identity copy', () => {
     expect(footer).toContain('Sweden');
     expect(footer).not.toContain('instagram.com');
     expect(footer).not.toContain('facebook.com');
-    expect(nav).toContain('https://www.instagram.com/alle12393');
-    expect(nav).toContain('https://www.facebook.com/alehar9320/');
+    expect(nav).not.toContain('instagram.com');
+    expect(nav).not.toContain('facebook.com');
     expect(footer).not.toContain('Designed & Developed');
     expect(footer).not.toContain('Latest Updates');
     expect(footer).not.toContain('Report an issue');
@@ -234,8 +234,8 @@ describe('identity copy', () => {
     expect(footer).toContain('Sweden');
     expect(footer).toContain('https://www.linkedin.com/in/alehar/');
     expect(footer).not.toContain('mailto:');
-    expect(nav).toContain('https://www.instagram.com/alle12393');
-    expect(nav).toContain('https://www.facebook.com/alehar9320/');
+    expect(nav).not.toContain('instagram.com');
+    expect(nav).not.toContain('facebook.com');
     expect(footer).not.toContain('instagram.com');
     expect(footer).not.toContain('facebook.com');
     expect(footer).not.toContain('with Astro');
@@ -245,6 +245,20 @@ describe('identity copy', () => {
     expect(footer).not.toContain('agentic engineering');
     expect(footer).not.toContain('>Source</span>');
     expect(footer).not.toContain('source-link');
+  });
+
+  it('drops Instagram and Facebook from the header and keeps LinkedIn hire', () => {
+    const nav = readFileSync('src/components/Nav.astro', 'utf8');
+    const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    expect(nav).not.toContain('instagram.com');
+    expect(nav).not.toContain('facebook.com');
+    expect(nav).toContain('https://www.linkedin.com/in/alehar');
+    expect(nav).toContain('https://github.com/alehar9320');
+    expect(nav).not.toContain('mailto:');
+    expect(footer).not.toContain('instagram.com');
+    expect(footer).not.toContain('facebook.com');
+    expect(footer).toContain('https://www.linkedin.com/in/alehar/');
+    expect(footer).not.toContain('mailto:');
   });
 
   it('keeps the header terminal glyph and drops the competing footer rocket', () => {

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -39,16 +39,6 @@ const iconLinks: {
     href: 'https://github.com/alehar9320',
     icon: 'github-logo',
   },
-  {
-    label: 'Instagram',
-    href: 'https://www.instagram.com/alle12393',
-    icon: 'instagram-logo',
-  },
-  {
-    label: 'Facebook',
-    href: 'https://www.facebook.com/alehar9320/',
-    icon: 'facebook-logo',
-  },
 ];
 
 /** Test if a link is pointing to the current page. */


### PR DESCRIPTION
## Summary
- Drop Instagram and Facebook from the header so hire stays on LinkedIn.
- Keep LinkedIn `https://www.linkedin.com/in/alehar/`, GitHub profile `https://github.com/alehar9320`, and IFS Blog. No replacement socials.
- Footer is already without Instagram and Facebook; this PR does not edit Footer.astro.
- Title stays Product Manager, Developer Experience at IFS. No public email.

## Test plan
- [ ] Header/Nav no longer contains `instagram.com` or `facebook.com`
- [ ] Header still has LinkedIn `https://www.linkedin.com/in/alehar/` and GitHub profile `https://github.com/alehar9320`
- [ ] Footer still has no `instagram.com` or `facebook.com`
- [ ] Header and footer have no `mailto:`
- [ ] Stay draft until Johan AND Vera PASS. Do not merge.