### PR TITLE
feat: add at IFS to the Home RSS alternate link title

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -654,6 +654,26 @@ describe('identity copy', () => {
     expect(rss).not.toContain('mailto:');
   });
 
+  it('lets the Home RSS alternate link title read Product Manager, Developer Experience at IFS', () => {
+    const head = readFileSync('src/components/MainHead.astro', 'utf8');
+    const home = readFileSync('src/pages/index.astro', 'utf8');
+    const rss = readFileSync('src/pages/rss.xml.ts', 'utf8');
+    expect(head).toContain('rel="alternate"');
+    expect(head).toContain('type="application/rss+xml"');
+    expect(head).toContain(
+      'title="Alexander Härenstam | Product Manager, Developer Experience at IFS"'
+    );
+    expect(head).toContain('https://me.alehar.workers.dev/rss.xml');
+    expect(home).toContain('https://www.linkedin.com/in/alehar/');
+    expect(head).not.toContain('mailto:');
+    expect(home).not.toContain('mailto:');
+    expect(rss).toContain(
+      '<title>Alexander Härenstam | Product Manager, Developer Experience at IFS</title>'
+    );
+    expect(rss).toContain('https://www.linkedin.com/in/alehar/');
+    expect(rss).not.toContain('mailto:');
+  });
+
   it('grounds llms.txt with Chalmers education and recruiter keywords', () => {
     const llms = sources.find((s) => s.path.endsWith('llms.txt'))!.text;
     expect(llms).toContain('Chalmers B.Sc. Software Engineering');

--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -47,7 +47,7 @@ const shareUrl = new URL(Astro.url.pathname, liveOrigin).href;
 <link
   rel="alternate"
   type="application/rss+xml"
-  title="Alexander Härenstam | Product Manager, Developer Experience"
+  title="Alexander Härenstam | Product Manager, Developer Experience at IFS"
   href="https://me.alehar.workers.dev/rss.xml"
 />
 <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
## Summary
- Set the Home `<link rel="alternate">` title to `Alexander Härenstam | Product Manager, Developer Experience at IFS`.
- `rss.xml.ts` channel title already has at IFS from #545. JSON-LD is unchanged. LinkedIn hire stays `https://www.linkedin.com/in/alehar/`. No email or CV.

## Test plan
- [ ] `identity.test.ts` asserts the Home RSS alternate link title includes `Product Manager, Developer Experience at IFS`, LinkedIn still present, no `mailto:`, rss.xml.ts still at IFS
- [ ] Confirm `src/pages/rss.xml.ts` and JSON-LD are unchanged
- [ ] Stay draft until Johan+Vera PASS a freeze SHA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the RSS feed link title to include “at IFS.”
  - Ensured the Home page displays the expected RSS URL and professional identity details.
  - Removed unintended mailto links from Home and RSS content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->