### PR TITLE
feat: add Get in touch on LinkedIn to the JSON-LD WebSite description

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -662,6 +662,24 @@ describe('identity copy', () => {
     expect(home).not.toContain('mailto:');
   });
 
+  it('lets WebSite.description read Product Manager, Developer Experience at IFS and LinkedIn', () => {
+    const home = readFileSync('src/pages/index.astro', 'utf8');
+    const websiteDescription =
+      'Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.';
+    expect(home).toContain("'@type': 'WebSite'");
+    expect(home).toContain(
+      `'@type': 'WebSite',
+      '@id': 'https://me.alehar.workers.dev/#website',
+      url: 'https://me.alehar.workers.dev/',
+      name: 'Alexander Härenstam | Product Manager, Developer Experience at IFS',
+      publisher: { '@id': 'https://me.alehar.workers.dev/#person' },
+      description: '${websiteDescription}'`
+    );
+    expect(home).toContain("jobTitle: 'Product Manager, Developer Experience at IFS'");
+    expect(home).toContain('https://www.linkedin.com/in/alehar/');
+    expect(home).not.toContain('mailto:');
+  });
+
   it('lets Home WebPage.name read Product Manager, Developer Experience at IFS', () => {
     const home = readFileSync('src/pages/index.astro', 'utf8');
     const rss = readFileSync('src/pages/rss.xml.ts', 'utf8');

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -45,7 +45,7 @@ const schema = {
       url: 'https://me.alehar.workers.dev/',
       name: 'Alexander Härenstam | Product Manager, Developer Experience at IFS',
       publisher: { '@id': 'https://me.alehar.workers.dev/#person' },
-      description: 'Product Manager, Developer Experience at IFS.',
+      description: 'Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.',
     },
     {
       '@type': 'WebPage',


### PR DESCRIPTION
## Summary
- JSON-LD WebSite.description now: `Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.`
- WebPage.description, RSS, and share descriptions unchanged
- LinkedIn hire unchanged (`https://www.linkedin.com/in/alehar/`). No mailto. No CV.
- Draft until Johan+Vera PASS. Do not merge. Stay off #512.

## Test plan
- [ ] `npx vitest run src/__tests__/identity.test.ts`
- [ ] Confirm Home JSON-LD WebSite.description is `Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.`
- [ ] Confirm WebPage.description, RSS, share descriptions, WebSite.name, Person.*, and WebPage.name are unchanged
- [ ] Confirm LinkedIn hire still points at https://www.linkedin.com/in/alehar/
- [ ] Confirm no `mailto:`
- [ ] Stay draft until Johan+Vera PASS a freeze SHA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the homepage’s structured metadata description to include the Product Manager, Developer Experience title and LinkedIn contact wording.
  * Preserved existing site, person, and contact information while removing email-link references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->