### PR TITLE
feat: drop Ask about the work from the twin chat welcome

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -358,6 +358,25 @@ describe('identity copy', () => {
     expect(chat).toContain("error: 'Not live'");
   });
 
+  it('drops Ask about the work from the twin chat welcome', () => {
+    const chat = readFileSync('src/components/Chat.astro', 'utf8');
+    expect(chat).not.toContain('Ask about the work, DevEx, Industrial AI, or background.');
+    expect(chat).not.toMatch(/<p>\s*Ask about the work/);
+    expect(chat).toContain('DevEx, Industrial AI, or background.');
+    expect(chat).toContain("I'm an AI with his context.");
+    expect(chat).not.toContain('class="status-tooltip">Ask about the work</span>');
+    expect(chat).toContain('id="status-tooltip" class="status-tooltip"></span>');
+    expect(chat).toContain("idle: ''");
+    expect(chat).not.toContain('placeholder="Ask about the work"');
+    expect(chat).not.toContain('placeholder=');
+    expect(chat).not.toContain('Ask me something');
+    expect(chat).not.toContain('Ask me anything');
+    expect(chat).not.toContain('chat-toggle-portrait');
+    expect(chat).not.toContain('mailto:');
+    expect(chat).toContain("idle: 'Live'");
+    expect(chat).toContain("error: 'Not live'");
+  });
+
   it('lets a visitor clear the twin chat and keeps identity in the header, not the FAB', () => {
     const chat = readFileSync('src/components/Chat.astro', 'utf8');
     expect(chat).toContain('aria-label="Clear conversation"');

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -71,8 +71,7 @@
         />
         <h2>Alexander's digital twin</h2>
         <p>
-          Ask about the work, DevEx, Industrial AI, or background. I'm an AI with his context. I can
-          get things wrong.
+          DevEx, Industrial AI, or background. I'm an AI with his context. I can get things wrong.
         </p>
         <div id="chat-suggestions" class="chat-suggestions">
           <button type="button" class="chat-suggestion">


### PR DESCRIPTION
## Summary
- Drop the twin chat welcome leading phrase `Ask about the work`. The rest of the sentence stays (`DevEx, Industrial AI, or background. I'm an AI with his context. I can get things wrong.`). No replacement topics.
- Identity tests now assert that welcome no longer starts with that phrase. The #588 tooltip-empty and #587 placeholder-gone assertions stay. Idle status label, announcer, and changelog are left for later PRs. JSON-LD, titles, share meta, Work cases, Biography, and hire path are unchanged. LinkedIn hire stays `https://www.linkedin.com/in/alehar/`. No email. No CV.

## Welcome
- Old: `Ask about the work, DevEx, Industrial AI, or background. I'm an AI with his context. I can get things wrong.`
- New: `DevEx, Industrial AI, or background. I'm an AI with his context. I can get things wrong.`

## Test plan
- [x] `npx vitest run src/__tests__/identity.test.ts`
- [ ] Confirm the chat welcome no longer starts with `Ask about the work`
- [ ] Confirm the remainder still reads `DevEx, Industrial AI, or background. I'm an AI with his context. I can get things wrong.`
- [ ] Confirm the chat tooltip stays empty after hydrate
- [ ] Confirm the chat input still has no `placeholder="Ask about the work"`
- [ ] Confirm idle status label, announcer, and changelog were not modified
- [ ] Confirm JSON-LD, share titles, Work cases, Biography, and hire path were not modified
- [ ] Confirm LinkedIn hire still points at https://www.linkedin.com/in/alehar/
- [ ] Confirm no `mailto:`
- [ ] Stay draft until Johan+Vera PASS a freeze SHA

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the chat welcome message to use shorter, clearer wording.
  * Preserved existing chat status, tooltip, placeholder, and identity behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->