### PR TITLE
feat: put PM DevEx in Work, Biography, and Contact share titles

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -557,6 +557,25 @@ describe('identity copy', () => {
     expect(slug).not.toContain('harenstam.com');
   });
 
+  it('lets Work, Biography, and Contact shares read Product Manager, Developer Experience at IFS', () => {
+    const work = readFileSync('src/pages/work.astro', 'utf8');
+    const bio = readFileSync('src/pages/biography.astro', 'utf8');
+    const contact = readFileSync('src/pages/contact.astro', 'utf8');
+    expect(work).toContain('title="Work | Product Manager, Developer Experience at IFS"');
+    expect(bio).toContain('title="Biography | Product Manager, Developer Experience at IFS"');
+    expect(contact).toContain(
+      'title="Get in touch | Product Manager, Developer Experience at IFS"'
+    );
+    expect(work).not.toContain('title="Work | Alexander Härenstam"');
+    expect(bio).not.toContain('title="Biography | Alexander Härenstam"');
+    expect(contact).not.toContain('title="Get in touch | Alexander Härenstam"');
+    expect(bio).toContain('https://www.linkedin.com/in/alehar/');
+    expect(contact).toContain('https://www.linkedin.com/in/alehar/');
+    expect(work).not.toContain('mailto:');
+    expect(bio).not.toContain('mailto:');
+    expect(contact).not.toContain('mailto:');
+  });
+
   it('lets a Home share read Product Manager, Developer Experience at IFS', () => {
     const head = readFileSync('src/components/MainHead.astro', 'utf8');
     const home = readFileSync('src/pages/index.astro', 'utf8');

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -30,7 +30,7 @@ const schema = {
       '@type': 'WebPage',
       '@id': 'https://me.alehar.workers.dev/biography/#webpage',
       url: 'https://me.alehar.workers.dev/biography/',
-      name: 'Biography | Alexander Härenstam',
+      name: 'Biography | Product Manager, Developer Experience at IFS',
       about: { '@id': 'https://me.alehar.workers.dev/#person' },
       description: 'Product Manager, Developer Experience at IFS.',
       breadcrumb: {
@@ -56,7 +56,7 @@ const schema = {
 ---
 
 <BaseLayout
-  title="Biography | Alexander Härenstam"
+  title="Biography | Product Manager, Developer Experience at IFS"
   description="Product Manager, Developer Experience at IFS."
 >
   <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -7,7 +7,7 @@ const linkedinHref = 'https://www.linkedin.com/in/alehar/';
 ---
 
 <BaseLayout
-  title="Get in touch | Alexander Härenstam"
+  title="Get in touch | Product Manager, Developer Experience at IFS"
   description="Product Manager, Developer Experience at IFS. Get in touch on LinkedIn."
 >
   <main id="main-content" class="wrapper stack gap-8">

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -36,7 +36,7 @@ const schema = {
       '@type': 'WebPage',
       '@id': 'https://me.alehar.workers.dev/work/#webpage',
       url: 'https://me.alehar.workers.dev/work/',
-      name: 'Work | Alexander Härenstam',
+      name: 'Work | Product Manager, Developer Experience at IFS',
       description:
         'Product Manager, Developer Experience at IFS. The IFS Design System case, then earlier work.',
       breadcrumb: {
@@ -64,7 +64,7 @@ const schema = {
     },
     {
       '@type': 'ItemList',
-      name: 'Work | Alexander Härenstam',
+      name: 'Work | Product Manager, Developer Experience at IFS',
       description:
         'Product Manager, Developer Experience at IFS. The IFS Design System case, then earlier work.',
       numberOfItems: ordered.length,
@@ -81,7 +81,7 @@ const schema = {
 ---
 
 <BaseLayout
-  title="Work | Alexander Härenstam"
+  title="Work | Product Manager, Developer Experience at IFS"
   description="Product Manager, Developer Experience at IFS. The IFS Design System case, then earlier work."
 >
   <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />


### PR DESCRIPTION
## Summary
- Put Product Manager, Developer Experience at IFS in Work, Biography, and Contact share titles (document title, og:title, twitter:title via MainHead `title`).
- Match the existing What’s New pattern. LinkedIn hire unchanged. No mailto. No CV.

## Titles
- Work: `Work | Product Manager, Developer Experience at IFS`
- Biography: `Biography | Product Manager, Developer Experience at IFS`
- Contact: `Get in touch | Product Manager, Developer Experience at IFS`

## Test plan
- [ ] `npx vitest run src/__tests__/identity.test.ts`
- [ ] Confirm Work / Biography / Contact source titles include Product Manager, Developer Experience at IFS
- [ ] Confirm LinkedIn hire still points at https://www.linkedin.com/in/alehar/
- [ ] Confirm no `mailto:`
- [ ] Stay draft until Johan+Vera PASS a freeze SHA