### PR TITLE
feat: add Get in touch on LinkedIn to the Chalmers master's thesis JSON-LD CreativeWork description

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -1145,7 +1145,8 @@ describe('identity copy', () => {
           description:
             entry.id === 'ifs-design-system' ||
             entry.id === 'ai-coding-copilots' ||
-            entry.id === 'user-behavior-analytics'
+            entry.id === 'user-behavior-analytics' ||
+            entry.id === 'master-thesis'
               ? \`\${entry.data.description.trim()} Get in touch on LinkedIn.\`
               : entry.data.description,`
     );
@@ -1161,7 +1162,8 @@ describe('identity copy', () => {
           description:
             entry.id === 'ifs-design-system' ||
             entry.id === 'ai-coding-copilots' ||
-            entry.id === 'user-behavior-analytics'
+            entry.id === 'user-behavior-analytics' ||
+            entry.id === 'master-thesis'
               ? \`\${entry.data.description.trim()} Get in touch on LinkedIn.\`
               : entry.data.description,`
     );
@@ -1177,7 +1179,25 @@ describe('identity copy', () => {
           description:
             entry.id === 'ifs-design-system' ||
             entry.id === 'ai-coding-copilots' ||
-            entry.id === 'user-behavior-analytics'
+            entry.id === 'user-behavior-analytics' ||
+            entry.id === 'master-thesis'
+              ? \`\${entry.data.description.trim()} Get in touch on LinkedIn.\`
+              : entry.data.description,`
+    );
+    expect(slug).not.toContain('mailto:');
+  });
+
+  it("lets the Chalmers master's thesis JSON-LD CreativeWork.description include Get in touch on LinkedIn", () => {
+    const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
+    expect(slug).toContain("'@type': 'CreativeWork'");
+    expect(slug).toContain(
+      `'@type': 'CreativeWork',
+          name: entry.data.title,
+          description:
+            entry.id === 'ifs-design-system' ||
+            entry.id === 'ai-coding-copilots' ||
+            entry.id === 'user-behavior-analytics' ||
+            entry.id === 'master-thesis'
               ? \`\${entry.data.description.trim()} Get in touch on LinkedIn.\`
               : entry.data.description,`
     );

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -86,7 +86,8 @@ const schema = entry
           description:
             entry.id === 'ifs-design-system' ||
             entry.id === 'ai-coding-copilots' ||
-            entry.id === 'user-behavior-analytics'
+            entry.id === 'user-behavior-analytics' ||
+            entry.id === 'master-thesis'
               ? `${entry.data.description.trim()} Get in touch on LinkedIn.`
               : entry.data.description,
           datePublished: entry.data.publishDate.toISOString(),


### PR DESCRIPTION
## Summary
- Add `Get in touch on LinkedIn` to the Chalmers master's thesis JSON-LD `CreativeWork.description`, keeping the existing description text.
- Resulting `CreativeWork.description` is exactly `Chalmers master's thesis, 2017. Get in touch on LinkedIn.`
- WebPage.description, other work cases, share meta, titles, visible copy, chat, Biography, hire path, and changelog are unchanged.

## Test plan
- [x] identity tests (`src/__tests__/identity.test.ts`)
- [ ] Johan + Vera PASS

Draft until Johan+Vera PASS.
Do not merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated work page metadata so master’s thesis entries include the appropriate LinkedIn contact information in their descriptions.
  * Improved structured data coverage for master’s thesis work entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->