### PR TITLE
feat: add at IFS to the IFS Design System work-case TL;DR

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -418,6 +418,17 @@ describe('identity copy', () => {
     expect(ds).not.toContain('mailto:');
   });
 
+  it('lets the IFS Design System work-case TL;DR include at IFS', () => {
+    const ds = readFileSync('src/content/work/ifs-design-system.md', 'utf8');
+    expect(ds).toContain('I am <strong>Product Manager, Developer Experience</strong> at IFS.');
+    expect(ds).toContain('<strong>TL;DR:</strong>');
+    expect(ds).toContain('title: IFS Design System');
+    expect(ds).toContain('**Up to 2x faster**');
+    expect(ds).toContain('**Up to 30x ROI**');
+    expect(ds).toContain('**Zeroheight Design System Awards**');
+    expect(ds).not.toContain('mailto:');
+  });
+
   it('keeps the chat FAB off Earlier work case body copy on a phone', () => {
     const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
     expect(slug).toContain('earlier-case');

--- a/src/content/work/ifs-design-system.md
+++ b/src/content/work/ifs-design-system.md
@@ -12,7 +12,7 @@ tags:
 ---
 
 <div class="tldr-box">
-  <p><strong>TL;DR:</strong> The <strong>IFS Design System</strong>, from the first version to IFS Cloud. I am <strong>Product Manager, Developer Experience</strong>.</p>
+  <p><strong>TL;DR:</strong> The <strong>IFS Design System</strong>, from the first version to IFS Cloud. I am <strong>Product Manager, Developer Experience</strong> at IFS.</p>
 </div>
 
 As Product Manager, Developer Experience at IFS, I took the design system from the first version to IFS Cloud. IFS Cloud is IFS's enterprise product platform. There was no Cloud-scale system to inherit.


### PR DESCRIPTION
IFS Design System work-case TL;DR now includes at IFS.
Metrics, titles, share meta, JSON-LD, hire path unchanged.
LinkedIn hire unchanged (https://www.linkedin.com/in/alehar/).

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.