### PR TITLE
feat: add a problem-approach-outcome section to the Chalmers master's thesis case

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -530,6 +530,24 @@ describe('identity copy', () => {
     );
   });
 
+  it("lets the Chalmers master's thesis case include a problem-approach-outcome section", () => {
+    const thesis = readFileSync('src/content/work/master-thesis.md', 'utf8');
+    expect(thesis).toContain('## Problem');
+    expect(thesis).toContain('## Approach');
+    expect(thesis).toContain('## Outcome');
+    expect(thesis).toContain('Chalmers University of Technology');
+    expect(thesis).toContain('business model innovation and digitalization');
+    expect(thesis).toContain('mapped what digitalization does to business models');
+    expect(thesis).toContain('studied one case');
+    expect(thesis).toContain('compared that to the literature');
+    expect(thesis).toContain('Opportunities showed up as reach, scale, and data for decisions');
+    expect(thesis).toContain('Barriers were mostly organizational');
+    expect(thesis).toContain(
+      '<a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>'
+    );
+    expect(thesis).not.toContain('mailto:');
+  });
+
   it('lets the Work index include a visible Get in touch on LinkedIn CTA', () => {
     const work = readFileSync('src/pages/work.astro', 'utf8');
     expect(work).toContain('href="https://www.linkedin.com/in/alehar/"');

--- a/src/content/work/master-thesis.md
+++ b/src/content/work/master-thesis.md
@@ -21,4 +21,16 @@ This is earlier work. Master's thesis at [Chalmers University of Technology](htt
 
 Opportunities showed up as reach, scale, and data for decisions. Barriers were mostly organizational. The featured case is the [IFS Design System](/work/ifs-design-system/).
 
+## Problem
+
+What digitalization does to a business model, including a case where digitalization was part of changing the model, and where that case differed from the literature.
+
+## Approach
+
+Master's thesis at Chalmers University of Technology in 2017 on business model innovation and digitalization. It mapped what digitalization does to business models, studied one case, and compared that to the literature.
+
+## Outcome
+
+Opportunities showed up as reach, scale, and data for decisions. Barriers were mostly organizational.
+
 <a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>


### PR DESCRIPTION
## Summary
- Add a short visitor-facing Problem / Approach / Outcome section to the Chalmers master's thesis case body (`/work/master-thesis/`), restating already-published facts only (Chalmers 2017, business model innovation and digitalization, mapped what digitalization does to business models, studied one case, compared that to the literature, opportunities as reach, scale, and data for decisions, barriers mostly organizational).
- Keep the visible Get in touch on LinkedIn CTA from #580. JSON-LD, titles, share meta, other cases, Work index, RSS, IFS Design System PAO (#581), analytics PAO (#582), and hire path elsewhere are unchanged.

## Test plan
- [x] identity tests (`src/__tests__/identity.test.ts`)
- [ ] Johan + Vera PASS

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.