### PR TITLE
feat: drop Lidköping Stenhuggeri from the Work index

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -477,15 +477,15 @@ describe('identity copy', () => {
 
   it('keeps only the IFS Design System on the main /work card grid', () => {
     const work = sources.find((s) => s.path.endsWith('work.astro'))!.text;
-    expect(work).toContain("'lidkoping-stenhuggeri'");
+    expect(work).not.toContain("'lidkoping-stenhuggeri'");
     expect(work).toContain("'ai-coding-copilots'");
     expect(work).toContain("'user-behavior-analytics'");
     expect(work).toContain("'master-thesis'");
     expect(work).toContain("featuredOrder = ['ifs-design-system']");
-    expect(work).toContain("'master-thesis',\n  'lidkoping-stenhuggeri'");
+    expect(work).not.toContain("'master-thesis',\n  'lidkoping-stenhuggeri'");
     expect(work).toContain('const ordered = [...featured, ...earlier]');
     expect(work).toContain('Earlier work');
-    expect(work).toContain('Early Android work, 2013.');
+    expect(work).not.toContain('Early Android work, 2013.');
     expect(work).toContain('Internal AI coding copilots for IFS engineering teams.');
     expect(work).toContain('Usage telemetry for IFS Cloud roadmap decisions.');
     expect(work).toContain("Chalmers master's thesis, 2017.");
@@ -888,7 +888,34 @@ describe('identity copy', () => {
     expect(sitemap).not.toContain('/work/lidkoping-stenhuggeri');
     expect(sitemap).toContain('ifs-design-system');
     const work = readFileSync('src/pages/work.astro', 'utf8');
-    expect(work).toContain("'lidkoping-stenhuggeri'");
+    expect(work).not.toContain("'lidkoping-stenhuggeri'");
+    const cta = readFileSync('src/components/ContactCTA.astro', 'utf8');
+    expect(cta).toContain('https://www.linkedin.com/in/alehar/');
+    expect(cta).not.toContain('mailto:');
+  });
+
+  it('drops Lidköping Stenhuggeri from the Work index and keeps the page', () => {
+    expect(existsSync('src/content/work/lidkoping-stenhuggeri.md')).toBe(true);
+    const lidkoping = readFileSync('src/content/work/lidkoping-stenhuggeri.md', 'utf8');
+    expect(lidkoping).toContain('title: Lidköping Stenhuggeri');
+    expect(lidkoping).toContain('Early Android work, 2013');
+    expect(lidkoping).not.toContain('mailto:');
+    const work = readFileSync('src/pages/work.astro', 'utf8');
+    expect(work).not.toContain("'lidkoping-stenhuggeri'");
+    expect(work).not.toContain('/work/lidkoping-stenhuggeri/');
+    expect(work).not.toContain('Lidköping');
+    expect(work).toContain("'ai-coding-copilots'");
+    expect(work).toContain("'user-behavior-analytics'");
+    expect(work).toContain("'master-thesis'");
+    expect(work).toContain("featuredOrder = ['ifs-design-system']");
+    expect(work).toContain('Earlier work');
+    const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
+    expect(slug).toContain("entry?.id === 'lidkoping-stenhuggeri' ? 'noindex'");
+    expect(slug).toContain('lidkoping-stenhuggeri');
+    const sitemap = readFileSync('src/pages/sitemap.xml.ts', 'utf8');
+    expect(sitemap).not.toContain('/work/lidkoping-stenhuggeri');
+    const robots = readFileSync('public/robots.txt', 'utf8');
+    expect(robots).toContain('Disallow: /work/lidkoping-stenhuggeri/');
     const cta = readFileSync('src/components/ContactCTA.astro', 'utf8');
     expect(cta).toContain('https://www.linkedin.com/in/alehar/');
     expect(cta).not.toContain('mailto:');

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -7,12 +7,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 const projects = await getCollection('work');
 const byId = new Map(projects.map((project) => [project.id, project]));
 const featuredOrder = ['ifs-design-system'] as const;
-const earlierOrder = [
-  'ai-coding-copilots',
-  'user-behavior-analytics',
-  'master-thesis',
-  'lidkoping-stenhuggeri',
-] as const;
+const earlierOrder = ['ai-coding-copilots', 'user-behavior-analytics', 'master-thesis'] as const;
 const featured = featuredOrder.flatMap((id) => {
   const project = byId.get(id);
   return project ? [project] : [];
@@ -23,7 +18,6 @@ const earlier = earlierOrder.flatMap((id) => {
 });
 const ordered = [...featured, ...earlier];
 const earlierBlurb: Record<string, string> = {
-  'lidkoping-stenhuggeri': 'Early Android work, 2013.',
   'ai-coding-copilots': 'Internal AI coding copilots for IFS engineering teams.',
   'user-behavior-analytics': 'Usage telemetry for IFS Cloud roadmap decisions.',
   'master-thesis': "Chalmers master's thesis, 2017.",


### PR DESCRIPTION
Lidköping Stenhuggeri dropped from the Work index.
Page itself kept (`/work/lidkoping-stenhuggeri/`).
sitemap, robots.txt, noindex, titles, share meta, JSON-LD, hire path unchanged.
LinkedIn hire unchanged (https://www.linkedin.com/in/alehar/).

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.