### PR TITLE
feat: add Get in touch on LinkedIn to the Chalmers master's thesis JSON-LD WebPage description

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -1071,7 +1071,8 @@ describe('identity copy', () => {
           description:
             entry.id === 'ifs-design-system' ||
             entry.id === 'ai-coding-copilots' ||
-            entry.id === 'user-behavior-analytics'
+            entry.id === 'user-behavior-analytics' ||
+            entry.id === 'master-thesis'
               ? \`\${entry.data.description.trim()} Get in touch on LinkedIn.\`
               : entry.data.description,`
     );
@@ -1089,7 +1090,8 @@ describe('identity copy', () => {
           description:
             entry.id === 'ifs-design-system' ||
             entry.id === 'ai-coding-copilots' ||
-            entry.id === 'user-behavior-analytics'
+            entry.id === 'user-behavior-analytics' ||
+            entry.id === 'master-thesis'
               ? \`\${entry.data.description.trim()} Get in touch on LinkedIn.\`
               : entry.data.description,`
     );
@@ -1107,7 +1109,27 @@ describe('identity copy', () => {
           description:
             entry.id === 'ifs-design-system' ||
             entry.id === 'ai-coding-copilots' ||
-            entry.id === 'user-behavior-analytics'
+            entry.id === 'user-behavior-analytics' ||
+            entry.id === 'master-thesis'
+              ? \`\${entry.data.description.trim()} Get in touch on LinkedIn.\`
+              : entry.data.description,`
+    );
+    expect(slug).not.toContain('mailto:');
+  });
+
+  it("lets the Chalmers master's thesis JSON-LD WebPage.description include Get in touch on LinkedIn", () => {
+    const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
+    expect(slug).toContain("'@type': 'WebPage'");
+    expect(slug).toContain(
+      `'@type': 'WebPage',
+          '@id': \`https://me.alehar.workers.dev/work/\${entry.id}/#webpage\`,
+          url: \`https://me.alehar.workers.dev/work/\${entry.id}/\`,
+          name: \`\${entry.data.title} | Alexander Härenstam\`,
+          description:
+            entry.id === 'ifs-design-system' ||
+            entry.id === 'ai-coding-copilots' ||
+            entry.id === 'user-behavior-analytics' ||
+            entry.id === 'master-thesis'
               ? \`\${entry.data.description.trim()} Get in touch on LinkedIn.\`
               : entry.data.description,`
     );

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -52,7 +52,8 @@ const schema = entry
           description:
             entry.id === 'ifs-design-system' ||
             entry.id === 'ai-coding-copilots' ||
-            entry.id === 'user-behavior-analytics'
+            entry.id === 'user-behavior-analytics' ||
+            entry.id === 'master-thesis'
               ? `${entry.data.description.trim()} Get in touch on LinkedIn.`
               : entry.data.description,
           breadcrumb: {


### PR DESCRIPTION
## Summary
- Add `Get in touch on LinkedIn` to the Chalmers master's thesis JSON-LD `WebPage.description`, keeping the existing description text.
- Resulting `WebPage.description` is exactly `Chalmers master's thesis, 2017. Get in touch on LinkedIn.`
- CreativeWork.description, other work cases, share meta, titles, visible copy, chat, Biography, hire path, and changelog are unchanged.

## Test plan
- [x] identity tests (`src/__tests__/identity.test.ts`)
- [ ] Johan + Vera PASS

Draft until Johan+Vera PASS.
Do not merge.
