### PR TITLE
feat: point 404 rel=canonical at live Home

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -868,6 +868,7 @@ describe('identity copy', () => {
     const page = readFileSync('src/pages/404.astro', 'utf8');
     const head = readFileSync('src/components/MainHead.astro', 'utf8');
     expect(page).toContain('shareUrl="https://me.alehar.workers.dev/"');
+    expect(page).toContain('canonicalUrl="https://me.alehar.workers.dev/"');
     expect(head).toContain('property="og:url"');
     expect(head).toContain('content={shareUrl}');
     expect(head).toContain('name="twitter:url"');

--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -7,6 +7,7 @@ interface Props {
   description?: string | undefined;
   ogTitle?: string | undefined;
   shareUrl?: string | undefined;
+  canonicalUrl?: string | undefined;
 }
 
 const {
@@ -14,11 +15,12 @@ const {
   description = 'Product Manager, Developer Experience at IFS.',
   ogTitle,
   shareUrl: shareUrlProp,
+  canonicalUrl: canonicalUrlProp,
 } = Astro.props;
 const shareTitle = ogTitle ?? title;
 const shareImage = 'https://me.alehar.workers.dev/assets/portrait.png';
 const liveOrigin = 'https://me.alehar.workers.dev';
-const canonicalUrl = new URL(Astro.url.pathname, liveOrigin).href;
+const canonicalUrl = canonicalUrlProp ?? new URL(Astro.url.pathname, liveOrigin).href;
 const shareUrl = shareUrlProp ?? canonicalUrl;
 ---
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,14 +13,21 @@ interface Props {
   description?: string | undefined;
   ogTitle?: string | undefined;
   shareUrl?: string | undefined;
+  canonicalUrl?: string | undefined;
 }
 
-const { title, description, ogTitle, shareUrl } = Astro.props;
+const { title, description, ogTitle, shareUrl, canonicalUrl } = Astro.props;
 ---
 
 <html lang="en">
   <head>
-    <MainHead title={title} description={description} ogTitle={ogTitle} shareUrl={shareUrl} />
+    <MainHead
+      title={title}
+      description={description}
+      ogTitle={ogTitle}
+      shareUrl={shareUrl}
+      canonicalUrl={canonicalUrl}
+    />
   </head>
   <body>
     <!-- Skip to content link for accessibility -->

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -10,6 +10,7 @@ Astro.response.status = 404;
   ogTitle="Page not found | Product Manager, Developer Experience at IFS"
   description="This page isn't here."
   shareUrl="https://me.alehar.workers.dev/"
+  canonicalUrl="https://me.alehar.workers.dev/"
 >
   <NotFoundContent />
 </BaseLayout>


### PR DESCRIPTION
404 `rel=canonical` now points at live Home https://me.alehar.workers.dev/

`og:url` and `twitter:url` still Home.
H1 (`Page not found`), tagline (`This page isn't here.`), share description, and LinkedIn CTA unchanged.
LinkedIn hire unchanged (https://www.linkedin.com/in/alehar/).

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.