### PR TITLE
feat: add Get in touch on LinkedIn to the AI coding copilots JSON-LD CreativeWork description

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -860,7 +860,21 @@ describe('identity copy', () => {
       `'@type': 'CreativeWork',
           name: entry.data.title,
           description:
-            entry.id === 'ifs-design-system'
+            entry.id === 'ifs-design-system' || entry.id === 'ai-coding-copilots'
+              ? \`\${entry.data.description.trim()} Get in touch on LinkedIn.\`
+              : entry.data.description,`
+    );
+    expect(slug).not.toContain('mailto:');
+  });
+
+  it('lets the AI coding copilots JSON-LD CreativeWork.description include Get in touch on LinkedIn', () => {
+    const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
+    expect(slug).toContain("'@type': 'CreativeWork'");
+    expect(slug).toContain(
+      `'@type': 'CreativeWork',
+          name: entry.data.title,
+          description:
+            entry.id === 'ifs-design-system' || entry.id === 'ai-coding-copilots'
               ? \`\${entry.data.description.trim()} Get in touch on LinkedIn.\`
               : entry.data.description,`
     );

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -81,7 +81,7 @@ const schema = entry
           '@type': 'CreativeWork',
           name: entry.data.title,
           description:
-            entry.id === 'ifs-design-system'
+            entry.id === 'ifs-design-system' || entry.id === 'ai-coding-copilots'
               ? `${entry.data.description.trim()} Get in touch on LinkedIn.`
               : entry.data.description,
           datePublished: entry.data.publishDate.toISOString(),


### PR DESCRIPTION
## Summary
- Add `Get in touch on LinkedIn` to the AI coding copilots JSON-LD `CreativeWork.description`, keeping the existing description text.
- Other work cases, WebPage.description, share meta, Work index JSON-LD, RSS, titles, IFS Design System JSON-LD, and hire path are unchanged.

## Test plan
- [x] identity tests (`src/__tests__/identity.test.ts`)
- [ ] Johan + Vera PASS