### PR TITLE
feat: add at IFS to the Biography current-role title

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -800,6 +800,13 @@ describe('identity copy', () => {
     expect(home).not.toContain('mailto:');
   });
 
+  it('lets the Biography visible current-role title read Product Manager, Developer Experience at IFS', () => {
+    const bio = readFileSync('src/pages/biography.astro', 'utf8');
+    expect(bio).toContain('<h3>Product Manager, Developer Experience at IFS</h3>');
+    expect(bio).toContain('https://www.linkedin.com/in/alehar/');
+    expect(bio).not.toContain('mailto:');
+  });
+
   it('lets Person.jobTitle read Product Manager, Developer Experience at IFS', () => {
     const home = readFileSync('src/pages/index.astro', 'utf8');
     const bio = readFileSync('src/pages/biography.astro', 'utf8');

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -70,7 +70,7 @@ const schema = {
           <ol class="timeline">
             <li>
               <p class="when">Feb 2025 – present</p>
-              <h3>Product Manager, Developer Experience</h3>
+              <h3>Product Manager, Developer Experience at IFS</h3>
               <p class="where">IFS, Greater Stockholm</p>
               <p>I work on Developer Experience at IFS, including internal AI coding copilots.</p>
             </li>


### PR DESCRIPTION
## Summary
- Set the visible Biography current-role title to `Product Manager, Developer Experience at IFS` (the Experience timeline `h3` on `/biography/`).
- JSON-LD, share meta, Hero tagline, Work cases, and hire path are unchanged — they already include at IFS. LinkedIn hire stays `https://www.linkedin.com/in/alehar/`. No email. No CV.

## Titles
- Biography visible current-role (old): `Product Manager, Developer Experience`
- Biography visible current-role (new): `Product Manager, Developer Experience at IFS`

## Test plan
- [ ] `npx vitest run src/__tests__/identity.test.ts`
- [ ] Confirm the Biography page body current-role line reads `Product Manager, Developer Experience at IFS`
- [ ] Confirm JSON-LD jobTitle, share titles, and Work cases were not modified
- [ ] Confirm LinkedIn hire still points at https://www.linkedin.com/in/alehar/
- [ ] Confirm no `mailto:`
- [ ] Stay draft until Johan+Vera PASS a freeze SHA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Biography page to display the current role as “Product Manager, Developer Experience at IFS.”
  * Ensured the LinkedIn profile is shown without displaying an email link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->