### PR TITLE
feat: disallow /whats-new/ in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -25,5 +25,6 @@
 
 User-agent: *
 Disallow: /experimental/
+Disallow: /whats-new/
 
 Sitemap: https://me.alehar.workers.dev/sitemap.xml

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -888,6 +888,7 @@ describe('identity copy', () => {
     expect(existsSync('public/robots.txt')).toBe(true);
     const robots = readFileSync('public/robots.txt', 'utf8');
     expect(robots).toContain('Disallow: /experimental/');
+    expect(robots).toContain('Disallow: /whats-new/');
     expect(robots).toContain('Sitemap: https://me.alehar.workers.dev/sitemap.xml');
     expect(robots).not.toContain('localhost');
     expect(robots).not.toContain('harenstam.com');


### PR DESCRIPTION
robots.txt Disallow: /whats-new/
User-agent: *, Disallow: /experimental/, Sitemap line kept.
Pages and sitemap.xml unchanged.
LinkedIn hire unchanged (https://www.linkedin.com/in/alehar/).

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.