### PR TITLE
feat: add at IFS to the Home browser title

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -592,6 +592,16 @@ describe('identity copy', () => {
     expect(head).toContain("description = 'Product Manager, Developer Experience at IFS.'");
   });
 
+  it('lets the Home browser title read Product Manager, Developer Experience at IFS', () => {
+    const home = readFileSync('src/pages/index.astro', 'utf8');
+    expect(home).toContain(
+      'title="Alexander Härenstam | Product Manager, Developer Experience at IFS"'
+    );
+    expect(home).toContain('ogTitle="Product Manager, Developer Experience at IFS"');
+    expect(home).toContain('https://www.linkedin.com/in/alehar/');
+    expect(home).not.toContain('mailto:');
+  });
+
   it('grounds llms.txt with Chalmers education and recruiter keywords', () => {
     const llms = sources.find((s) => s.path.endsWith('llms.txt'))!.text;
     expect(llms).toContain('Chalmers B.Sc. Software Engineering');

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -64,7 +64,7 @@ const schema = {
 ---
 
 <BaseLayout
-  title="Alexander Härenstam | Product Manager, Developer Experience"
+  title="Alexander Härenstam | Product Manager, Developer Experience at IFS"
   description="Product Manager, Developer Experience at IFS."
   ogTitle="Product Manager, Developer Experience at IFS"
 >


### PR DESCRIPTION
## Summary
- Add `at IFS` to the Home document `<title>` so it matches live og/twitter: `Alexander Härenstam | Product Manager, Developer Experience at IFS`.
- Leave og:title and twitter:title unchanged; they already include at IFS. LinkedIn hire unchanged. No mailto. No CV.

## Titles
- Home document: `Alexander Härenstam | Product Manager, Developer Experience at IFS`
- Home og/twitter: unchanged (`Product Manager, Developer Experience at IFS`)

## Test plan
- [ ] `npx vitest run src/__tests__/identity.test.ts`
- [ ] Confirm Home source title includes Product Manager, Developer Experience at IFS
- [ ] Confirm LinkedIn hire still points at https://www.linkedin.com/in/alehar/
- [ ] Confirm no `mailto:`
- [ ] Stay draft until Johan+Vera PASS a freeze SHA