### PR TITLE
feat: add Get in touch on LinkedIn to the Biography share description

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -576,6 +576,19 @@ describe('identity copy', () => {
     expect(contact).not.toContain('mailto:');
   });
 
+  it('lets a Biography share read Product Manager, Developer Experience at IFS and LinkedIn', () => {
+    const head = readFileSync('src/components/MainHead.astro', 'utf8');
+    const bio = readFileSync('src/pages/biography.astro', 'utf8');
+    const shareDescription =
+      'Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.';
+    expect(bio).toContain(`description="${shareDescription}"`);
+    expect(bio).toContain('title="Biography | Product Manager, Developer Experience at IFS"');
+    expect(bio).toContain('https://www.linkedin.com/in/alehar/');
+    expect(bio).not.toContain('mailto:');
+    expect(head).toContain('name="description" property="og:description" content={description}');
+    expect(head).toContain('name="twitter:description" content={description}');
+  });
+
   it('lets a Home share read Product Manager, Developer Experience at IFS and LinkedIn', () => {
     const head = readFileSync('src/components/MainHead.astro', 'utf8');
     const home = readFileSync('src/pages/index.astro', 'utf8');

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -57,7 +57,7 @@ const schema = {
 
 <BaseLayout
   title="Biography | Product Manager, Developer Experience at IFS"
-  description="Product Manager, Developer Experience at IFS."
+  description="Product Manager, Developer Experience at IFS. Get in touch on LinkedIn."
 >
   <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
 


### PR DESCRIPTION
## Summary
- Biography meta/og/twitter description now: `Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.`
- Home unchanged.
- LinkedIn hire unchanged (`https://www.linkedin.com/in/alehar/`). No mailto. No CV.
- Draft until Johan+Vera PASS. Do not merge. Stay off #512.

## Test plan
- [ ] `npx vitest run src/__tests__/identity.test.ts`
- [ ] Confirm Biography meta, og:description, and twitter:description match Contact
- [ ] Confirm Home share description unchanged
- [ ] Confirm LinkedIn hire still points at https://www.linkedin.com/in/alehar/
- [ ] Confirm no `mailto:`
- [ ] Stay draft until Johan+Vera PASS a freeze SHA