### PR TITLE
feat: add at IFS to the JSON-LD WebSite name

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -613,6 +613,17 @@ describe('identity copy', () => {
     expect(bio).not.toContain('mailto:');
   });
 
+  it('lets WebSite.name read Product Manager, Developer Experience at IFS', () => {
+    const home = readFileSync('src/pages/index.astro', 'utf8');
+    expect(home).toContain("'@type': 'WebSite'");
+    expect(home).toContain(
+      "name: 'Alexander Härenstam | Product Manager, Developer Experience at IFS'"
+    );
+    expect(home).toContain("jobTitle: 'Product Manager, Developer Experience at IFS'");
+    expect(home).toContain('https://www.linkedin.com/in/alehar/');
+    expect(home).not.toContain('mailto:');
+  });
+
   it('grounds llms.txt with Chalmers education and recruiter keywords', () => {
     const llms = sources.find((s) => s.path.endsWith('llms.txt'))!.text;
     expect(llms).toContain('Chalmers B.Sc. Software Engineering');

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -43,7 +43,7 @@ const schema = {
       '@type': 'WebSite',
       '@id': 'https://me.alehar.workers.dev/#website',
       url: 'https://me.alehar.workers.dev/',
-      name: 'Alexander Härenstam | Product Manager, Developer Experience',
+      name: 'Alexander Härenstam | Product Manager, Developer Experience at IFS',
       publisher: { '@id': 'https://me.alehar.workers.dev/#person' },
       description: 'Product Manager, Developer Experience at IFS.',
     },


### PR DESCRIPTION
## Summary
- Set Home JSON-LD WebSite.name to `Alexander Härenstam | Product Manager, Developer Experience at IFS`.
- LinkedIn hire stays `https://www.linkedin.com/in/alehar/`. No email, CV, RSS, WebPage.name, or jobTitle changes.

## Test plan
- [ ] `identity.test.ts` asserts WebSite.name includes `Product Manager, Developer Experience at IFS`, jobTitle still has at IFS, no `mailto:`, LinkedIn still present
- [ ] Confirm RSS, WebPage.name, and Person.jobTitle are unchanged
- [ ] Stay draft until Johan+Vera PASS a freeze SHA