### PR TITLE
feat: add Get in touch on LinkedIn to the AI coding copilots JSON-LD WebPage description

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -830,7 +830,23 @@ describe('identity copy', () => {
           url: \`https://me.alehar.workers.dev/work/\${entry.id}/\`,
           name: \`\${entry.data.title} | Alexander Härenstam\`,
           description:
-            entry.id === 'ifs-design-system'
+            entry.id === 'ifs-design-system' || entry.id === 'ai-coding-copilots'
+              ? \`\${entry.data.description.trim()} Get in touch on LinkedIn.\`
+              : entry.data.description,`
+    );
+    expect(slug).not.toContain('mailto:');
+  });
+
+  it('lets the AI coding copilots JSON-LD WebPage.description include Get in touch on LinkedIn', () => {
+    const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
+    expect(slug).toContain("'@type': 'WebPage'");
+    expect(slug).toContain(
+      `'@type': 'WebPage',
+          '@id': \`https://me.alehar.workers.dev/work/\${entry.id}/#webpage\`,
+          url: \`https://me.alehar.workers.dev/work/\${entry.id}/\`,
+          name: \`\${entry.data.title} | Alexander Härenstam\`,
+          description:
+            entry.id === 'ifs-design-system' || entry.id === 'ai-coding-copilots'
               ? \`\${entry.data.description.trim()} Get in touch on LinkedIn.\`
               : entry.data.description,`
     );

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -50,7 +50,7 @@ const schema = entry
           url: `https://me.alehar.workers.dev/work/${entry.id}/`,
           name: `${entry.data.title} | Alexander Härenstam`,
           description:
-            entry.id === 'ifs-design-system'
+            entry.id === 'ifs-design-system' || entry.id === 'ai-coding-copilots'
               ? `${entry.data.description.trim()} Get in touch on LinkedIn.`
               : entry.data.description,
           breadcrumb: {


### PR DESCRIPTION
feat: add Get in touch on LinkedIn to the AI coding copilots JSON-LD WebPage description

## Summary
- Add `Get in touch on LinkedIn` to the AI coding copilots JSON-LD `WebPage.description`, keeping the existing description text.
- IFS Design System JSON-LD branches, CreativeWork.description, other work cases, share meta, Work index JSON-LD, RSS, titles, and hire path are unchanged.

## Test plan
- [x] identity tests (`src/__tests__/identity.test.ts`)
- [ ] Johan + Vera PASS