### PR TITLE
feat: add Get in touch on LinkedIn to the Chalmers master's thesis case

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -437,12 +437,8 @@ describe('identity copy', () => {
     expect(ds).not.toContain('mailto:');
 
     const lidkoping = readFileSync('src/content/work/lidkoping-stenhuggeri.md', 'utf8');
-    const thesis = readFileSync('src/content/work/master-thesis.md', 'utf8');
     const work = readFileSync('src/pages/work.astro', 'utf8');
-    for (const { path, text } of [
-      { path: 'lidkoping-stenhuggeri.md', text: lidkoping },
-      { path: 'master-thesis.md', text: thesis },
-    ]) {
+    for (const { path, text } of [{ path: 'lidkoping-stenhuggeri.md', text: lidkoping }]) {
       expect(text, path).not.toContain('Get in touch on LinkedIn');
       expect(text, path).not.toContain('https://www.linkedin.com/in/alehar/');
     }
@@ -459,12 +455,8 @@ describe('identity copy', () => {
     expect(copilots).not.toContain('mailto:');
 
     const lidkoping = readFileSync('src/content/work/lidkoping-stenhuggeri.md', 'utf8');
-    const thesis = readFileSync('src/content/work/master-thesis.md', 'utf8');
     const work = readFileSync('src/pages/work.astro', 'utf8');
-    for (const { path, text } of [
-      { path: 'lidkoping-stenhuggeri.md', text: lidkoping },
-      { path: 'master-thesis.md', text: thesis },
-    ]) {
+    for (const { path, text } of [{ path: 'lidkoping-stenhuggeri.md', text: lidkoping }]) {
       expect(text, path).not.toContain('Get in touch on LinkedIn');
       expect(text, path).not.toContain('https://www.linkedin.com/in/alehar/');
     }
@@ -481,12 +473,26 @@ describe('identity copy', () => {
     expect(analytics).not.toContain('mailto:');
 
     const lidkoping = readFileSync('src/content/work/lidkoping-stenhuggeri.md', 'utf8');
-    const thesis = readFileSync('src/content/work/master-thesis.md', 'utf8');
     const work = readFileSync('src/pages/work.astro', 'utf8');
-    for (const { path, text } of [
-      { path: 'lidkoping-stenhuggeri.md', text: lidkoping },
-      { path: 'master-thesis.md', text: thesis },
-    ]) {
+    for (const { path, text } of [{ path: 'lidkoping-stenhuggeri.md', text: lidkoping }]) {
+      expect(text, path).not.toContain('Get in touch on LinkedIn');
+      expect(text, path).not.toContain('https://www.linkedin.com/in/alehar/');
+    }
+    expect(work).not.toContain(
+      '<a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>'
+    );
+  });
+
+  it("lets the Chalmers master's thesis case include a visible Get in touch on LinkedIn CTA", () => {
+    const thesis = readFileSync('src/content/work/master-thesis.md', 'utf8');
+    expect(thesis).toContain(
+      '<a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>'
+    );
+    expect(thesis).not.toContain('mailto:');
+
+    const lidkoping = readFileSync('src/content/work/lidkoping-stenhuggeri.md', 'utf8');
+    const work = readFileSync('src/pages/work.astro', 'utf8');
+    for (const { path, text } of [{ path: 'lidkoping-stenhuggeri.md', text: lidkoping }]) {
       expect(text, path).not.toContain('Get in touch on LinkedIn');
       expect(text, path).not.toContain('https://www.linkedin.com/in/alehar/');
     }

--- a/src/content/work/master-thesis.md
+++ b/src/content/work/master-thesis.md
@@ -20,3 +20,5 @@ This is earlier work. Master's thesis at [Chalmers University of Technology](htt
 3. Where that case differed from the literature.
 
 Opportunities showed up as reach, scale, and data for decisions. Barriers were mostly organizational. The featured case is the [IFS Design System](/work/ifs-design-system/).
+
+<a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>


### PR DESCRIPTION
## Summary
- Add a visible `Get in touch on LinkedIn` CTA to the Chalmers master's thesis case body (`/work/master-thesis/`), linking to `https://www.linkedin.com/in/alehar/`.
- Other work cases, Work index, JSON-LD, titles, share meta, RSS, and hire path elsewhere are unchanged. IFS Design System keeps the CTA from #576. AI coding copilots keeps the CTA from #577. User behavior analytics keeps the CTA from #578. Work index keeps the CTA from #579.

## Test plan
- [x] identity tests (`src/__tests__/identity.test.ts`)
- [ ] Johan + Vera PASS

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a LinkedIn contact link to the Chalmers master’s thesis work case.

* **Bug Fixes**
  * Updated work-case behavior checks to accurately reflect which cases include LinkedIn contact options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->