### PR TITLE
feat: add Product Manager, Developer Experience at IFS to the AI coding copilots JSON-LD WebPage name

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -1070,7 +1070,31 @@ describe('identity copy', () => {
           name:
             entry.id === 'ifs-design-system'
               ? 'IFS Design System | Product Manager, Developer Experience at IFS'
-              : \`\${entry.data.title} | Alexander Härenstam\`,`
+              : entry.id === 'ai-coding-copilots'
+                ? 'Internal AI coding copilots | Product Manager, Developer Experience at IFS'
+                : \`\${entry.data.title} | Alexander Härenstam\`,`
+    );
+    expect(slug).toContain("'@type': 'CreativeWork'");
+    expect(slug).toContain(
+      `'@type': 'CreativeWork',
+          name: entry.data.title,`
+    );
+    expect(slug).not.toContain('mailto:');
+  });
+
+  it('lets the AI coding copilots JSON-LD WebPage.name read Product Manager, Developer Experience at IFS', () => {
+    const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
+    expect(slug).toContain("'@type': 'WebPage'");
+    expect(slug).toContain(
+      `'@type': 'WebPage',
+          '@id': \`https://me.alehar.workers.dev/work/\${entry.id}/#webpage\`,
+          url: \`https://me.alehar.workers.dev/work/\${entry.id}/\`,
+          name:
+            entry.id === 'ifs-design-system'
+              ? 'IFS Design System | Product Manager, Developer Experience at IFS'
+              : entry.id === 'ai-coding-copilots'
+                ? 'Internal AI coding copilots | Product Manager, Developer Experience at IFS'
+                : \`\${entry.data.title} | Alexander Härenstam\`,`
     );
     expect(slug).toContain("'@type': 'CreativeWork'");
     expect(slug).toContain(
@@ -1090,7 +1114,9 @@ describe('identity copy', () => {
           name:
             entry.id === 'ifs-design-system'
               ? 'IFS Design System | Product Manager, Developer Experience at IFS'
-              : \`\${entry.data.title} | Alexander Härenstam\`,
+              : entry.id === 'ai-coding-copilots'
+                ? 'Internal AI coding copilots | Product Manager, Developer Experience at IFS'
+                : \`\${entry.data.title} | Alexander Härenstam\`,
           description:
             entry.id === 'ifs-design-system' ||
             entry.id === 'ai-coding-copilots' ||
@@ -1112,7 +1138,9 @@ describe('identity copy', () => {
           name:
             entry.id === 'ifs-design-system'
               ? 'IFS Design System | Product Manager, Developer Experience at IFS'
-              : \`\${entry.data.title} | Alexander Härenstam\`,
+              : entry.id === 'ai-coding-copilots'
+                ? 'Internal AI coding copilots | Product Manager, Developer Experience at IFS'
+                : \`\${entry.data.title} | Alexander Härenstam\`,
           description:
             entry.id === 'ifs-design-system' ||
             entry.id === 'ai-coding-copilots' ||
@@ -1134,7 +1162,9 @@ describe('identity copy', () => {
           name:
             entry.id === 'ifs-design-system'
               ? 'IFS Design System | Product Manager, Developer Experience at IFS'
-              : \`\${entry.data.title} | Alexander Härenstam\`,
+              : entry.id === 'ai-coding-copilots'
+                ? 'Internal AI coding copilots | Product Manager, Developer Experience at IFS'
+                : \`\${entry.data.title} | Alexander Härenstam\`,
           description:
             entry.id === 'ifs-design-system' ||
             entry.id === 'ai-coding-copilots' ||
@@ -1156,7 +1186,9 @@ describe('identity copy', () => {
           name:
             entry.id === 'ifs-design-system'
               ? 'IFS Design System | Product Manager, Developer Experience at IFS'
-              : \`\${entry.data.title} | Alexander Härenstam\`,
+              : entry.id === 'ai-coding-copilots'
+                ? 'Internal AI coding copilots | Product Manager, Developer Experience at IFS'
+                : \`\${entry.data.title} | Alexander Härenstam\`,
           description:
             entry.id === 'ifs-design-system' ||
             entry.id === 'ai-coding-copilots' ||

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -51,7 +51,9 @@ const schema = entry
           name:
             entry.id === 'ifs-design-system'
               ? 'IFS Design System | Product Manager, Developer Experience at IFS'
-              : `${entry.data.title} | Alexander Härenstam`,
+              : entry.id === 'ai-coding-copilots'
+                ? 'Internal AI coding copilots | Product Manager, Developer Experience at IFS'
+                : `${entry.data.title} | Alexander Härenstam`,
           description:
             entry.id === 'ifs-design-system' ||
             entry.id === 'ai-coding-copilots' ||


### PR DESCRIPTION
## Summary
- Add `Product Manager, Developer Experience at IFS` to the AI coding copilots JSON-LD `WebPage.name` only.
- Resulting `WebPage.name` is exactly `Internal AI coding copilots | Product Manager, Developer Experience at IFS`.
- `CreativeWork.name` stays `Internal AI coding copilots`. IFS Design System `WebPage.name` stays `IFS Design System | Product Manager, Developer Experience at IFS`. Other work cases keep `${title} | Alexander Härenstam`. Descriptions, titles, share meta, visible copy, chat, Biography, hire path, and changelog are unchanged.

## Test plan
- [x] identity tests (`src/__tests__/identity.test.ts`)
- [ ] Johan + Vera PASS

Draft until Johan+Vera PASS.
Do not merge.