### PR TITLE
feat: disallow /work/lidkoping-stenhuggeri/ in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -26,5 +26,6 @@
 User-agent: *
 Disallow: /experimental/
 Disallow: /whats-new/
+Disallow: /work/lidkoping-stenhuggeri/
 
 Sitemap: https://me.alehar.workers.dev/sitemap.xml

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -889,6 +889,7 @@ describe('identity copy', () => {
     const robots = readFileSync('public/robots.txt', 'utf8');
     expect(robots).toContain('Disallow: /experimental/');
     expect(robots).toContain('Disallow: /whats-new/');
+    expect(robots).toContain('Disallow: /work/lidkoping-stenhuggeri/');
     expect(robots).toContain('Sitemap: https://me.alehar.workers.dev/sitemap.xml');
     expect(robots).not.toContain('localhost');
     expect(robots).not.toContain('harenstam.com');


### PR DESCRIPTION
robots.txt Disallow: /work/lidkoping-stenhuggeri/
User-agent: *, Disallow: /experimental/, Disallow: /whats-new/, Sitemap line kept.
Pages and sitemap.xml unchanged.
LinkedIn hire unchanged (https://www.linkedin.com/in/alehar/).

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.