### PR TITLE
feat: drop Lidköping Stenhuggeri from the sitemap

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -796,10 +796,12 @@ describe('identity copy', () => {
     expect(sitemap).not.toContain('/experimental/now');
     expect(sitemap).not.toContain('/experimental/reading-list');
     expect(sitemap).not.toContain('/whats-new');
+    expect(sitemap).not.toContain('/work/lidkoping-stenhuggeri');
     expect(sitemap).not.toContain('localhost');
     expect(sitemap).not.toContain('harenstam.com');
     expect(sitemap).not.toContain('mailto:');
     expect(existsSync('src/pages/whats-new.astro')).toBe(true);
+    expect(existsSync('src/content/work/lidkoping-stenhuggeri.md')).toBe(true);
     const footer = readFileSync('src/components/Footer.astro', 'utf8');
     expect(footer).toContain('https://www.linkedin.com/in/alehar/');
     expect(footer).not.toContain('mailto:');

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -25,7 +25,9 @@ export const GET: APIRoute = async () => {
   const work = await getCollection('work');
   const urls = [
     ...staticPaths.map((path) => urlXml(path)),
-    ...work.map((entry) => urlXml(`/work/${entry.id}/`, entry.data.publishDate)),
+    ...work
+      .filter((entry) => entry.id !== 'lidkoping-stenhuggeri')
+      .map((entry) => urlXml(`/work/${entry.id}/`, entry.data.publishDate)),
   ];
 
   const xml = `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Lidköping Stenhuggeri dropped from sitemap.xml.
Page itself kept (`/work/lidkoping-stenhuggeri/`).
LinkedIn hire unchanged (https://www.linkedin.com/in/alehar/).

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.