### PR TITLE
feat: add a problem-approach-outcome section to the user behavior analytics case

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -497,6 +497,21 @@ describe('identity copy', () => {
     );
   });
 
+  it('lets the user behavior analytics case include a problem-approach-outcome section', () => {
+    const analytics = readFileSync('src/content/work/user-behavior-analytics.md', 'utf8');
+    expect(analytics).toContain('## Problem');
+    expect(analytics).toContain('## Approach');
+    expect(analytics).toContain('## Outcome');
+    expect(analytics).toContain('Product Manager, Developer Experience');
+    expect(analytics).toContain('capturing usage');
+    expect(analytics).toContain('product teams can see what customers actually do');
+    expect(analytics).toContain('Roadmap decisions rest on that usage');
+    expect(analytics).toContain(
+      '<a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>'
+    );
+    expect(analytics).not.toContain('mailto:');
+  });
+
   it("lets the Chalmers master's thesis case include a visible Get in touch on LinkedIn CTA", () => {
     const thesis = readFileSync('src/content/work/master-thesis.md', 'utf8');
     expect(thesis).toContain(

--- a/src/content/work/user-behavior-analytics.md
+++ b/src/content/work/user-behavior-analytics.md
@@ -15,4 +15,16 @@ tags:
 
 At IFS I worked on user behavior analytics for IFS Cloud: capturing usage so product teams can see what customers actually do. Roadmap decisions rest on that usage.
 
+## Problem
+
+Product teams need to see what customers actually do so IFS Cloud roadmap decisions rest on that usage.
+
+## Approach
+
+As Product Manager, Developer Experience at IFS, I worked on user behavior analytics for IFS Cloud: capturing usage so product teams can see what customers actually do.
+
+## Outcome
+
+Usage telemetry so IFS Cloud roadmap decisions rest on how people actually use the product. Roadmap decisions rest on that usage.
+
 <a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>


### PR DESCRIPTION
## Summary
- Add a short visitor-facing Problem / Approach / Outcome section to the user behavior analytics case body (`/work/user-behavior-analytics/`), restating already-published facts only (usage telemetry, IFS Cloud roadmap decisions, product teams can see what customers actually do, Product Manager, Developer Experience at IFS).
- Keep the visible Get in touch on LinkedIn CTA from #578. JSON-LD, titles, share meta, other cases, Work index, RSS, IFS Design System PAO (#581), and hire path elsewhere are unchanged.

## Test plan
- [x] identity tests (`src/__tests__/identity.test.ts`)
- [ ] Johan + Vera PASS

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.