### PR TITLE
feat: disallow /experimental/ in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -23,4 +23,7 @@
 # RIGHTS UNDER ARTICLE 4 OF THE EUROPEAN UNION DIRECTIVE 2019/790 ON COPYRIGHT
 # AND RELATED RIGHTS IN THE DIGITAL SINGLE MARKET.
 
+User-agent: *
+Disallow: /experimental/
+
 Sitemap: https://me.alehar.workers.dev/sitemap.xml

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -887,6 +887,7 @@ describe('identity copy', () => {
   it('points robots.txt at the live sitemap so search can find it', () => {
     expect(existsSync('public/robots.txt')).toBe(true);
     const robots = readFileSync('public/robots.txt', 'utf8');
+    expect(robots).toContain('Disallow: /experimental/');
     expect(robots).toContain('Sitemap: https://me.alehar.workers.dev/sitemap.xml');
     expect(robots).not.toContain('localhost');
     expect(robots).not.toContain('harenstam.com');


### PR DESCRIPTION
robots.txt Disallow: /experimental/
Sitemap line unchanged.
Pages and sitemap.xml unchanged.
LinkedIn hire unchanged (https://www.linkedin.com/in/alehar/).

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.