### PR TITLE
feat: add Get in touch on LinkedIn to the RSS channel description

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -692,6 +692,18 @@ describe('identity copy', () => {
     expect(rss).not.toContain('mailto:');
   });
 
+  it('lets the RSS channel description read Product Manager, Developer Experience at IFS and LinkedIn', () => {
+    const rss = readFileSync('src/pages/rss.xml.ts', 'utf8');
+    const channelDescription =
+      'Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.';
+    expect(rss).toContain(`<description>${channelDescription}</description>`);
+    expect(rss).toContain(
+      '<title>Alexander Härenstam | Product Manager, Developer Experience at IFS</title>'
+    );
+    expect(rss).toContain('https://www.linkedin.com/in/alehar/');
+    expect(rss).not.toContain('mailto:');
+  });
+
   it('lets the Home RSS alternate link title read Product Manager, Developer Experience at IFS', () => {
     const head = readFileSync('src/components/MainHead.astro', 'utf8');
     const home = readFileSync('src/pages/index.astro', 'utf8');
@@ -804,6 +816,9 @@ describe('identity copy', () => {
     expect(rss).toContain('https://me.alehar.workers.dev');
     expect(rss).toContain(
       '<title>Alexander Härenstam | Product Manager, Developer Experience at IFS</title>'
+    );
+    expect(rss).toContain(
+      '<description>Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.</description>'
     );
     expect(rss).toContain('ifs-design-system');
     expect(rss).not.toContain('localhost');

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -46,7 +46,7 @@ export const GET: APIRoute = async () => {
   <channel>
     <title>Alexander Härenstam | Product Manager, Developer Experience at IFS</title>
     <link>${liveOrigin}/</link>
-    <description>Product Manager, Developer Experience at IFS.</description>
+    <description>Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.</description>
     <atom:link href="${liveOrigin}/rss.xml" rel="self" type="application/rss+xml"/>
     <atom:link href="${hireLinkedIn}" rel="related"/>
 ${items.map(itemXml).join('\n')}


### PR DESCRIPTION
## Summary
- RSS channel description now: `Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.`
- Home, Biography, and Work share descriptions unchanged.
- RSS title unchanged.
- LinkedIn hire unchanged (`https://www.linkedin.com/in/alehar/`). No mailto. No CV.
- Draft until Johan+Vera PASS. Do not merge. Stay off #512.

## Test plan
- [ ] `npx vitest run src/__tests__/identity.test.ts`
- [ ] Confirm RSS channel `<description>` is `Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.`
- [ ] Confirm RSS `<title>` unchanged
- [ ] Confirm Home, Biography, and Work share descriptions unchanged
- [ ] Confirm LinkedIn hire still points at https://www.linkedin.com/in/alehar/
- [ ] Confirm no `mailto:`
- [ ] Stay draft until Johan+Vera PASS a freeze SHA