### PR TITLE
feat: add Get in touch on LinkedIn to the AI coding copilots case

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -436,13 +436,35 @@ describe('identity copy', () => {
     );
     expect(ds).not.toContain('mailto:');
 
-    const copilots = readFileSync('src/content/work/ai-coding-copilots.md', 'utf8');
     const analytics = readFileSync('src/content/work/user-behavior-analytics.md', 'utf8');
     const lidkoping = readFileSync('src/content/work/lidkoping-stenhuggeri.md', 'utf8');
     const thesis = readFileSync('src/content/work/master-thesis.md', 'utf8');
     const work = readFileSync('src/pages/work.astro', 'utf8');
     for (const { path, text } of [
-      { path: 'ai-coding-copilots.md', text: copilots },
+      { path: 'user-behavior-analytics.md', text: analytics },
+      { path: 'lidkoping-stenhuggeri.md', text: lidkoping },
+      { path: 'master-thesis.md', text: thesis },
+    ]) {
+      expect(text, path).not.toContain('Get in touch on LinkedIn');
+      expect(text, path).not.toContain('https://www.linkedin.com/in/alehar/');
+    }
+    expect(work).not.toContain(
+      '<a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>'
+    );
+  });
+
+  it('lets the AI coding copilots case include a visible Get in touch on LinkedIn CTA', () => {
+    const copilots = readFileSync('src/content/work/ai-coding-copilots.md', 'utf8');
+    expect(copilots).toContain(
+      '<a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>'
+    );
+    expect(copilots).not.toContain('mailto:');
+
+    const analytics = readFileSync('src/content/work/user-behavior-analytics.md', 'utf8');
+    const lidkoping = readFileSync('src/content/work/lidkoping-stenhuggeri.md', 'utf8');
+    const thesis = readFileSync('src/content/work/master-thesis.md', 'utf8');
+    const work = readFileSync('src/pages/work.astro', 'utf8');
+    for (const { path, text } of [
       { path: 'user-behavior-analytics.md', text: analytics },
       { path: 'lidkoping-stenhuggeri.md', text: lidkoping },
       { path: 'master-thesis.md', text: thesis },

--- a/src/content/work/ai-coding-copilots.md
+++ b/src/content/work/ai-coding-copilots.md
@@ -14,3 +14,5 @@ tags:
 </div>
 
 As Product Manager, Developer Experience at IFS in Greater Stockholm, I work on internal AI coding copilots for engineering teams. I have been in this role since February 2025.
+
+<a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>


### PR DESCRIPTION
## Summary
- Add a visible `Get in touch on LinkedIn` CTA to the AI coding copilots case body (`/work/ai-coding-copilots/`), linking to `https://www.linkedin.com/in/alehar/`.
- Other work cases, Work index, JSON-LD, titles, share meta, RSS, and hire path elsewhere are unchanged. IFS Design System keeps the CTA from #576.

## Test plan
- [x] identity tests (`src/__tests__/identity.test.ts`)
- [ ] Johan + Vera PASS

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.