### PR TITLE
feat: drop Ask about the work from the twin chat tooltip

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -340,6 +340,19 @@ describe('identity copy', () => {
     expect(chat).toContain("error: 'Not live'");
   });
 
+  it('drops Ask about the work from the twin chat tooltip', () => {
+    const chat = readFileSync('src/components/Chat.astro', 'utf8');
+    expect(chat).not.toContain('class="status-tooltip">Ask about the work</span>');
+    expect(chat).toContain('id="status-tooltip" class="status-tooltip"></span>');
+    expect(chat).not.toContain('placeholder="Ask about the work"');
+    expect(chat).not.toContain('placeholder=');
+    expect(chat).not.toContain('Ask me something');
+    expect(chat).not.toContain('chat-toggle-portrait');
+    expect(chat).not.toContain('mailto:');
+    expect(chat).toContain("idle: 'Live'");
+    expect(chat).toContain("error: 'Not live'");
+  });
+
   it('lets a visitor clear the twin chat and keeps identity in the header, not the FAB', () => {
     const chat = readFileSync('src/components/Chat.astro', 'utf8');
     expect(chat).toContain('aria-label="Clear conversation"');

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -344,9 +344,14 @@ describe('identity copy', () => {
     const chat = readFileSync('src/components/Chat.astro', 'utf8');
     expect(chat).not.toContain('class="status-tooltip">Ask about the work</span>');
     expect(chat).toContain('id="status-tooltip" class="status-tooltip"></span>');
+    expect(chat).toContain('statusTooltip.textContent = tooltipLabels[state]');
+    expect(chat).not.toContain('statusTooltip.textContent = statusLabels[state]');
+    expect(chat).toContain("idle: ''");
+    expect(chat).not.toMatch(/statusTooltip\.textContent\s*=\s*['"]Ask about the work['"]/);
     expect(chat).not.toContain('placeholder="Ask about the work"');
     expect(chat).not.toContain('placeholder=');
     expect(chat).not.toContain('Ask me something');
+    expect(chat).not.toContain('Ask me anything');
     expect(chat).not.toContain('chat-toggle-portrait');
     expect(chat).not.toContain('mailto:');
     expect(chat).toContain("idle: 'Live'");

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -25,7 +25,7 @@
     >
       <path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"></path>
     </svg>
-    <span role="tooltip" id="status-tooltip" class="status-tooltip">Ask about the work</span>
+    <span role="tooltip" id="status-tooltip" class="status-tooltip"></span>
   </button>
 
   <div id="chat-window" class="chat-window hidden">

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -558,6 +558,12 @@
     error: 'Not live',
     limited: 'Live. Hourly limit reached',
   };
+  const tooltipLabels = {
+    idle: '',
+    loading: 'Live. Thinking...',
+    error: 'Not live',
+    limited: 'Live. Hourly limit reached',
+  };
   const liveLabels = {
     idle: 'Live',
     loading: 'Live',
@@ -566,7 +572,7 @@
   };
 
   function setStatus(state: 'idle' | 'loading' | 'error' | 'limited') {
-    if (statusTooltip) statusTooltip.textContent = statusLabels[state];
+    if (statusTooltip) statusTooltip.textContent = tooltipLabels[state];
     if (statusAnnouncer) statusAnnouncer.textContent = statusLabels[state];
     if (liveLabel) liveLabel.textContent = liveLabels[state];
     if (statusDot) {


### PR DESCRIPTION
## Summary
- Drop the twin chat tooltip `Ask about the work`. The `#status-tooltip` text is omitted (no replacement copy). The tooltip span stays so JS can still set idle/loading/error.
- Identity tests now assert that tooltip string is gone. The #587 placeholder drop stays. Intro line, idle status label, and changelog are left for later PRs. JSON-LD, titles, share meta, Work cases, Biography, and hire path are unchanged. LinkedIn hire stays `https://www.linkedin.com/in/alehar/`. No email. No CV.

## Tooltip
- Old: `<span role="tooltip" id="status-tooltip" class="status-tooltip">Ask about the work</span>`
- New: text omitted (`<span role="tooltip" id="status-tooltip" class="status-tooltip"></span>`)

## Test plan
- [x] `npx vitest run src/__tests__/identity.test.ts`
- [ ] Confirm the chat tooltip has no `Ask about the work` copy
- [ ] Confirm the chat input still has no `placeholder="Ask about the work"`
- [ ] Confirm intro line, idle status label, and changelog were not modified
- [ ] Confirm JSON-LD, share titles, Work cases, Biography, and hire path were not modified
- [ ] Confirm LinkedIn hire still points at https://www.linkedin.com/in/alehar/
- [ ] Confirm no `mailto:`
- [ ] Stay draft until Johan+Vera PASS a freeze SHA

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.