### PR TITLE
feat: add robots noindex on experimental manifesto, now, and reading-list

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -855,16 +855,9 @@ describe('identity copy', () => {
     expect(cta).not.toContain('mailto:');
   });
 
-  it('adds robots noindex on the experimental manifesto, now, and reading-list pages and keeps the pages', () => {
-    expect(existsSync('src/pages/experimental/manifesto.astro')).toBe(true);
+  it('adds robots noindex on /experimental/now/ and /experimental/reading-list/ and keeps the pages', () => {
     expect(existsSync('src/pages/experimental/now.astro')).toBe(true);
     expect(existsSync('src/pages/experimental/reading-list.astro')).toBe(true);
-    const manifesto = readFileSync('src/pages/experimental/manifesto.astro', 'utf8');
-    expect(manifesto).toContain('robots="noindex"');
-    expect(manifesto).toContain('title="Manifesto"');
-    expect(manifesto).toContain('Product Manifesto');
-    expect(manifesto).not.toContain('mailto:');
-    expect(manifesto).not.toContain('nofollow');
     const now = readFileSync('src/pages/experimental/now.astro', 'utf8');
     expect(now).toContain('robots="noindex"');
     expect(now).toContain('https://www.linkedin.com/in/alehar/');
@@ -883,7 +876,6 @@ describe('identity copy', () => {
     const layout = readFileSync('src/layouts/BaseLayout.astro', 'utf8');
     expect(layout).toContain('robots={robots}');
     const sitemap = readFileSync('src/pages/sitemap.xml.ts', 'utf8');
-    expect(sitemap).not.toContain('/experimental/manifesto');
     expect(sitemap).not.toContain('/experimental/now');
     expect(sitemap).not.toContain('/experimental/reading-list');
     expect(sitemap).toContain('ifs-design-system');

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -855,6 +855,43 @@ describe('identity copy', () => {
     expect(cta).not.toContain('mailto:');
   });
 
+  it('adds robots noindex on the experimental manifesto, now, and reading-list pages and keeps the pages', () => {
+    expect(existsSync('src/pages/experimental/manifesto.astro')).toBe(true);
+    expect(existsSync('src/pages/experimental/now.astro')).toBe(true);
+    expect(existsSync('src/pages/experimental/reading-list.astro')).toBe(true);
+    const manifesto = readFileSync('src/pages/experimental/manifesto.astro', 'utf8');
+    expect(manifesto).toContain('robots="noindex"');
+    expect(manifesto).toContain('title="Manifesto"');
+    expect(manifesto).toContain('Product Manifesto');
+    expect(manifesto).not.toContain('mailto:');
+    expect(manifesto).not.toContain('nofollow');
+    const now = readFileSync('src/pages/experimental/now.astro', 'utf8');
+    expect(now).toContain('robots="noindex"');
+    expect(now).toContain('https://www.linkedin.com/in/alehar/');
+    expect(now).toContain('Product Manager, Developer Experience at IFS');
+    expect(now).not.toContain('mailto:');
+    expect(now).not.toContain('nofollow');
+    const readingList = readFileSync('src/pages/experimental/reading-list.astro', 'utf8');
+    expect(readingList).toContain('robots="noindex"');
+    expect(readingList).toContain('https://www.linkedin.com/in/alehar/');
+    expect(readingList).toContain('Reading list');
+    expect(readingList).not.toContain('mailto:');
+    expect(readingList).not.toContain('nofollow');
+    const head = readFileSync('src/components/MainHead.astro', 'utf8');
+    expect(head).toContain('<meta name="robots" content={robots} />');
+    expect(head).not.toContain('nofollow');
+    const layout = readFileSync('src/layouts/BaseLayout.astro', 'utf8');
+    expect(layout).toContain('robots={robots}');
+    const sitemap = readFileSync('src/pages/sitemap.xml.ts', 'utf8');
+    expect(sitemap).not.toContain('/experimental/manifesto');
+    expect(sitemap).not.toContain('/experimental/now');
+    expect(sitemap).not.toContain('/experimental/reading-list');
+    expect(sitemap).toContain('ifs-design-system');
+    const cta = readFileSync('src/components/ContactCTA.astro', 'utf8');
+    expect(cta).toContain('https://www.linkedin.com/in/alehar/');
+    expect(cta).not.toContain('mailto:');
+  });
+
   it('points robots.txt at the live sitemap so search can find it', () => {
     expect(existsSync('public/robots.txt')).toBe(true);
     const robots = readFileSync('public/robots.txt', 'utf8');

--- a/src/pages/experimental/manifesto.astro
+++ b/src/pages/experimental/manifesto.astro
@@ -26,7 +26,7 @@ const principles = [
 ];
 ---
 
-<BaseLayout title="Manifesto" description="Core product principles." robots="noindex">
+<BaseLayout title="Manifesto" description="Core product principles.">
   <main class="wrapper stack gap-8" style="margin-top: 4rem;">
     <Hero
       title="Product Manifesto"

--- a/src/pages/experimental/manifesto.astro
+++ b/src/pages/experimental/manifesto.astro
@@ -26,7 +26,7 @@ const principles = [
 ];
 ---
 
-<BaseLayout title="Manifesto" description="Core product principles.">
+<BaseLayout title="Manifesto" description="Core product principles." robots="noindex">
   <main class="wrapper stack gap-8" style="margin-top: 4rem;">
     <Hero
       title="Product Manifesto"

--- a/src/pages/experimental/now.astro
+++ b/src/pages/experimental/now.astro
@@ -13,6 +13,7 @@ const linkedinHref = 'https://www.linkedin.com/in/alehar/';
 <BaseLayout
   title="Product Manager, Developer Experience at IFS"
   description="Product Manager, Developer Experience at IFS. Design systems, DevEx, and Industrial AI."
+  robots="noindex"
 >
   <main id="main-content" class="wrapper stack gap-8">
     <Hero title="Product Manager, Developer Experience at IFS" align="start">

--- a/src/pages/experimental/reading-list.astro
+++ b/src/pages/experimental/reading-list.astro
@@ -33,6 +33,7 @@ const books = [
   title="Reading list | Product Manager, Developer Experience at IFS"
   ogTitle="Reading list | Product Manager, Developer Experience at IFS"
   description="Product Manager, Developer Experience at IFS. Reading behind the work."
+  robots="noindex"
 >
   <main id="main-content" role="main" class="wrapper stack gap-10">
     <Hero title="Reading list" align="start">


### PR DESCRIPTION
Robots noindex on `/experimental/manifesto/`, `/experimental/now/`, and `/experimental/reading-list/`.
Pages kept.
Sitemap unchanged in this PR.
LinkedIn hire unchanged (https://www.linkedin.com/in/alehar/).

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Marked the experimental Now and Reading List pages as `noindex` while keeping them accessible to visitors.
  * Ensured these pages remain excluded from the sitemap and retain their expected content and navigation calls to action.
* **Tests**
  * Added coverage verifying robots directives, sitemap exclusion, page content, and shared navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->