### PR TITLE
feat: drop Ask Alexander from the twin chat header

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -401,12 +401,36 @@ describe('identity copy', () => {
     expect(chat).toContain("error: 'Not live'");
   });
 
+  it('drops Ask Alexander from the twin chat header', () => {
+    const chat = readFileSync('src/components/Chat.astro', 'utf8');
+    expect(chat).toContain('<span class="chat-header-name"></span>');
+    expect(chat).not.toContain('Ask Alexander');
+    expect(chat).not.toContain('Ask about the work');
+    expect(chat).toContain("const statusLabels = {\n    idle: 'Live',");
+    expect(chat).not.toContain('Ask about the work, DevEx, Industrial AI, or background.');
+    expect(chat).not.toMatch(/<p>\s*Ask about the work/);
+    expect(chat).toContain('DevEx, Industrial AI, or background.');
+    expect(chat).toContain("I'm an AI with his context.");
+    expect(chat).not.toContain('class="status-tooltip">Ask about the work</span>');
+    expect(chat).toContain('id="status-tooltip" class="status-tooltip"></span>');
+    expect(chat).toContain("idle: ''");
+    expect(chat).not.toContain('placeholder="Ask about the work"');
+    expect(chat).not.toContain('placeholder=');
+    expect(chat).not.toContain('Ask me something');
+    expect(chat).not.toContain('Ask me anything');
+    expect(chat).not.toContain('chat-toggle-portrait');
+    expect(chat).not.toContain('mailto:');
+    expect(chat).toContain("idle: 'Live'");
+    expect(chat).toContain("error: 'Not live'");
+  });
+
   it('lets a visitor clear the twin chat and keeps identity in the header, not the FAB', () => {
     const chat = readFileSync('src/components/Chat.astro', 'utf8');
     expect(chat).toContain('aria-label="Clear conversation"');
     expect(chat).toContain('clearConversation');
     expect(chat).toContain('chat-header-avatar');
-    expect(chat).toContain('Ask Alexander');
+    expect(chat).not.toContain('Ask Alexander');
+    expect(chat).toContain('class="chat-header-name"');
     expect(chat).not.toContain('chat-toggle-portrait');
     expect(chat).not.toContain('mailto:');
     expect(chat).toContain("idle: 'Live'");

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -33,7 +33,7 @@
       <div class="chat-header-profile">
         <img src="/assets/portrait.png" alt="" class="chat-header-avatar" width="64" height="64" />
         <span class="chat-header-copy">
-          <span class="chat-header-name">Ask Alexander</span>
+          <span class="chat-header-name"></span>
           <span class="chat-live" id="chat-live">
             <span class="status-dot" aria-hidden="true"></span>
             <span class="chat-live-label" id="chat-live-label">Live</span>


### PR DESCRIPTION
## Summary
- Drop `Ask Alexander` from the twin chat header (`.chat-header-name`). Header text is now empty (heading node kept, no replacement copy).
- Identity tests now assert that the chat header does not contain `Ask Alexander`. The #590 idle-announcer, #589 welcome, #588 tooltip-empty, and #587 placeholder-gone assertions stay. Visible idle status label stays `Live` / `Not live`. Changelog is left unchanged. JSON-LD, titles, share meta, Work cases, Biography, and hire path are unchanged. LinkedIn hire stays `https://www.linkedin.com/in/alehar/`. No email. No CV.

## Chat header
- Old: `Ask Alexander`
- New: `` (empty; `<span class="chat-header-name"></span>` kept)

## Test plan
- [x] `npx vitest run src/__tests__/identity.test.ts`
- [ ] Confirm `.chat-header-name` no longer contains `Ask Alexander`
- [ ] Confirm the header element/structure is still present
- [ ] Confirm idle announcer still reads `Live`
- [ ] Confirm the visible idle status label stays `Live` / `Not live`
- [ ] Confirm the chat tooltip stays empty after hydrate
- [ ] Confirm the chat input still has no `placeholder="Ask about the work"`
- [ ] Confirm the chat welcome still starts with `DevEx, Industrial AI, or background.`
- [ ] Confirm changelog was not modified
- [ ] Confirm JSON-LD, share titles, Work cases, Biography, and hire path were not modified
- [ ] Confirm LinkedIn hire still points at https://www.linkedin.com/in/alehar/
- [ ] Confirm no `mailto:`
- [ ] Stay draft until Johan+Vera PASS a freeze SHA

Draft until Johan+Vera PASS.
Do not merge.
Stay off #512.