### PR TITLE
feat: return HTTP 404 for GET /404/

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
+import { fetchDirectNotFound, isDirectNotFoundPath } from '../direct-not-found';
 import { toVisitorChangelogTitle, toVisitorRelease } from '../utils/visitor-changelog';
 
 const files = [
@@ -874,6 +875,36 @@ describe('identity copy', () => {
     expect(head).toContain('name="twitter:url"');
     expect(head).toContain('rel="canonical"');
     expect(head).toContain('href={canonicalUrl}');
+  });
+
+  it('GET /404/ returns HTTP 404', async () => {
+    const page = readFileSync('src/pages/404.astro', 'utf8');
+    const content = readFileSync('src/components/NotFoundContent.astro', 'utf8');
+    const wrangler = readFileSync('wrangler.jsonc', 'utf8');
+    const worker = readFileSync('src/cloudflare-worker.ts', 'utf8');
+    expect(page).toContain('Astro.response.status = 404');
+    expect(page).toContain('title="Page not found | Product Manager, Developer Experience at IFS"');
+    expect(page).toContain('description="This page isn\'t here."');
+    expect(page).toContain('shareUrl="https://me.alehar.workers.dev/"');
+    expect(page).toContain('canonicalUrl="https://me.alehar.workers.dev/"');
+    expect(content).toContain('title="Page not found"');
+    expect(content).toContain('tagline="This page isn\'t here."');
+    expect(content).toContain('https://www.linkedin.com/in/alehar/');
+    expect(content).not.toContain('mailto:');
+    expect(wrangler).toContain('./src/cloudflare-worker.ts');
+    expect(wrangler).toContain('run_worker_first');
+    expect(wrangler).toContain('"/404/"');
+    expect(wrangler).toContain('"/404"');
+    expect(worker).toContain('fetchDirectNotFound');
+    expect(isDirectNotFoundPath('/404/')).toBe(true);
+    expect(isDirectNotFoundPath('/404')).toBe(true);
+    expect(isDirectNotFoundPath('/')).toBe(false);
+    const html = "<h1>Page not found</h1><p>This page isn't here.</p>";
+    const response = await fetchDirectNotFound(new Request('https://me.alehar.workers.dev/404/'), {
+      fetch: async () => new Response(html, { status: 200 }),
+    });
+    expect(response.status).toBe(404);
+    expect(await response.text()).toContain('Page not found');
   });
 
   it('ships a live RSS feed at /rss.xml so visitors can follow new work', () => {

--- a/src/cloudflare-worker.ts
+++ b/src/cloudflare-worker.ts
@@ -1,0 +1,12 @@
+import astro from '@astrojs/cloudflare/entrypoints/server';
+
+import { fetchDirectNotFound, isDirectNotFoundPath } from './direct-not-found';
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    if (isDirectNotFoundPath(new URL(request.url).pathname)) {
+      return fetchDirectNotFound(request, env.ASSETS);
+    }
+    return astro.fetch(request, env, ctx);
+  },
+};

--- a/src/direct-not-found.ts
+++ b/src/direct-not-found.ts
@@ -1,0 +1,22 @@
+export function isDirectNotFoundPath(pathname: string): boolean {
+  return pathname === '/404' || pathname === '/404/';
+}
+
+export function withNotFoundStatus(response: Response): Response {
+  if (response.status === 404) {
+    return response;
+  }
+  return new Response(response.body, {
+    status: 404,
+    statusText: 'Not Found',
+    headers: response.headers,
+  });
+}
+
+export async function fetchDirectNotFound(
+  request: Request,
+  assets: { fetch: (input: Request | URL | string) => Promise<Response> }
+): Promise<Response> {
+  const asset = await assets.fetch(new URL('/404', request.url));
+  return withNotFoundStatus(asset);
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,10 +2,11 @@
   "compatibility_date": "2026-03-12",
   "compatibility_flags": ["global_fetch_strictly_public"],
   "name": "me",
-  "main": "@astrojs/cloudflare/entrypoints/server",
+  "main": "./src/cloudflare-worker.ts",
   "assets": {
     "directory": "./dist",
-    "binding": "ASSETS"
+    "binding": "ASSETS",
+    "run_worker_first": ["/404", "/404/"]
   },
   "observability": {
     "enabled": true


### PR DESCRIPTION
GET `/404/` now returns HTTP 404.

Page copy, share URL, canonical at Home, LinkedIn CTA unchanged.
LinkedIn hire unchanged (https://www.linkedin.com/in/alehar/).

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Direct requests to `/404` and `/404/` now return the correct HTTP 404 status.
  * The not-found page content and metadata are preserved when accessed directly.
  * Cloudflare-hosted routing now correctly handles direct not-found requests while continuing to serve other requests normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->