### PR TITLE
feat: add robots noindex on What’s New

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -834,6 +834,27 @@ describe('identity copy', () => {
     expect(cta).not.toContain('mailto:');
   });
 
+  it('adds robots noindex on What’s New and keeps the page', () => {
+    expect(existsSync('src/pages/whats-new.astro')).toBe(true);
+    const page = readFileSync('src/pages/whats-new.astro', 'utf8');
+    expect(page).toContain('robots="noindex"');
+    expect(page).toContain('A public changelog of this site.');
+    expect(page).toContain('title="What\'s New | Product Manager, Developer Experience at IFS"');
+    expect(page).not.toContain('mailto:');
+    expect(page).not.toContain('nofollow');
+    const head = readFileSync('src/components/MainHead.astro', 'utf8');
+    expect(head).toContain('<meta name="robots" content={robots} />');
+    expect(head).not.toContain('nofollow');
+    const layout = readFileSync('src/layouts/BaseLayout.astro', 'utf8');
+    expect(layout).toContain('robots={robots}');
+    const sitemap = readFileSync('src/pages/sitemap.xml.ts', 'utf8');
+    expect(sitemap).not.toContain('/whats-new');
+    expect(sitemap).toContain('ifs-design-system');
+    const cta = readFileSync('src/components/ContactCTA.astro', 'utf8');
+    expect(cta).toContain('https://www.linkedin.com/in/alehar/');
+    expect(cta).not.toContain('mailto:');
+  });
+
   it('points robots.txt at the live sitemap so search can find it', () => {
     expect(existsSync('public/robots.txt')).toBe(true);
     const robots = readFileSync('public/robots.txt', 'utf8');

--- a/src/pages/whats-new.astro
+++ b/src/pages/whats-new.astro
@@ -43,6 +43,7 @@ const schema = {
   title="What's New | Product Manager, Developer Experience at IFS"
   ogTitle="What's New | Product Manager, Developer Experience at IFS"
   description="A public changelog of this site. Product Manager, Developer Experience at IFS."
+  robots="noindex"
 >
   <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
   <div class="stack gap-20">


### PR DESCRIPTION
Robots noindex on `/whats-new/`.
Page kept.
Sitemap unchanged in this PR.
LinkedIn hire unchanged (https://www.linkedin.com/in/alehar/).

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.