### PR TITLE
feat: add Get in touch on LinkedIn to the Work share description

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -576,6 +576,23 @@ describe('identity copy', () => {
     expect(contact).not.toContain('mailto:');
   });
 
+  it('lets a Work share read Product Manager, Developer Experience at IFS and LinkedIn', () => {
+    const head = readFileSync('src/components/MainHead.astro', 'utf8');
+    const work = readFileSync('src/pages/work.astro', 'utf8');
+    const cta = readFileSync('src/components/ContactCTA.astro', 'utf8');
+    const shareDescription =
+      'Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.';
+    expect(work).toContain(`description="${shareDescription}"`);
+    expect(work).toContain('title="Work | Product Manager, Developer Experience at IFS"');
+    expect(work).toContain('Product Manager, Developer Experience at IFS');
+    expect(work).toContain('Get in touch on LinkedIn.');
+    expect(cta).toContain('https://www.linkedin.com/in/alehar/');
+    expect(work).not.toContain('mailto:');
+    expect(cta).not.toContain('mailto:');
+    expect(head).toContain('name="description" property="og:description" content={description}');
+    expect(head).toContain('name="twitter:description" content={description}');
+  });
+
   it('lets a Biography share read Product Manager, Developer Experience at IFS and LinkedIn', () => {
     const head = readFileSync('src/components/MainHead.astro', 'utf8');
     const bio = readFileSync('src/pages/biography.astro', 'utf8');

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -82,7 +82,7 @@ const schema = {
 
 <BaseLayout
   title="Work | Product Manager, Developer Experience at IFS"
-  description="Product Manager, Developer Experience at IFS. The IFS Design System case, then earlier work."
+  description="Product Manager, Developer Experience at IFS. Get in touch on LinkedIn."
 >
   <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
   <div class="stack gap-20">


### PR DESCRIPTION
## Summary
- Work meta/og/twitter description now: `Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.`
- Home and Biography unchanged.
- LinkedIn hire unchanged (`https://www.linkedin.com/in/alehar/`). No mailto. No CV.
- Draft until Johan+Vera PASS. Do not merge. Stay off #512.

## Test plan
- [ ] `npx vitest run src/__tests__/identity.test.ts`
- [ ] Confirm Work meta, og:description, and twitter:description match Contact
- [ ] Confirm Home and Biography share descriptions unchanged
- [ ] Confirm LinkedIn hire still points at https://www.linkedin.com/in/alehar/
- [ ] Confirm no `mailto:`
- [ ] Stay draft until Johan+Vera PASS a freeze SHA