### PR TITLE
feat: add a problem-approach-outcome section to the AI coding copilots case

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -479,6 +479,22 @@ describe('identity copy', () => {
     );
   });
 
+  it('lets the AI coding copilots case include a problem-approach-outcome section', () => {
+    const copilots = readFileSync('src/content/work/ai-coding-copilots.md', 'utf8');
+    expect(copilots).toContain('## Problem');
+    expect(copilots).toContain('## Approach');
+    expect(copilots).toContain('## Outcome');
+    expect(copilots).toContain('Product Manager, Developer Experience');
+    expect(copilots).toContain('Greater Stockholm');
+    expect(copilots).toContain('internal AI coding copilots');
+    expect(copilots).toContain('engineering teams');
+    expect(copilots).toContain('February 2025');
+    expect(copilots).toContain(
+      '<a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>'
+    );
+    expect(copilots).not.toContain('mailto:');
+  });
+
   it('lets the user behavior analytics case include a visible Get in touch on LinkedIn CTA', () => {
     const analytics = readFileSync('src/content/work/user-behavior-analytics.md', 'utf8');
     expect(analytics).toContain(

--- a/src/content/work/ai-coding-copilots.md
+++ b/src/content/work/ai-coding-copilots.md
@@ -15,4 +15,16 @@ tags:
 
 As Product Manager, Developer Experience at IFS in Greater Stockholm, I work on internal AI coding copilots for engineering teams. I have been in this role since February 2025.
 
+## Problem
+
+Internal AI coding copilots for IFS engineering teams.
+
+## Approach
+
+As Product Manager, Developer Experience at IFS in Greater Stockholm, I work on internal AI coding copilots for engineering teams. I have been in this role since February 2025.
+
+## Outcome
+
+Internal AI coding copilots for IFS engineering teams.
+
 <a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>


### PR DESCRIPTION
## Summary
- Add a short visitor-facing Problem / Approach / Outcome section to the AI coding copilots case body (`/work/ai-coding-copilots/`), restating already-published facts only (internal AI coding copilots for IFS engineering teams, Product Manager, Developer Experience at IFS in Greater Stockholm, in this role since February 2025).
- Keep the visible Get in touch on LinkedIn CTA from #577. JSON-LD, titles, share meta, other cases, Work index, RSS, IFS Design System PAO (#581), analytics PAO (#582), thesis PAO (#583), and hire path elsewhere are unchanged.

## Test plan
- [x] identity tests (`src/__tests__/identity.test.ts`)
- [ ] Johan + Vera PASS

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.