### PR TITLE
feat: add Get in touch on LinkedIn to the Work JSON-LD WebPage description

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -793,6 +793,21 @@ describe('identity copy', () => {
     expect(bio).not.toContain('mailto:');
   });
 
+  it('lets Work WebPage.description read Product Manager, Developer Experience at IFS and LinkedIn', () => {
+    const work = readFileSync('src/pages/work.astro', 'utf8');
+    const webpageDescription =
+      'Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.';
+    expect(work).toContain("'@type': 'WebPage'");
+    expect(work).toContain(
+      `'@type': 'WebPage',
+      '@id': 'https://me.alehar.workers.dev/work/#webpage',
+      url: 'https://me.alehar.workers.dev/work/',
+      name: 'Work | Product Manager, Developer Experience at IFS',
+      description: '${webpageDescription}'`
+    );
+    expect(work).not.toContain('mailto:');
+  });
+
   it('lets the RSS title read Product Manager, Developer Experience at IFS', () => {
     const rss = readFileSync('src/pages/rss.xml.ts', 'utf8');
     expect(rss).toContain(

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -31,8 +31,7 @@ const schema = {
       '@id': 'https://me.alehar.workers.dev/work/#webpage',
       url: 'https://me.alehar.workers.dev/work/',
       name: 'Work | Product Manager, Developer Experience at IFS',
-      description:
-        'Product Manager, Developer Experience at IFS. The IFS Design System case, then earlier work.',
+      description: 'Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.',
       breadcrumb: {
         '@type': 'BreadcrumbList',
         itemListElement: [


### PR DESCRIPTION
## Summary
- Work JSON-LD WebPage.description now: `Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.`
- Home/Biography JSON-LD, share meta, titles, RSS, Work index, Person/WebSite JSON-LD, and hire path unchanged.
- LinkedIn hire unchanged (`https://www.linkedin.com/in/alehar/`). No mailto. No CV.
- Draft until Johan+Vera PASS. Do not merge. Stay off #512.

## Test plan
- [ ] `npx vitest run src/__tests__/identity.test.ts`
- [ ] Confirm Work JSON-LD WebPage.description is `Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.`
- [ ] Confirm Home/Biography JSON-LD, share meta, titles, RSS, Work index, Person/WebSite JSON-LD, and hire path are unchanged
- [ ] Confirm LinkedIn hire still points at https://www.linkedin.com/in/alehar/
- [ ] Confirm no `mailto:`
- [ ] Stay draft until Johan+Vera PASS a freeze SHA