### PR TITLE
feat: add Get in touch on LinkedIn to the user behavior analytics JSON-LD CreativeWork description

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -1121,7 +1121,9 @@ describe('identity copy', () => {
       `'@type': 'CreativeWork',
           name: entry.data.title,
           description:
-            entry.id === 'ifs-design-system' || entry.id === 'ai-coding-copilots'
+            entry.id === 'ifs-design-system' ||
+            entry.id === 'ai-coding-copilots' ||
+            entry.id === 'user-behavior-analytics'
               ? \`\${entry.data.description.trim()} Get in touch on LinkedIn.\`
               : entry.data.description,`
     );
@@ -1135,7 +1137,25 @@ describe('identity copy', () => {
       `'@type': 'CreativeWork',
           name: entry.data.title,
           description:
-            entry.id === 'ifs-design-system' || entry.id === 'ai-coding-copilots'
+            entry.id === 'ifs-design-system' ||
+            entry.id === 'ai-coding-copilots' ||
+            entry.id === 'user-behavior-analytics'
+              ? \`\${entry.data.description.trim()} Get in touch on LinkedIn.\`
+              : entry.data.description,`
+    );
+    expect(slug).not.toContain('mailto:');
+  });
+
+  it('lets the user behavior analytics JSON-LD CreativeWork.description include Get in touch on LinkedIn', () => {
+    const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
+    expect(slug).toContain("'@type': 'CreativeWork'");
+    expect(slug).toContain(
+      `'@type': 'CreativeWork',
+          name: entry.data.title,
+          description:
+            entry.id === 'ifs-design-system' ||
+            entry.id === 'ai-coding-copilots' ||
+            entry.id === 'user-behavior-analytics'
               ? \`\${entry.data.description.trim()} Get in touch on LinkedIn.\`
               : entry.data.description,`
     );

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -83,7 +83,9 @@ const schema = entry
           '@type': 'CreativeWork',
           name: entry.data.title,
           description:
-            entry.id === 'ifs-design-system' || entry.id === 'ai-coding-copilots'
+            entry.id === 'ifs-design-system' ||
+            entry.id === 'ai-coding-copilots' ||
+            entry.id === 'user-behavior-analytics'
               ? `${entry.data.description.trim()} Get in touch on LinkedIn.`
               : entry.data.description,
           datePublished: entry.data.publishDate.toISOString(),


### PR DESCRIPTION
## Summary
- Add `Get in touch on LinkedIn` to the user behavior analytics JSON-LD `CreativeWork.description`, keeping the existing description text.
- Other work cases, WebPage.description, share meta, Work index JSON-LD, RSS, titles, IFS Design System JSON-LD, AI coding copilots JSON-LD, and hire path are unchanged.

## Test plan
- [x] identity tests (`src/__tests__/identity.test.ts`)
- [ ] Johan + Vera PASS

Draft until Johan+Vera PASS.
Do not merge.