### PR TITLE
feat: add a problem-approach-outcome section to the IFS Design System case

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -447,6 +447,20 @@ describe('identity copy', () => {
     );
   });
 
+  it('lets the IFS Design System case include a problem-approach-outcome section', () => {
+    const ds = readFileSync('src/content/work/ifs-design-system.md', 'utf8');
+    expect(ds).toContain('## Problem');
+    expect(ds).toContain('## Approach');
+    expect(ds).toContain('## Outcome');
+    expect(ds).toContain('up to 2x');
+    expect(ds).toContain('up to 30x');
+    expect(ds).toContain('Zeroheight');
+    expect(ds).toContain(
+      '<a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>'
+    );
+    expect(ds).not.toContain('mailto:');
+  });
+
   it('lets the AI coding copilots case include a visible Get in touch on LinkedIn CTA', () => {
     const copilots = readFileSync('src/content/work/ai-coding-copilots.md', 'utf8');
     expect(copilots).toContain(

--- a/src/content/work/ifs-design-system.md
+++ b/src/content/work/ifs-design-system.md
@@ -19,6 +19,18 @@ As Product Manager, Developer Experience at IFS, I took the design system from t
 
 Product teams needed a shared way to ship UI across Cloud, so feature work could move faster and the experience stayed consistent.
 
+## Problem
+
+Product teams needed a shared way to ship UI across Cloud. There was no Cloud-scale system to inherit.
+
+## Approach
+
+As Product Manager, Developer Experience at IFS, I took the design system from the first version to IFS Cloud, IFS's enterprise product platform.
+
+## Outcome
+
+The system now runs at IFS Cloud scale. Developers and designers use it to ship a consistent experience across Cloud, with up to 2x faster feature delivery and up to 30x ROI on the initial investment. It was a Zeroheight Design System Awards runner-up.
+
 ## Metrics
 
 - **Up to 2x faster** feature delivery


### PR DESCRIPTION
## Summary
- Add a short visitor-facing Problem / Approach / Outcome section to the IFS Design System case body (`/work/ifs-design-system/`), restating already-published facts only (up to 2x, up to 30x, Zeroheight, Product Manager, Developer Experience at IFS).
- Keep the visible Get in touch on LinkedIn CTA from #576. JSON-LD, titles, share meta, other cases, Work index, RSS, and hire path elsewhere are unchanged.

## Test plan
- [x] identity tests (`src/__tests__/identity.test.ts`)
- [ ] Johan + Vera PASS

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.