### PR TITLE
feat: add Get in touch on LinkedIn to the IFS Design System case

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -429,6 +429,32 @@ describe('identity copy', () => {
     expect(ds).not.toContain('mailto:');
   });
 
+  it('lets the IFS Design System case include a visible Get in touch on LinkedIn CTA', () => {
+    const ds = readFileSync('src/content/work/ifs-design-system.md', 'utf8');
+    expect(ds).toContain(
+      '<a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>'
+    );
+    expect(ds).not.toContain('mailto:');
+
+    const copilots = readFileSync('src/content/work/ai-coding-copilots.md', 'utf8');
+    const analytics = readFileSync('src/content/work/user-behavior-analytics.md', 'utf8');
+    const lidkoping = readFileSync('src/content/work/lidkoping-stenhuggeri.md', 'utf8');
+    const thesis = readFileSync('src/content/work/master-thesis.md', 'utf8');
+    const work = readFileSync('src/pages/work.astro', 'utf8');
+    for (const { path, text } of [
+      { path: 'ai-coding-copilots.md', text: copilots },
+      { path: 'user-behavior-analytics.md', text: analytics },
+      { path: 'lidkoping-stenhuggeri.md', text: lidkoping },
+      { path: 'master-thesis.md', text: thesis },
+    ]) {
+      expect(text, path).not.toContain('Get in touch on LinkedIn');
+      expect(text, path).not.toContain('https://www.linkedin.com/in/alehar/');
+    }
+    expect(work).not.toContain(
+      '<a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>'
+    );
+  });
+
   it('lets the AI coding copilots work-case TL;DR include at IFS', () => {
     const copilots = readFileSync('src/content/work/ai-coding-copilots.md', 'utf8');
     expect(copilots).toContain(

--- a/src/content/work/ifs-design-system.md
+++ b/src/content/work/ifs-design-system.md
@@ -26,3 +26,5 @@ Product teams needed a shared way to ship UI across Cloud, so feature work could
 - **Zeroheight Design System Awards** runner-up
 
 The system now runs at IFS Cloud scale. Developers and designers use it to ship a consistent experience across Cloud.
+
+<a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>


### PR DESCRIPTION
## Summary
- Add a visible `Get in touch on LinkedIn` CTA to the IFS Design System case body (`/work/ifs-design-system/`), linking to `https://www.linkedin.com/in/alehar/`.
- Other work cases, Work index, JSON-LD, titles, share meta, RSS, and hire path elsewhere are unchanged.

## Test plan
- [x] identity tests (`src/__tests__/identity.test.ts`)
- [ ] Johan + Vera PASS

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible LinkedIn “Get in touch” call-to-action to the IFS Design System work case.
  * The contact option opens LinkedIn rather than using an email link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->