### PR TITLE
feat: add at IFS to the RSS title

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -639,7 +639,16 @@ describe('identity copy', () => {
     expect(home).toContain('https://www.linkedin.com/in/alehar/');
     expect(home).not.toContain('mailto:');
     expect(rss).toContain(
-      '<title>Alexander Härenstam | Product Manager, Developer Experience</title>'
+      '<title>Alexander Härenstam | Product Manager, Developer Experience at IFS</title>'
+    );
+    expect(rss).toContain('https://www.linkedin.com/in/alehar/');
+    expect(rss).not.toContain('mailto:');
+  });
+
+  it('lets the RSS title read Product Manager, Developer Experience at IFS', () => {
+    const rss = readFileSync('src/pages/rss.xml.ts', 'utf8');
+    expect(rss).toContain(
+      '<title>Alexander Härenstam | Product Manager, Developer Experience at IFS</title>'
     );
     expect(rss).toContain('https://www.linkedin.com/in/alehar/');
     expect(rss).not.toContain('mailto:');
@@ -735,7 +744,9 @@ describe('identity copy', () => {
     expect(existsSync('src/pages/rss.xml.ts')).toBe(true);
     const rss = readFileSync('src/pages/rss.xml.ts', 'utf8');
     expect(rss).toContain('https://me.alehar.workers.dev');
-    expect(rss).toContain('Product Manager, Developer Experience');
+    expect(rss).toContain(
+      '<title>Alexander Härenstam | Product Manager, Developer Experience at IFS</title>'
+    );
     expect(rss).toContain('ifs-design-system');
     expect(rss).not.toContain('localhost');
     expect(rss).not.toContain('harenstam.com');

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -44,7 +44,7 @@ export const GET: APIRoute = async () => {
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>Alexander Härenstam | Product Manager, Developer Experience</title>
+    <title>Alexander Härenstam | Product Manager, Developer Experience at IFS</title>
     <link>${liveOrigin}/</link>
     <description>Product Manager, Developer Experience at IFS.</description>
     <atom:link href="${liveOrigin}/rss.xml" rel="self" type="application/rss+xml"/>


### PR DESCRIPTION
## Summary
- Set the RSS channel title to `Alexander Härenstam | Product Manager, Developer Experience at IFS`.
- RSS description already has at IFS. JSON-LD jobTitle, WebSite.name, and WebPage.name are unchanged. LinkedIn hire stays `https://www.linkedin.com/in/alehar/`. No email or CV.

## Test plan
- [ ] `identity.test.ts` asserts rss.xml.ts title includes `Product Manager, Developer Experience at IFS`, LinkedIn still present, no `mailto:`, JSON-LD jobTitle/WebSite/WebPage not changed
- [ ] Confirm JSON-LD jobTitle, WebSite.name, and WebPage.name are unchanged
- [ ] Stay draft until Johan+Vera PASS a freeze SHA