### PR TITLE
feat: add Get in touch on LinkedIn to the JSON-LD Person description

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -652,6 +652,35 @@ describe('identity copy', () => {
     expect(bio).not.toContain('mailto:');
   });
 
+  it('lets Person.description read Product Manager, Developer Experience at IFS and LinkedIn', () => {
+    const home = readFileSync('src/pages/index.astro', 'utf8');
+    const bio = readFileSync('src/pages/biography.astro', 'utf8');
+    const personDescription =
+      'Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.';
+    expect(home).toContain("'@type': 'Person'");
+    expect(home).toContain(
+      `'@type': 'Person',
+      '@id': 'https://me.alehar.workers.dev/#person',
+      name: 'Alexander Härenstam',
+      jobTitle: 'Product Manager, Developer Experience at IFS',
+      description: '${personDescription}'`
+    );
+    expect(bio).toContain("'@type': 'Person'");
+    expect(bio).toContain(
+      `'@type': 'Person',
+      '@id': 'https://me.alehar.workers.dev/#person',
+      name: 'Alexander Härenstam',
+      jobTitle: 'Product Manager, Developer Experience at IFS',
+      description: '${personDescription}'`
+    );
+    expect(home).toContain("jobTitle: 'Product Manager, Developer Experience at IFS'");
+    expect(bio).toContain("jobTitle: 'Product Manager, Developer Experience at IFS'");
+    expect(home).toContain('https://www.linkedin.com/in/alehar/');
+    expect(bio).toContain('https://www.linkedin.com/in/alehar/');
+    expect(home).not.toContain('mailto:');
+    expect(bio).not.toContain('mailto:');
+  });
+
   it('lets WebSite.name read Product Manager, Developer Experience at IFS', () => {
     const home = readFileSync('src/pages/index.astro', 'utf8');
     expect(home).toContain("'@type': 'WebSite'");

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -11,8 +11,7 @@ const schema = {
       '@id': 'https://me.alehar.workers.dev/#person',
       name: 'Alexander Härenstam',
       jobTitle: 'Product Manager, Developer Experience at IFS',
-      description:
-        'Product Manager, Developer Experience at IFS. Design systems, DevEx, and Industrial AI.',
+      description: 'Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.',
       url: 'https://me.alehar.workers.dev/',
       sameAs: ['https://www.linkedin.com/in/alehar/'],
       worksFor: {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,8 +13,7 @@ const schema = {
       '@id': 'https://me.alehar.workers.dev/#person',
       name: 'Alexander Härenstam',
       jobTitle: 'Product Manager, Developer Experience at IFS',
-      description:
-        'Product Manager, Developer Experience at IFS. Design systems, DevEx, and Industrial AI.',
+      description: 'Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.',
       url: 'https://me.alehar.workers.dev/',
       sameAs: [
         'https://www.linkedin.com/in/alehar/',


### PR DESCRIPTION
## Summary
- JSON-LD Person.description now: `Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.`
- WebPage.description, WebSite.description, share meta, RSS unchanged
- LinkedIn hire unchanged (`https://www.linkedin.com/in/alehar/`). No mailto. No CV.
- Draft until Johan+Vera PASS. Do not merge. Stay off #512.

## Test plan
- [ ] `npx vitest run src/__tests__/identity.test.ts`
- [ ] Confirm Home and Biography JSON-LD Person.description is `Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.`
- [ ] Confirm WebPage.description, WebSite.description, share meta, RSS, Person.jobTitle, WebPage.name, and WebSite.name are unchanged
- [ ] Confirm LinkedIn hire still points at https://www.linkedin.com/in/alehar/
- [ ] Confirm no `mailto:`
- [ ] Stay draft until Johan+Vera PASS a freeze SHA