### PR TITLE
feat: drop Ask about the work from the twin chat idle announcer

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -377,6 +377,30 @@ describe('identity copy', () => {
     expect(chat).toContain("error: 'Not live'");
   });
 
+  it('drops Ask about the work from the twin chat idle announcer', () => {
+    const chat = readFileSync('src/components/Chat.astro', 'utf8');
+    expect(chat).toContain('id="status-announcer"');
+    expect(chat).toContain('statusAnnouncer.textContent = statusLabels[state]');
+    expect(chat).not.toContain("idle: 'Live. Ask about the work'");
+    expect(chat).not.toContain('Ask about the work');
+    expect(chat).toContain("const statusLabels = {\n    idle: 'Live',");
+    expect(chat).not.toContain('Ask about the work, DevEx, Industrial AI, or background.');
+    expect(chat).not.toMatch(/<p>\s*Ask about the work/);
+    expect(chat).toContain('DevEx, Industrial AI, or background.');
+    expect(chat).toContain("I'm an AI with his context.");
+    expect(chat).not.toContain('class="status-tooltip">Ask about the work</span>');
+    expect(chat).toContain('id="status-tooltip" class="status-tooltip"></span>');
+    expect(chat).toContain("idle: ''");
+    expect(chat).not.toContain('placeholder="Ask about the work"');
+    expect(chat).not.toContain('placeholder=');
+    expect(chat).not.toContain('Ask me something');
+    expect(chat).not.toContain('Ask me anything');
+    expect(chat).not.toContain('chat-toggle-portrait');
+    expect(chat).not.toContain('mailto:');
+    expect(chat).toContain("idle: 'Live'");
+    expect(chat).toContain("error: 'Not live'");
+  });
+
   it('lets a visitor clear the twin chat and keeps identity in the header, not the FAB', () => {
     const chat = readFileSync('src/components/Chat.astro', 'utf8');
     expect(chat).toContain('aria-label="Clear conversation"');

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -552,7 +552,7 @@
   ];
 
   const statusLabels = {
-    idle: 'Live. Ask about the work',
+    idle: 'Live',
     loading: 'Live. Thinking...',
     error: 'Not live',
     limited: 'Live. Hourly limit reached',


### PR DESCRIPTION
## Summary
- Drop `Ask about the work` from the twin chat idle announcer (`#status-announcer`). Idle announcer copy is now the remaining published word `Live` (leftover period/space cleaned). No replacement sentence.
- Identity tests now assert that the `#status-announcer` idle path does not contain `Ask about the work`. The #589 welcome, #588 tooltip-empty, and #587 placeholder-gone assertions stay. Visible idle status label stays `Live` / `Not live`. Changelog is left unchanged. JSON-LD, titles, share meta, Work cases, Biography, and hire path are unchanged. LinkedIn hire stays `https://www.linkedin.com/in/alehar/`. No email. No CV.

## Idle announcer
- Old: `Live. Ask about the work`
- New: `Live`

## Test plan
- [x] `npx vitest run src/__tests__/identity.test.ts`
- [ ] Confirm `#status-announcer` idle no longer contains `Ask about the work`
- [ ] Confirm idle announcer still reads `Live`
- [ ] Confirm the visible idle status label stays `Live` / `Not live`
- [ ] Confirm the chat tooltip stays empty after hydrate
- [ ] Confirm the chat input still has no `placeholder="Ask about the work"`
- [ ] Confirm the chat welcome still starts with `DevEx, Industrial AI, or background.`
- [ ] Confirm changelog was not modified
- [ ] Confirm JSON-LD, share titles, Work cases, Biography, and hire path were not modified
- [ ] Confirm LinkedIn hire still points at https://www.linkedin.com/in/alehar/
- [ ] Confirm no `mailto:`
- [ ] Stay draft until Johan+Vera PASS a freeze SHA

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.