### PR TITLE
feat: rewrite the not-found share description to the live tagline

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -833,6 +833,11 @@ describe('identity copy', () => {
     expect(page).toContain(
       'ogTitle="Page not found | Product Manager, Developer Experience at IFS"'
     );
+    const head = readFileSync('src/components/MainHead.astro', 'utf8');
+    expect(page).toContain('description="This page isn\'t here."');
+    expect(page).not.toContain('404 Error — this page was not found');
+    expect(head).toContain('name="description" property="og:description" content={description}');
+    expect(head).toContain('name="twitter:description" content={description}');
     expect(notFound).toContain('Product Manager, Developer Experience at IFS');
     expect(notFound).not.toContain('mailto:');
     expect(notFound).not.toContain('this is not on the site');

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -8,7 +8,7 @@ Astro.response.status = 404;
 <BaseLayout
   title="Page not found | Product Manager, Developer Experience at IFS"
   ogTitle="Page not found | Product Manager, Developer Experience at IFS"
-  description="404 Error — this page was not found"
+  description="This page isn't here."
 >
   <NotFoundContent />
 </BaseLayout>


### PR DESCRIPTION
404 meta/og/twitter description now matches the live tagline (`This page isn't here.`).

H1, on-page tagline, and LinkedIn CTA are unchanged.
LinkedIn hire path stays https://www.linkedin.com/in/alehar/.

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.