### PR TITLE
feat: drop Lidköping Stenhuggeri from the RSS feed

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -916,6 +916,36 @@ describe('identity copy', () => {
     expect(sitemap).not.toContain('/work/lidkoping-stenhuggeri');
     const robots = readFileSync('public/robots.txt', 'utf8');
     expect(robots).toContain('Disallow: /work/lidkoping-stenhuggeri/');
+    const rss = readFileSync('src/pages/rss.xml.ts', 'utf8');
+    expect(rss).not.toContain('/work/lidkoping-stenhuggeri');
+    const cta = readFileSync('src/components/ContactCTA.astro', 'utf8');
+    expect(cta).toContain('https://www.linkedin.com/in/alehar/');
+    expect(cta).not.toContain('mailto:');
+  });
+
+  it('drops Lidköping Stenhuggeri from the RSS feed and keeps the page', () => {
+    expect(existsSync('src/content/work/lidkoping-stenhuggeri.md')).toBe(true);
+    const lidkoping = readFileSync('src/content/work/lidkoping-stenhuggeri.md', 'utf8');
+    expect(lidkoping).toContain('title: Lidköping Stenhuggeri');
+    expect(lidkoping).toContain('Early Android work, 2013');
+    expect(lidkoping).not.toContain('mailto:');
+    const rss = readFileSync('src/pages/rss.xml.ts', 'utf8');
+    expect(rss).toContain("entry.id !== 'lidkoping-stenhuggeri'");
+    expect(rss).not.toContain('/work/lidkoping-stenhuggeri');
+    expect(rss).toContain('ifs-design-system');
+    expect(rss).toContain('https://www.linkedin.com/in/alehar/');
+    expect(rss).not.toContain('mailto:');
+    const work = readFileSync('src/pages/work.astro', 'utf8');
+    expect(work).not.toContain("'lidkoping-stenhuggeri'");
+    expect(work).not.toContain('/work/lidkoping-stenhuggeri/');
+    expect(work).not.toContain('Lidköping');
+    const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
+    expect(slug).toContain("entry?.id === 'lidkoping-stenhuggeri' ? 'noindex'");
+    expect(slug).toContain('lidkoping-stenhuggeri');
+    const sitemap = readFileSync('src/pages/sitemap.xml.ts', 'utf8');
+    expect(sitemap).not.toContain('/work/lidkoping-stenhuggeri');
+    const robots = readFileSync('public/robots.txt', 'utf8');
+    expect(robots).toContain('Disallow: /work/lidkoping-stenhuggeri/');
     const cta = readFileSync('src/components/ContactCTA.astro', 'utf8');
     expect(cta).toContain('https://www.linkedin.com/in/alehar/');
     expect(cta).not.toContain('mailto:');
@@ -1086,6 +1116,8 @@ describe('identity copy', () => {
       '<description>Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.</description>'
     );
     expect(rss).toContain('ifs-design-system');
+    expect(rss).toContain("entry.id !== 'lidkoping-stenhuggeri'");
+    expect(rss).not.toContain('/work/lidkoping-stenhuggeri');
     expect(rss).not.toContain('localhost');
     expect(rss).not.toContain('harenstam.com');
     expect(rss).not.toContain('mailto:');

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -37,9 +37,9 @@ function itemXml(entry: {
 
 export const GET: APIRoute = async () => {
   const work = await getCollection('work');
-  const items = [...work].sort(
-    (a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime()
-  );
+  const items = [...work]
+    .filter((entry) => entry.id !== 'lidkoping-stenhuggeri')
+    .sort((a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime());
 
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">


### PR DESCRIPTION
Lidköping Stenhuggeri dropped from the RSS feed.
Page itself kept (`/work/lidkoping-stenhuggeri/`).
Work index, sitemap, robots.txt, noindex, titles, share meta, JSON-LD, hire path unchanged.
LinkedIn hire unchanged (https://www.linkedin.com/in/alehar/).

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.