### PR TITLE
feat: drop Ask about the work from the twin chat input placeholder

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -329,9 +329,10 @@ describe('identity copy', () => {
     expect(head).not.toContain('harenstam.com');
   });
 
-  it('keeps the twin idle prompt as Ask about the work', () => {
+  it('drops Ask about the work from the twin chat input placeholder', () => {
     const chat = readFileSync('src/components/Chat.astro', 'utf8');
-    expect(chat).toContain('placeholder="Ask about the work"');
+    expect(chat).not.toContain('placeholder="Ask about the work"');
+    expect(chat).not.toContain('placeholder=');
     expect(chat).not.toContain('Ask me something');
     expect(chat).not.toContain('chat-toggle-portrait');
     expect(chat).not.toContain('mailto:');

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -86,13 +86,7 @@
     <div id="typing-indicator" class="typing-indicator hidden">Alexander is typing...</div>
     <p id="chat-remaining" class="chat-remaining" aria-live="polite" hidden></p>
     <form id="chat-form" class="chat-form">
-      <input
-        type="text"
-        id="chat-input"
-        placeholder="Ask about the work"
-        required
-        autocomplete="off"
-      />
+      <input type="text" id="chat-input" required autocomplete="off" />
       <button type="submit" aria-label="Send message">
         <svg
           xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Summary
- Drop the twin chat input placeholder `Ask about the work`. The `#chat-input` attribute is omitted (no replacement copy).
- Identity tests now assert that placeholder string is gone from the chat input. Tooltip, intro line, idle status label, JSON-LD, titles, share meta, Work cases, Biography, and hire path are unchanged. LinkedIn hire stays `https://www.linkedin.com/in/alehar/`. No email. No CV.

## Placeholder
- Old: `placeholder="Ask about the work"`
- New: attribute omitted (`<input type="text" id="chat-input" required autocomplete="off" />`)

## Test plan
- [x] `npx vitest run src/__tests__/identity.test.ts`
- [ ] Confirm the chat input has no `Ask about the work` placeholder
- [ ] Confirm JSON-LD, share titles, Work cases, Biography, and hire path were not modified
- [ ] Confirm LinkedIn hire still points at https://www.linkedin.com/in/alehar/
- [ ] Confirm no `mailto:`
- [ ] Stay draft until Johan+Vera PASS a freeze SHA

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.