### PR TITLE
feat: add Get in touch on LinkedIn to the Home share description

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -576,18 +576,26 @@ describe('identity copy', () => {
     expect(contact).not.toContain('mailto:');
   });
 
-  it('lets a Home share read Product Manager, Developer Experience at IFS', () => {
+  it('lets a Home share read Product Manager, Developer Experience at IFS and LinkedIn', () => {
     const head = readFileSync('src/components/MainHead.astro', 'utf8');
     const home = readFileSync('src/pages/index.astro', 'utf8');
     const layout = readFileSync('src/layouts/BaseLayout.astro', 'utf8');
+    const contact = readFileSync('src/pages/contact.astro', 'utf8');
+    const shareDescription =
+      'Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.';
     expect(home).toContain('ogTitle="Product Manager, Developer Experience at IFS"');
-    expect(home).toContain('description="Product Manager, Developer Experience at IFS."');
+    expect(home).toContain(`description="${shareDescription}"`);
+    expect(contact).toContain(`description="${shareDescription}"`);
     expect(home).toContain('Hero title="Product Manager, Developer Experience at IFS"');
     expect(home).toContain('https://www.linkedin.com/in/alehar/');
     expect(home).not.toContain('mailto:');
+    expect(contact).toContain('https://www.linkedin.com/in/alehar/');
+    expect(contact).not.toContain('mailto:');
     expect(layout).toContain('ogTitle={ogTitle}');
     expect(head).toContain('content={shareTitle}');
     expect(head).toContain('property="og:title"');
+    expect(head).toContain('name="description" property="og:description" content={description}');
+    expect(head).toContain('name="twitter:description" content={description}');
     expect(head).not.toContain('Design systems, DevEx, and Industrial AI.');
     expect(head).toContain("description = 'Product Manager, Developer Experience at IFS.'");
   });

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -65,7 +65,7 @@ const schema = {
 
 <BaseLayout
   title="Alexander Härenstam | Product Manager, Developer Experience at IFS"
-  description="Product Manager, Developer Experience at IFS."
+  description="Product Manager, Developer Experience at IFS. Get in touch on LinkedIn."
   ogTitle="Product Manager, Developer Experience at IFS"
 >
   <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />


### PR DESCRIPTION
## Summary
- Home meta/og/twitter description now matches Contact: `Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.`
- LinkedIn hire unchanged (`https://www.linkedin.com/in/alehar/`). No mailto. No CV.
- Draft until Johan+Vera PASS. Do not merge. Stay off #512.

## Test plan
- [ ] `npx vitest run src/__tests__/identity.test.ts`
- [ ] Confirm Home meta, og:description, and twitter:description match Contact
- [ ] Confirm LinkedIn hire still points at https://www.linkedin.com/in/alehar/
- [ ] Confirm no `mailto:`
- [ ] Stay draft until Johan+Vera PASS a freeze SHA