### PR TITLE
feat: drop extra IFS after the Biography current-role title

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -819,6 +819,8 @@ describe('identity copy', () => {
   it('lets the Biography visible current-role title read Product Manager, Developer Experience at IFS', () => {
     const bio = readFileSync('src/pages/biography.astro', 'utf8');
     expect(bio).toContain('<h3>Product Manager, Developer Experience at IFS</h3>');
+    expect(bio).toContain('<p class="where">Greater Stockholm</p>');
+    expect(bio).not.toContain('<p class="where">IFS, Greater Stockholm</p>');
     expect(bio).toContain('https://www.linkedin.com/in/alehar/');
     expect(bio).not.toContain('mailto:');
   });

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -71,7 +71,7 @@ const schema = {
             <li>
               <p class="when">Feb 2025 – present</p>
               <h3>Product Manager, Developer Experience at IFS</h3>
-              <p class="where">IFS, Greater Stockholm</p>
+              <p class="where">Greater Stockholm</p>
               <p>I work on Developer Experience at IFS, including internal AI coding copilots.</p>
             </li>
             <li>


### PR DESCRIPTION
## Summary
- Drop the extra company `IFS` that sat immediately after the Biography current-role title on `/biography/` (`<p class="where">IFS, Greater Stockholm</p>` → `<p class="where">Greater Stockholm</p>`).
- Keep the visible title from #584 as `Product Manager, Developer Experience at IFS`. JSON-LD, share meta, Hero tagline, Work cases, and hire path elsewhere are unchanged. LinkedIn hire stays `https://www.linkedin.com/in/alehar/`. No email. No CV.

## Extra IFS dropped
- Old: `<h3>Product Manager, Developer Experience at IFS</h3>` then `<p class="where">IFS, Greater Stockholm</p>`
- New: `<h3>Product Manager, Developer Experience at IFS</h3>` then `<p class="where">Greater Stockholm</p>`

## Test plan
- [x] `npx vitest run src/__tests__/identity.test.ts`
- [ ] Confirm the Biography current-role title still reads `Product Manager, Developer Experience at IFS`
- [ ] Confirm the extra `IFS` under that title is gone (location line is `Greater Stockholm`)
- [ ] Confirm JSON-LD, share titles, Work cases, and hire path were not modified
- [ ] Confirm LinkedIn hire still points at https://www.linkedin.com/in/alehar/
- [ ] Confirm no `mailto:`
- [ ] Stay draft until Johan+Vera PASS a freeze SHA

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.