### PR TITLE
feat: add Get in touch on LinkedIn to the IFS Design System JSON-LD CreativeWork description

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -837,6 +837,20 @@ describe('identity copy', () => {
     expect(slug).not.toContain('mailto:');
   });
 
+  it('lets the IFS Design System JSON-LD CreativeWork.description include Get in touch on LinkedIn', () => {
+    const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
+    expect(slug).toContain("'@type': 'CreativeWork'");
+    expect(slug).toContain(
+      `'@type': 'CreativeWork',
+          name: entry.data.title,
+          description:
+            entry.id === 'ifs-design-system'
+              ? \`\${entry.data.description.trim()} Get in touch on LinkedIn.\`
+              : entry.data.description,`
+    );
+    expect(slug).not.toContain('mailto:');
+  });
+
   it('lets the RSS title read Product Manager, Developer Experience at IFS', () => {
     const rss = readFileSync('src/pages/rss.xml.ts', 'utf8');
     expect(rss).toContain(

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -80,7 +80,10 @@ const schema = entry
         {
           '@type': 'CreativeWork',
           name: entry.data.title,
-          description: entry.data.description,
+          description:
+            entry.id === 'ifs-design-system'
+              ? `${entry.data.description.trim()} Get in touch on LinkedIn.`
+              : entry.data.description,
           datePublished: entry.data.publishDate.toISOString(),
           author: {
             '@id': 'https://me.alehar.workers.dev/#person',


### PR DESCRIPTION
## Summary
- Add `Get in touch on LinkedIn` to the IFS Design System JSON-LD `CreativeWork.description`, keeping the existing description text.
- Other work cases, WebPage.description, share meta, Work index JSON-LD, RSS, titles, and hire path are unchanged.

## Test plan
- [x] identity tests (`src/__tests__/identity.test.ts`)
- [ ] Johan + Vera PASS