### PR TITLE
feat: add Get in touch on LinkedIn to the JSON-LD WebPage description

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -683,6 +683,37 @@ describe('identity copy', () => {
     expect(rss).not.toContain('mailto:');
   });
 
+  it('lets Home and Biography WebPage.description read Product Manager, Developer Experience at IFS and LinkedIn', () => {
+    const home = readFileSync('src/pages/index.astro', 'utf8');
+    const bio = readFileSync('src/pages/biography.astro', 'utf8');
+    const webpageDescription =
+      'Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.';
+    expect(home).toContain("'@type': 'WebPage'");
+    expect(home).toContain(
+      `'@type': 'WebPage',
+      '@id': 'https://me.alehar.workers.dev/#webpage',
+      url: 'https://me.alehar.workers.dev/',
+      name: 'Alexander Härenstam | Product Manager, Developer Experience at IFS',
+      about: { '@id': 'https://me.alehar.workers.dev/#person' },
+      description: '${webpageDescription}'`
+    );
+    expect(bio).toContain("'@type': 'WebPage'");
+    expect(bio).toContain(
+      `'@type': 'WebPage',
+      '@id': 'https://me.alehar.workers.dev/biography/#webpage',
+      url: 'https://me.alehar.workers.dev/biography/',
+      name: 'Biography | Product Manager, Developer Experience at IFS',
+      about: { '@id': 'https://me.alehar.workers.dev/#person' },
+      description: '${webpageDescription}'`
+    );
+    expect(home).toContain("jobTitle: 'Product Manager, Developer Experience at IFS'");
+    expect(bio).toContain("jobTitle: 'Product Manager, Developer Experience at IFS'");
+    expect(home).toContain('https://www.linkedin.com/in/alehar/');
+    expect(bio).toContain('https://www.linkedin.com/in/alehar/');
+    expect(home).not.toContain('mailto:');
+    expect(bio).not.toContain('mailto:');
+  });
+
   it('lets the RSS title read Product Manager, Developer Experience at IFS', () => {
     const rss = readFileSync('src/pages/rss.xml.ts', 'utf8');
     expect(rss).toContain(

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -32,7 +32,7 @@ const schema = {
       url: 'https://me.alehar.workers.dev/biography/',
       name: 'Biography | Product Manager, Developer Experience at IFS',
       about: { '@id': 'https://me.alehar.workers.dev/#person' },
-      description: 'Product Manager, Developer Experience at IFS.',
+      description: 'Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.',
       breadcrumb: {
         '@type': 'BreadcrumbList',
         itemListElement: [

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -53,7 +53,7 @@ const schema = {
       url: 'https://me.alehar.workers.dev/',
       name: 'Alexander Härenstam | Product Manager, Developer Experience at IFS',
       about: { '@id': 'https://me.alehar.workers.dev/#person' },
-      description: 'Product Manager, Developer Experience at IFS.',
+      description: 'Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.',
       primaryImageOfPage: {
         '@type': 'ImageObject',
         url: 'https://me.alehar.workers.dev/assets/portrait.png',


### PR DESCRIPTION
## Summary
- JSON-LD WebPage.description now: `Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.`
- RSS, share descriptions, and other JSON-LD fields unchanged (WebSite.*, Person.*, WebPage.name).
- LinkedIn hire unchanged (`https://www.linkedin.com/in/alehar/`). No mailto. No CV.
- Draft until Johan+Vera PASS. Do not merge. Stay off #512.

## Test plan
- [ ] `npx vitest run src/__tests__/identity.test.ts`
- [ ] Confirm Home and Biography JSON-LD WebPage.description is `Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.`
- [ ] Confirm RSS, share descriptions, WebSite.*, Person.*, and WebPage.name are unchanged
- [ ] Confirm LinkedIn hire still points at https://www.linkedin.com/in/alehar/
- [ ] Confirm no `mailto:`
- [ ] Stay draft until Johan+Vera PASS a freeze SHA