### PR TITLE
feat: add Get in touch on LinkedIn to the Work index

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -495,6 +495,15 @@ describe('identity copy', () => {
     );
   });
 
+  it('lets the Work index include a visible Get in touch on LinkedIn CTA', () => {
+    const work = readFileSync('src/pages/work.astro', 'utf8');
+    expect(work).toContain('href="https://www.linkedin.com/in/alehar/"');
+    expect(work).toContain('target="_blank"');
+    expect(work).toContain('rel="noopener noreferrer"');
+    expect(work).toMatch(/>Get in touch on LinkedIn<\/a/);
+    expect(work).not.toContain('mailto:');
+  });
+
   it('lets the AI coding copilots work-case TL;DR include at IFS', () => {
     const copilots = readFileSync('src/content/work/ai-coding-copilots.md', 'utf8');
     expect(copilots).toContain(

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -121,6 +121,11 @@ const schema = {
           }
         </ul>
       </section>
+      <p class="hire-cta">
+        <a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer"
+          >Get in touch on LinkedIn</a
+        >
+      </p>
     </main>
     <ContactCTA />
   </div>
@@ -226,6 +231,25 @@ const schema = {
     font-size: var(--text-sm);
   }
 
+  .hire-cta {
+    margin: 0;
+    color: var(--gray-300);
+    /* Phone: keep the LinkedIn hire CTA out of the fixed chat FAB band. */
+    padding-bottom: var(--chat-fab-clearance);
+    padding-right: var(--chat-fab-clearance);
+  }
+
+  .hire-cta a {
+    color: var(--gray-200);
+    text-decoration: 1px solid underline transparent;
+    text-underline-offset: 0.25em;
+  }
+
+  .hire-cta a:hover,
+  .hire-cta a:focus-visible {
+    text-decoration-color: currentColor;
+  }
+
   @media (prefers-reduced-motion: no-preference) {
     .proof-card {
       transition:
@@ -247,6 +271,11 @@ const schema = {
     }
 
     .earlier {
+      padding-bottom: 0;
+      padding-right: 0;
+    }
+
+    .hire-cta {
       padding-bottom: 0;
       padding-right: 0;
     }


### PR DESCRIPTION
## Summary
- Add a visible `Get in touch on LinkedIn` CTA to the Work index (`/work/`), linking to `https://www.linkedin.com/in/alehar/`.
- Same visitor-facing hire link as the IFS Design System, copilots, and analytics cases. JSON-LD, titles, share meta, work cases, RSS, IFS/copilots/analytics CTAs, and hire path elsewhere are unchanged.

## Test plan
- [x] identity tests (`src/__tests__/identity.test.ts`)
- [ ] Johan + Vera PASS

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.