### PR TITLE
feat: add at IFS to the user behavior analytics work-case TL;DR

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -439,6 +439,16 @@ describe('identity copy', () => {
     expect(copilots).not.toContain('mailto:');
   });
 
+  it('lets the user behavior analytics work-case TL;DR include at IFS', () => {
+    const analytics = readFileSync('src/content/work/user-behavior-analytics.md', 'utf8');
+    expect(analytics).toContain(
+      'I am <strong>Product Manager, Developer Experience</strong> at IFS.'
+    );
+    expect(analytics).toContain('<strong>TL;DR:</strong>');
+    expect(analytics).toContain('title: User behavior analytics');
+    expect(analytics).not.toContain('mailto:');
+  });
+
   it('keeps the chat FAB off Earlier work case body copy on a phone', () => {
     const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
     expect(slug).toContain('earlier-case');

--- a/src/content/work/user-behavior-analytics.md
+++ b/src/content/work/user-behavior-analytics.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 <div class="tldr-box">
-  <p><strong>TL;DR:</strong> Usage telemetry so <strong>IFS Cloud</strong> roadmap decisions rest on how people actually use the product. I am <strong>Product Manager, Developer Experience</strong>.</p>
+  <p><strong>TL;DR:</strong> Usage telemetry so <strong>IFS Cloud</strong> roadmap decisions rest on how people actually use the product. I am <strong>Product Manager, Developer Experience</strong> at IFS.</p>
 </div>
 
 At IFS I worked on user behavior analytics for IFS Cloud: capturing usage so product teams can see what customers actually do. Roadmap decisions rest on that usage.


### PR DESCRIPTION
User behavior analytics work-case TL;DR now includes at IFS.

Metrics, titles, share meta, JSON-LD, and hire path are unchanged. LinkedIn hire stays https://www.linkedin.com/in/alehar/.

Draft until Johan+Vera PASS. Do not merge. Stay off #512.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the user behavior analytics case study to identify the author as Product Manager, Developer Experience at IFS.
  - Refined the TL;DR and verified the case study title and contact-link presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->