### PR TITLE
feat: add Product Manager, Developer Experience at IFS to the IFS Design System JSON-LD WebPage name

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -1060,6 +1060,26 @@ describe('identity copy', () => {
     expect(work).not.toContain('mailto:');
   });
 
+  it('lets the IFS Design System JSON-LD WebPage.name read Product Manager, Developer Experience at IFS', () => {
+    const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
+    expect(slug).toContain("'@type': 'WebPage'");
+    expect(slug).toContain(
+      `'@type': 'WebPage',
+          '@id': \`https://me.alehar.workers.dev/work/\${entry.id}/#webpage\`,
+          url: \`https://me.alehar.workers.dev/work/\${entry.id}/\`,
+          name:
+            entry.id === 'ifs-design-system'
+              ? 'IFS Design System | Product Manager, Developer Experience at IFS'
+              : \`\${entry.data.title} | Alexander Härenstam\`,`
+    );
+    expect(slug).toContain("'@type': 'CreativeWork'");
+    expect(slug).toContain(
+      `'@type': 'CreativeWork',
+          name: entry.data.title,`
+    );
+    expect(slug).not.toContain('mailto:');
+  });
+
   it('lets the IFS Design System JSON-LD WebPage.description include Get in touch on LinkedIn', () => {
     const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
     expect(slug).toContain("'@type': 'WebPage'");
@@ -1067,7 +1087,10 @@ describe('identity copy', () => {
       `'@type': 'WebPage',
           '@id': \`https://me.alehar.workers.dev/work/\${entry.id}/#webpage\`,
           url: \`https://me.alehar.workers.dev/work/\${entry.id}/\`,
-          name: \`\${entry.data.title} | Alexander Härenstam\`,
+          name:
+            entry.id === 'ifs-design-system'
+              ? 'IFS Design System | Product Manager, Developer Experience at IFS'
+              : \`\${entry.data.title} | Alexander Härenstam\`,
           description:
             entry.id === 'ifs-design-system' ||
             entry.id === 'ai-coding-copilots' ||
@@ -1086,7 +1109,10 @@ describe('identity copy', () => {
       `'@type': 'WebPage',
           '@id': \`https://me.alehar.workers.dev/work/\${entry.id}/#webpage\`,
           url: \`https://me.alehar.workers.dev/work/\${entry.id}/\`,
-          name: \`\${entry.data.title} | Alexander Härenstam\`,
+          name:
+            entry.id === 'ifs-design-system'
+              ? 'IFS Design System | Product Manager, Developer Experience at IFS'
+              : \`\${entry.data.title} | Alexander Härenstam\`,
           description:
             entry.id === 'ifs-design-system' ||
             entry.id === 'ai-coding-copilots' ||
@@ -1105,7 +1131,10 @@ describe('identity copy', () => {
       `'@type': 'WebPage',
           '@id': \`https://me.alehar.workers.dev/work/\${entry.id}/#webpage\`,
           url: \`https://me.alehar.workers.dev/work/\${entry.id}/\`,
-          name: \`\${entry.data.title} | Alexander Härenstam\`,
+          name:
+            entry.id === 'ifs-design-system'
+              ? 'IFS Design System | Product Manager, Developer Experience at IFS'
+              : \`\${entry.data.title} | Alexander Härenstam\`,
           description:
             entry.id === 'ifs-design-system' ||
             entry.id === 'ai-coding-copilots' ||
@@ -1124,7 +1153,10 @@ describe('identity copy', () => {
       `'@type': 'WebPage',
           '@id': \`https://me.alehar.workers.dev/work/\${entry.id}/#webpage\`,
           url: \`https://me.alehar.workers.dev/work/\${entry.id}/\`,
-          name: \`\${entry.data.title} | Alexander Härenstam\`,
+          name:
+            entry.id === 'ifs-design-system'
+              ? 'IFS Design System | Product Manager, Developer Experience at IFS'
+              : \`\${entry.data.title} | Alexander Härenstam\`,
           description:
             entry.id === 'ifs-design-system' ||
             entry.id === 'ai-coding-copilots' ||

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -48,7 +48,10 @@ const schema = entry
           '@type': 'WebPage',
           '@id': `https://me.alehar.workers.dev/work/${entry.id}/#webpage`,
           url: `https://me.alehar.workers.dev/work/${entry.id}/`,
-          name: `${entry.data.title} | Alexander Härenstam`,
+          name:
+            entry.id === 'ifs-design-system'
+              ? 'IFS Design System | Product Manager, Developer Experience at IFS'
+              : `${entry.data.title} | Alexander Härenstam`,
           description:
             entry.id === 'ifs-design-system' ||
             entry.id === 'ai-coding-copilots' ||


### PR DESCRIPTION
## Summary
- Add `Product Manager, Developer Experience at IFS` to the IFS Design System JSON-LD `WebPage.name` only.
- Resulting `WebPage.name` is exactly `IFS Design System | Product Manager, Developer Experience at IFS`.
- `CreativeWork.name` stays `IFS Design System`. Other work cases keep `${title} | Alexander Härenstam`. Descriptions, titles, share meta, visible copy, chat, Biography, hire path, and changelog are unchanged.

## Test plan
- [x] identity tests (`src/__tests__/identity.test.ts`)
- [ ] Johan + Vera PASS

Draft until Johan+Vera PASS.
Do not merge.