### PR TITLE
feat: point 404 share URLs at live Home

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -322,7 +322,7 @@ describe('identity copy', () => {
     expect(head).toContain('name="twitter:url"');
     expect(head).toContain('content={shareUrl}');
     expect(head).toContain('rel="canonical"');
-    expect(head).toContain('href={shareUrl}');
+    expect(head).toContain('href={canonicalUrl}');
     expect(head).not.toContain('content={Astro.url}');
     expect(head).not.toContain('localhost');
     expect(head).not.toContain('harenstam.com');
@@ -862,6 +862,17 @@ describe('identity copy', () => {
     expect(notFound).not.toContain("this isn't on the site yet");
     expect(notFound.toLowerCase()).not.toContain('this page is missing');
     expect(notFound.toLowerCase()).not.toContain("we couldn't find");
+  });
+
+  it('points 404 og:url and twitter:url at live Home', () => {
+    const page = readFileSync('src/pages/404.astro', 'utf8');
+    const head = readFileSync('src/components/MainHead.astro', 'utf8');
+    expect(page).toContain('shareUrl="https://me.alehar.workers.dev/"');
+    expect(head).toContain('property="og:url"');
+    expect(head).toContain('content={shareUrl}');
+    expect(head).toContain('name="twitter:url"');
+    expect(head).toContain('rel="canonical"');
+    expect(head).toContain('href={canonicalUrl}');
   });
 
   it('ships a live RSS feed at /rss.xml so visitors can follow new work', () => {

--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -6,17 +6,20 @@ interface Props {
   title?: string | undefined;
   description?: string | undefined;
   ogTitle?: string | undefined;
+  shareUrl?: string | undefined;
 }
 
 const {
   title = 'Alexander Härenstam | Product Manager, Developer Experience',
   description = 'Product Manager, Developer Experience at IFS.',
   ogTitle,
+  shareUrl: shareUrlProp,
 } = Astro.props;
 const shareTitle = ogTitle ?? title;
 const shareImage = 'https://me.alehar.workers.dev/assets/portrait.png';
 const liveOrigin = 'https://me.alehar.workers.dev';
-const shareUrl = new URL(Astro.url.pathname, liveOrigin).href;
+const canonicalUrl = new URL(Astro.url.pathname, liveOrigin).href;
+const shareUrl = shareUrlProp ?? canonicalUrl;
 ---
 
 <meta charset="UTF-8" />
@@ -29,7 +32,7 @@ const shareUrl = new URL(Astro.url.pathname, liveOrigin).href;
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="website" />
 <meta property="og:url" content={shareUrl} />
-<link rel="canonical" href={shareUrl} />
+<link rel="canonical" href={canonicalUrl} />
 <meta property="og:title" content={shareTitle} />
 <meta property="og:image" content={shareImage} />
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -12,14 +12,15 @@ interface Props {
   title?: string | undefined;
   description?: string | undefined;
   ogTitle?: string | undefined;
+  shareUrl?: string | undefined;
 }
 
-const { title, description, ogTitle } = Astro.props;
+const { title, description, ogTitle, shareUrl } = Astro.props;
 ---
 
 <html lang="en">
   <head>
-    <MainHead title={title} description={description} ogTitle={ogTitle} />
+    <MainHead title={title} description={description} ogTitle={ogTitle} shareUrl={shareUrl} />
   </head>
   <body>
     <!-- Skip to content link for accessibility -->

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -9,6 +9,7 @@ Astro.response.status = 404;
   title="Page not found | Product Manager, Developer Experience at IFS"
   ogTitle="Page not found | Product Manager, Developer Experience at IFS"
   description="This page isn't here."
+  shareUrl="https://me.alehar.workers.dev/"
 >
   <NotFoundContent />
 </BaseLayout>


### PR DESCRIPTION
404 `og:url` and `twitter:url` now point at live Home https://me.alehar.workers.dev/

H1 (`Page not found`), tagline (`This page isn't here.`), share description, and LinkedIn CTA unchanged.
LinkedIn hire unchanged (https://www.linkedin.com/in/alehar/).
`rel=canonical` left on the 404 URL.

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.