### PR TITLE
feat: add Get in touch on LinkedIn to the IFS Design System JSON-LD WebPage description

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -821,6 +821,22 @@ describe('identity copy', () => {
     expect(work).not.toContain('mailto:');
   });
 
+  it('lets the IFS Design System JSON-LD WebPage.description include Get in touch on LinkedIn', () => {
+    const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
+    expect(slug).toContain("'@type': 'WebPage'");
+    expect(slug).toContain(
+      `'@type': 'WebPage',
+          '@id': \`https://me.alehar.workers.dev/work/\${entry.id}/#webpage\`,
+          url: \`https://me.alehar.workers.dev/work/\${entry.id}/\`,
+          name: \`\${entry.data.title} | Alexander Härenstam\`,
+          description:
+            entry.id === 'ifs-design-system'
+              ? \`\${entry.data.description.trim()} Get in touch on LinkedIn.\`
+              : entry.data.description,`
+    );
+    expect(slug).not.toContain('mailto:');
+  });
+
   it('lets the RSS title read Product Manager, Developer Experience at IFS', () => {
     const rss = readFileSync('src/pages/rss.xml.ts', 'utf8');
     expect(rss).toContain(

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -49,7 +49,10 @@ const schema = entry
           '@id': `https://me.alehar.workers.dev/work/${entry.id}/#webpage`,
           url: `https://me.alehar.workers.dev/work/${entry.id}/`,
           name: `${entry.data.title} | Alexander Härenstam`,
-          description: entry.data.description,
+          description:
+            entry.id === 'ifs-design-system'
+              ? `${entry.data.description.trim()} Get in touch on LinkedIn.`
+              : entry.data.description,
           breadcrumb: {
             '@type': 'BreadcrumbList',
             itemListElement: [


### PR DESCRIPTION
## Summary
- Add `Get in touch on LinkedIn` to the IFS Design System JSON-LD `WebPage.description`, keeping the existing description text.
- Other work cases, share meta, Work index JSON-LD, RSS, titles, and hire path are unchanged.

## Test plan
- [x] identity tests (`src/__tests__/identity.test.ts`)
- [ ] Johan + Vera PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the IFS Design System work page metadata to include “Get in touch on LinkedIn.”
  - Preserved existing page descriptions for all other work pages.
  - Ensured generated metadata excludes email links while retaining expected page information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->