### PR TITLE
feat: add at IFS to the JSON-LD WebPage name

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -624,6 +624,27 @@ describe('identity copy', () => {
     expect(home).not.toContain('mailto:');
   });
 
+  it('lets Home WebPage.name read Product Manager, Developer Experience at IFS', () => {
+    const home = readFileSync('src/pages/index.astro', 'utf8');
+    const rss = readFileSync('src/pages/rss.xml.ts', 'utf8');
+    expect(home).toContain("'@type': 'WebPage'");
+    expect(home).toContain("'@id': 'https://me.alehar.workers.dev/#webpage'");
+    expect(home).toContain(
+      `'@type': 'WebPage',
+      '@id': 'https://me.alehar.workers.dev/#webpage',
+      url: 'https://me.alehar.workers.dev/',
+      name: 'Alexander Härenstam | Product Manager, Developer Experience at IFS'`
+    );
+    expect(home).toContain("jobTitle: 'Product Manager, Developer Experience at IFS'");
+    expect(home).toContain('https://www.linkedin.com/in/alehar/');
+    expect(home).not.toContain('mailto:');
+    expect(rss).toContain(
+      '<title>Alexander Härenstam | Product Manager, Developer Experience</title>'
+    );
+    expect(rss).toContain('https://www.linkedin.com/in/alehar/');
+    expect(rss).not.toContain('mailto:');
+  });
+
   it('grounds llms.txt with Chalmers education and recruiter keywords', () => {
     const llms = sources.find((s) => s.path.endsWith('llms.txt'))!.text;
     expect(llms).toContain('Chalmers B.Sc. Software Engineering');

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -51,7 +51,7 @@ const schema = {
       '@type': 'WebPage',
       '@id': 'https://me.alehar.workers.dev/#webpage',
       url: 'https://me.alehar.workers.dev/',
-      name: 'Alexander Härenstam | Product Manager, Developer Experience',
+      name: 'Alexander Härenstam | Product Manager, Developer Experience at IFS',
       about: { '@id': 'https://me.alehar.workers.dev/#person' },
       description: 'Product Manager, Developer Experience at IFS.',
       primaryImageOfPage: {


### PR DESCRIPTION
## Summary
- Set Home JSON-LD WebPage.name to `Alexander Härenstam | Product Manager, Developer Experience at IFS`.
- Biography WebPage.name already has at IFS. LinkedIn hire stays `https://www.linkedin.com/in/alehar/`. No email, CV, RSS, WebSite.name, or jobTitle changes.

## Test plan
- [ ] `identity.test.ts` asserts Home WebPage.name includes `Product Manager, Developer Experience at IFS`, LinkedIn still present, no `mailto:`, jobTitle still has at IFS, RSS unchanged
- [ ] Confirm RSS, WebSite.name, and Person.jobTitle are unchanged
- [ ] Stay draft until Johan+Vera PASS a freeze SHA