### PR TITLE
feat: add at IFS to the AI coding copilots work-case TL;DR

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -429,6 +429,16 @@ describe('identity copy', () => {
     expect(ds).not.toContain('mailto:');
   });
 
+  it('lets the AI coding copilots work-case TL;DR include at IFS', () => {
+    const copilots = readFileSync('src/content/work/ai-coding-copilots.md', 'utf8');
+    expect(copilots).toContain(
+      'I am <strong>Product Manager, Developer Experience</strong> at IFS.'
+    );
+    expect(copilots).toContain('<strong>TL;DR:</strong>');
+    expect(copilots).toContain('title: Internal AI coding copilots');
+    expect(copilots).not.toContain('mailto:');
+  });
+
   it('keeps the chat FAB off Earlier work case body copy on a phone', () => {
     const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
     expect(slug).toContain('earlier-case');

--- a/src/content/work/ai-coding-copilots.md
+++ b/src/content/work/ai-coding-copilots.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 <div class="tldr-box">
-  <p><strong>TL;DR:</strong> Internal AI coding copilots for <strong>IFS</strong> engineering teams. I am <strong>Product Manager, Developer Experience</strong>.</p>
+  <p><strong>TL;DR:</strong> Internal AI coding copilots for <strong>IFS</strong> engineering teams. I am <strong>Product Manager, Developer Experience</strong> at IFS.</p>
 </div>
 
 As Product Manager, Developer Experience at IFS in Greater Stockholm, I work on internal AI coding copilots for engineering teams. I have been in this role since February 2025.


### PR DESCRIPTION
AI coding copilots work-case TL;DR now includes at IFS.

Metrics, titles, share meta, JSON-LD, and hire path are unchanged. LinkedIn hire stays https://www.linkedin.com/in/alehar/.

Draft until Johan+Vera PASS. Do not merge. Stay off #512.