### PR TITLE
feat: add Get in touch on LinkedIn to the user behavior analytics case

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -436,12 +436,10 @@ describe('identity copy', () => {
     );
     expect(ds).not.toContain('mailto:');
 
-    const analytics = readFileSync('src/content/work/user-behavior-analytics.md', 'utf8');
     const lidkoping = readFileSync('src/content/work/lidkoping-stenhuggeri.md', 'utf8');
     const thesis = readFileSync('src/content/work/master-thesis.md', 'utf8');
     const work = readFileSync('src/pages/work.astro', 'utf8');
     for (const { path, text } of [
-      { path: 'user-behavior-analytics.md', text: analytics },
       { path: 'lidkoping-stenhuggeri.md', text: lidkoping },
       { path: 'master-thesis.md', text: thesis },
     ]) {
@@ -460,12 +458,32 @@ describe('identity copy', () => {
     );
     expect(copilots).not.toContain('mailto:');
 
-    const analytics = readFileSync('src/content/work/user-behavior-analytics.md', 'utf8');
     const lidkoping = readFileSync('src/content/work/lidkoping-stenhuggeri.md', 'utf8');
     const thesis = readFileSync('src/content/work/master-thesis.md', 'utf8');
     const work = readFileSync('src/pages/work.astro', 'utf8');
     for (const { path, text } of [
-      { path: 'user-behavior-analytics.md', text: analytics },
+      { path: 'lidkoping-stenhuggeri.md', text: lidkoping },
+      { path: 'master-thesis.md', text: thesis },
+    ]) {
+      expect(text, path).not.toContain('Get in touch on LinkedIn');
+      expect(text, path).not.toContain('https://www.linkedin.com/in/alehar/');
+    }
+    expect(work).not.toContain(
+      '<a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>'
+    );
+  });
+
+  it('lets the user behavior analytics case include a visible Get in touch on LinkedIn CTA', () => {
+    const analytics = readFileSync('src/content/work/user-behavior-analytics.md', 'utf8');
+    expect(analytics).toContain(
+      '<a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>'
+    );
+    expect(analytics).not.toContain('mailto:');
+
+    const lidkoping = readFileSync('src/content/work/lidkoping-stenhuggeri.md', 'utf8');
+    const thesis = readFileSync('src/content/work/master-thesis.md', 'utf8');
+    const work = readFileSync('src/pages/work.astro', 'utf8');
+    for (const { path, text } of [
       { path: 'lidkoping-stenhuggeri.md', text: lidkoping },
       { path: 'master-thesis.md', text: thesis },
     ]) {

--- a/src/content/work/user-behavior-analytics.md
+++ b/src/content/work/user-behavior-analytics.md
@@ -14,3 +14,5 @@ tags:
 </div>
 
 At IFS I worked on user behavior analytics for IFS Cloud: capturing usage so product teams can see what customers actually do. Roadmap decisions rest on that usage.
+
+<a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>


### PR DESCRIPTION
## Summary
- Add a visible `Get in touch on LinkedIn` CTA to the user behavior analytics case body (`/work/user-behavior-analytics/`), linking to `https://www.linkedin.com/in/alehar/`.
- Other work cases, Work index, JSON-LD, titles, share meta, RSS, and hire path elsewhere are unchanged. IFS Design System keeps the CTA from #576. AI coding copilots keeps the CTA from #577.

## Test plan
- [x] identity tests (`src/__tests__/identity.test.ts`)
- [ ] Johan + Vera PASS

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.