### PR TITLE
feat: add robots noindex on the Lidköping Stenhuggeri work page

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -808,6 +808,32 @@ describe('identity copy', () => {
     expect(footer).not.toContain('mailto:');
   });
 
+  it('adds robots noindex on the Lidköping Stenhuggeri work page and keeps the page', () => {
+    expect(existsSync('src/content/work/lidkoping-stenhuggeri.md')).toBe(true);
+    const lidkoping = readFileSync('src/content/work/lidkoping-stenhuggeri.md', 'utf8');
+    expect(lidkoping).toContain('title: Lidköping Stenhuggeri');
+    expect(lidkoping).toContain('Early Android work, 2013');
+    expect(lidkoping).not.toContain('mailto:');
+    const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
+    expect(slug).toContain("entry?.id === 'lidkoping-stenhuggeri' ? 'noindex'");
+    expect(slug).toContain('robots={robots}');
+    expect((slug.match(/noindex/g) || []).length).toBe(1);
+    expect(slug).not.toContain('nofollow');
+    const head = readFileSync('src/components/MainHead.astro', 'utf8');
+    expect(head).toContain('<meta name="robots" content={robots} />');
+    expect(head).not.toContain('nofollow');
+    const layout = readFileSync('src/layouts/BaseLayout.astro', 'utf8');
+    expect(layout).toContain('robots={robots}');
+    const sitemap = readFileSync('src/pages/sitemap.xml.ts', 'utf8');
+    expect(sitemap).not.toContain('/work/lidkoping-stenhuggeri');
+    expect(sitemap).toContain('ifs-design-system');
+    const work = readFileSync('src/pages/work.astro', 'utf8');
+    expect(work).toContain("'lidkoping-stenhuggeri'");
+    const cta = readFileSync('src/components/ContactCTA.astro', 'utf8');
+    expect(cta).toContain('https://www.linkedin.com/in/alehar/');
+    expect(cta).not.toContain('mailto:');
+  });
+
   it('points robots.txt at the live sitemap so search can find it', () => {
     expect(existsSync('public/robots.txt')).toBe(true);
     const robots = readFileSync('public/robots.txt', 'utf8');

--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -8,6 +8,7 @@ interface Props {
   ogTitle?: string | undefined;
   shareUrl?: string | undefined;
   canonicalUrl?: string | undefined;
+  robots?: string | undefined;
 }
 
 const {
@@ -16,6 +17,7 @@ const {
   ogTitle,
   shareUrl: shareUrlProp,
   canonicalUrl: canonicalUrlProp,
+  robots,
 } = Astro.props;
 const shareTitle = ogTitle ?? title;
 const shareImage = 'https://me.alehar.workers.dev/assets/portrait.png';
@@ -29,6 +31,7 @@ const shareUrl = shareUrlProp ?? canonicalUrl;
 <meta name="viewport" content="width=device-width" />
 <meta name="generator" content={Astro.generator} />
 <meta name="referrer" content="strict-origin-when-cross-origin" />
+{robots && <meta name="robots" content={robots} />}
 <title>{title}</title>
 
 <!-- Open Graph / Facebook -->

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -14,9 +14,10 @@ interface Props {
   ogTitle?: string | undefined;
   shareUrl?: string | undefined;
   canonicalUrl?: string | undefined;
+  robots?: string | undefined;
 }
 
-const { title, description, ogTitle, shareUrl, canonicalUrl } = Astro.props;
+const { title, description, ogTitle, shareUrl, canonicalUrl, robots } = Astro.props;
 ---
 
 <html lang="en">
@@ -27,6 +28,7 @@ const { title, description, ogTitle, shareUrl, canonicalUrl } = Astro.props;
       ogTitle={ogTitle}
       shareUrl={shareUrl}
       canonicalUrl={canonicalUrl}
+      robots={robots}
     />
   </head>
   <body>

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -95,9 +95,15 @@ const shareTitle = entry
 const shareDescription = entry
   ? `Product Manager, Developer Experience at IFS. ${entry.data.description.trim()} Get in touch on LinkedIn.`
   : '404 Error — this page was not found';
+const robots = entry?.id === 'lidkoping-stenhuggeri' ? 'noindex' : undefined;
 ---
 
-<BaseLayout title={shareTitle ?? 'Not Found'} description={shareDescription} ogTitle={shareTitle}>
+<BaseLayout
+  title={shareTitle ?? 'Not Found'}
+  description={shareDescription}
+  ogTitle={shareTitle}
+  robots={robots}
+>
   {schema && <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />}
   {
     entry ? (


### PR DESCRIPTION
Robots noindex on the Lidköping Stenhuggeri work page (`/work/lidkoping-stenhuggeri/`).
Page kept.
Sitemap unchanged in this PR.
LinkedIn hire unchanged (https://www.linkedin.com/in/alehar/).

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.