### PR TITLE
feat: add Get in touch on LinkedIn to the Work JSON-LD ItemList description

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -808,6 +808,19 @@ describe('identity copy', () => {
     expect(work).not.toContain('mailto:');
   });
 
+  it('lets Work ItemList.description read Product Manager, Developer Experience at IFS and LinkedIn', () => {
+    const work = readFileSync('src/pages/work.astro', 'utf8');
+    const itemListDescription =
+      'Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.';
+    expect(work).toContain("'@type': 'ItemList'");
+    expect(work).toContain(
+      `'@type': 'ItemList',
+      name: 'Work | Product Manager, Developer Experience at IFS',
+      description: '${itemListDescription}'`
+    );
+    expect(work).not.toContain('mailto:');
+  });
+
   it('lets the RSS title read Product Manager, Developer Experience at IFS', () => {
     const rss = readFileSync('src/pages/rss.xml.ts', 'utf8');
     expect(rss).toContain(

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -58,8 +58,7 @@ const schema = {
     {
       '@type': 'ItemList',
       name: 'Work | Product Manager, Developer Experience at IFS',
-      description:
-        'Product Manager, Developer Experience at IFS. The IFS Design System case, then earlier work.',
+      description: 'Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.',
       numberOfItems: ordered.length,
       itemListElement: ordered.map((project, index) => ({
         '@type': 'ListItem',


### PR DESCRIPTION
## Summary
- Work JSON-LD ItemList.description now: `Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.`
- Work JSON-LD WebPage.description, Home/Biography JSON-LD, share meta, titles, RSS, Work index, Person/WebSite JSON-LD, and hire path unchanged.
- LinkedIn hire unchanged (`https://www.linkedin.com/in/alehar/`). No mailto. No CV.
- Draft until Johan+Vera PASS. Do not merge. Stay off #512.

## Test plan
- [ ] `npx vitest run src/__tests__/identity.test.ts`
- [ ] Confirm Work JSON-LD ItemList.description is `Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.`
- [ ] Confirm Work JSON-LD WebPage.description is unchanged (`Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.`)
- [ ] Confirm Home/Biography JSON-LD, share meta, titles, RSS, Work index, Person/WebSite JSON-LD, and hire path are unchanged
- [ ] Confirm LinkedIn hire still points at https://www.linkedin.com/in/alehar/
- [ ] Confirm no `mailto:`
- [ ] Stay draft until Johan+Vera PASS a freeze SHA