### PR TITLE
feat: add at IFS to the JSON-LD job title

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -602,6 +602,17 @@ describe('identity copy', () => {
     expect(home).not.toContain('mailto:');
   });
 
+  it('lets Person.jobTitle read Product Manager, Developer Experience at IFS', () => {
+    const home = readFileSync('src/pages/index.astro', 'utf8');
+    const bio = readFileSync('src/pages/biography.astro', 'utf8');
+    expect(home).toContain("jobTitle: 'Product Manager, Developer Experience at IFS'");
+    expect(bio).toContain("jobTitle: 'Product Manager, Developer Experience at IFS'");
+    expect(home).toContain('https://www.linkedin.com/in/alehar/');
+    expect(bio).toContain('https://www.linkedin.com/in/alehar/');
+    expect(home).not.toContain('mailto:');
+    expect(bio).not.toContain('mailto:');
+  });
+
   it('grounds llms.txt with Chalmers education and recruiter keywords', () => {
     const llms = sources.find((s) => s.path.endsWith('llms.txt'))!.text;
     expect(llms).toContain('Chalmers B.Sc. Software Engineering');

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -10,7 +10,7 @@ const schema = {
       '@type': 'Person',
       '@id': 'https://me.alehar.workers.dev/#person',
       name: 'Alexander Härenstam',
-      jobTitle: 'Product Manager, Developer Experience',
+      jobTitle: 'Product Manager, Developer Experience at IFS',
       description:
         'Product Manager, Developer Experience at IFS. Design systems, DevEx, and Industrial AI.',
       url: 'https://me.alehar.workers.dev/',

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,7 @@ const schema = {
       '@type': 'Person',
       '@id': 'https://me.alehar.workers.dev/#person',
       name: 'Alexander Härenstam',
-      jobTitle: 'Product Manager, Developer Experience',
+      jobTitle: 'Product Manager, Developer Experience at IFS',
       description:
         'Product Manager, Developer Experience at IFS. Design systems, DevEx, and Industrial AI.',
       url: 'https://me.alehar.workers.dev/',


### PR DESCRIPTION
## Summary
- Set Person.jobTitle to `Product Manager, Developer Experience at IFS` on Home and Biography JSON-LD.
- LinkedIn hire stays `https://www.linkedin.com/in/alehar/`. No email, CV, RSS, WebSite.name, or WebPage.name changes.

## Test plan
- [ ] `identity.test.ts` asserts jobTitle includes `Product Manager, Developer Experience at IFS` on Home and Biography JSON-LD sources, no `mailto:`, LinkedIn still present
- [ ] Confirm RSS, WebSite.name, and WebPage.name are unchanged
- [ ] Stay draft until Johan+Vera PASS a freeze SHA