### PR TITLE
feat: denser frost overlay on the open mobile menu

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -739,6 +739,29 @@ describe('identity copy', () => {
     expect(nav).toContain("{ label: 'Work', href: '/work/' }");
   });
 
+  it('lets the open mobile menu sheet use a denser 0.90 frost overlay', () => {
+    const nav = readFileSync('src/components/Nav.astro', 'utf8');
+    expect(nav).toContain('#menu-content:not([hidden]) .nav-items');
+    expect(nav).toContain('#menu-content:not([hidden]) .menu-footer');
+    expect(nav).toContain('hsla(var(--gray-999-basis), 0.9)');
+    expect(nav).toContain('backdrop-filter: blur(40px) saturate(140%)');
+    expect(nav).toContain('-webkit-backdrop-filter: blur(40px) saturate(140%)');
+    expect(nav).toContain('hsla(0, 0%, 0%, 0.18)');
+    expect(nav).toContain('hsla(0, 0%, 100%, 0.14)');
+    expect(nav).toContain('linear-gradient(180deg, hsla(0, 0%, 100%, 0.35), transparent 12px)');
+    expect(nav).toContain('linear-gradient(180deg, hsla(0, 0%, 100%, 0.12), transparent 12px)');
+    expect(nav).toContain(".menu-button[aria-expanded='true']");
+    expect(nav).toContain('prefers-reduced-transparency: reduce');
+    expect(nav).toContain('background: hsl(var(--gray-999-basis))');
+    expect(nav).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(nav).not.toContain('hsla(var(--gray-999-basis), 1.0)');
+    expect(nav).not.toContain('hsla(var(--gray-999-basis), 1)');
+    expect(nav).toContain('background: hsla(var(--gray-999-basis), 0.6)');
+    expect(nav).toContain('backdrop-filter: blur(24px) saturate(150%)');
+    expect(nav).toContain('background: hsla(var(--gray-999-basis), 0.7)');
+    expect(nav).not.toContain('hsla(var(--gray-999-basis), 0.85)');
+  });
+
   it('uses honest Earlier work labels, not Platform or copilots-as-product', () => {
     const copilots = readFileSync('src/content/work/ai-coding-copilots.md', 'utf8');
     const analytics = readFileSync('src/content/work/user-behavior-analytics.md', 'utf8');

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -741,13 +741,18 @@ describe('identity copy', () => {
 
   it('lets the open mobile menu sheet use a denser 0.90 frost overlay', () => {
     const nav = readFileSync('src/components/Nav.astro', 'utf8');
+    const openSheet = nav.slice(nav.indexOf('@media not (min-width: 50em)'));
     expect(nav).toContain('#menu-content:not([hidden]) .nav-items');
     expect(nav).toContain('#menu-content:not([hidden]) .menu-footer');
     expect(nav).toContain('hsla(var(--gray-999-basis), 0.9)');
     expect(nav).toContain('backdrop-filter: blur(40px) saturate(140%)');
     expect(nav).toContain('-webkit-backdrop-filter: blur(40px) saturate(140%)');
+    expect(openSheet.indexOf('-webkit-backdrop-filter: blur(40px) saturate(140%)')).toBeLessThan(
+      openSheet.indexOf('\n      backdrop-filter: blur(40px) saturate(140%)')
+    );
     expect(nav).toContain('hsla(0, 0%, 0%, 0.18)');
     expect(nav).toContain('hsla(0, 0%, 100%, 0.14)');
+    expect(openSheet).toContain('border-width: 0 1px 1px');
     expect(nav).toContain('linear-gradient(180deg, hsla(0, 0%, 100%, 0.35), transparent 12px)');
     expect(nav).toContain('linear-gradient(180deg, hsla(0, 0%, 100%, 0.12), transparent 12px)');
     expect(nav).toContain(".menu-button[aria-expanded='true']");

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -352,18 +352,19 @@ const isCurrentPage = (href: string) => {
     #menu-content:not([hidden]) .nav-items {
       background-color: hsla(var(--gray-999-basis), 0.9);
       background-image: linear-gradient(180deg, hsla(0, 0%, 100%, 0.35), transparent 12px);
-      backdrop-filter: blur(40px) saturate(140%);
       -webkit-backdrop-filter: blur(40px) saturate(140%);
+      backdrop-filter: blur(40px) saturate(140%);
       border: 1px solid hsla(0, 0%, 0%, 0.18);
       border-bottom: 0;
     }
 
     #menu-content:not([hidden]) .menu-footer {
       background: hsla(var(--gray-999-basis), 0.9);
-      backdrop-filter: blur(40px) saturate(140%);
       -webkit-backdrop-filter: blur(40px) saturate(140%);
-      border: 1px solid hsla(0, 0%, 0%, 0.18);
-      border-top: 0;
+      backdrop-filter: blur(40px) saturate(140%);
+      border-color: hsla(0, 0%, 0%, 0.18);
+      border-style: solid;
+      border-width: 0 1px 1px;
       box-shadow: none;
     }
 
@@ -387,8 +388,8 @@ const isCurrentPage = (href: string) => {
     @media (prefers-reduced-transparency: reduce), (forced-colors: active) {
       #menu-content:not([hidden]) .nav-items,
       #menu-content:not([hidden]) .menu-footer {
-        backdrop-filter: none;
         -webkit-backdrop-filter: none;
+        backdrop-filter: none;
         background: hsl(var(--gray-999-basis));
       }
     }

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -276,7 +276,7 @@ const isCurrentPage = (href: string) => {
 
   .menu-button[aria-expanded='true'] {
     color: var(--gray-0);
-    background: hsla(var(--gray-999-basis), 0.85);
+    background: hsla(var(--gray-999-basis), 0.9);
   }
 
   .menu-button[hidden] {
@@ -346,6 +346,52 @@ const isCurrentPage = (href: string) => {
     -webkit-backdrop-filter: blur(24px);
     border-radius: 0 0 0.75rem 0.75rem;
     box-shadow: var(--shadow-lg);
+  }
+
+  @media not (min-width: 50em) {
+    #menu-content:not([hidden]) .nav-items {
+      background-color: hsla(var(--gray-999-basis), 0.9);
+      background-image: linear-gradient(180deg, hsla(0, 0%, 100%, 0.35), transparent 12px);
+      backdrop-filter: blur(40px) saturate(140%);
+      -webkit-backdrop-filter: blur(40px) saturate(140%);
+      border: 1px solid hsla(0, 0%, 0%, 0.18);
+      border-bottom: 0;
+    }
+
+    #menu-content:not([hidden]) .menu-footer {
+      background: hsla(var(--gray-999-basis), 0.9);
+      backdrop-filter: blur(40px) saturate(140%);
+      -webkit-backdrop-filter: blur(40px) saturate(140%);
+      border: 1px solid hsla(0, 0%, 0%, 0.18);
+      border-top: 0;
+      box-shadow: none;
+    }
+
+    :global(.theme-dark) #menu-content:not([hidden]) .nav-items {
+      background-image: linear-gradient(180deg, hsla(0, 0%, 100%, 0.12), transparent 12px);
+      border-color: hsla(0, 0%, 100%, 0.14);
+    }
+
+    :global(.theme-dark) #menu-content:not([hidden]) .menu-footer {
+      border-color: hsla(0, 0%, 100%, 0.14);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      #menu-content:not([hidden]) .nav-items,
+      #menu-content:not([hidden]) .menu-footer {
+        transition: none;
+        animation: none;
+      }
+    }
+
+    @media (prefers-reduced-transparency: reduce), (forced-colors: active) {
+      #menu-content:not([hidden]) .nav-items,
+      #menu-content:not([hidden]) .menu-footer {
+        backdrop-filter: none;
+        -webkit-backdrop-filter: none;
+        background: hsl(var(--gray-999-basis));
+      }
+    }
   }
 
   .socials {


### PR DESCRIPTION
## Summary
- Open mobile sheet (`#menu-content:not([hidden]) .nav-items` and matching `.menu-footer`) uses denser frost: fill `0.90`, `blur(40px) saturate(140%)`, darkened-edge hairline, thin top specular. Not fully opaque.
- Expanded hamburger fill matches the sheet at `0.90`. `prefers-reduced-transparency` / `forced-colors` drop `backdrop-filter` for a solid bar. Reduced-motion: no overlay filter animation.
- Desktop pill nav (`>=50em`) is unchanged. No second full-viewport scrim. Chat, hire path, JSON-LD, changelog, and #597 are untouched.

## Test plan
- [x] identity tests (`src/__tests__/identity.test.ts`)
- [ ] Johan + Vera PASS

Draft until Johan+Vera PASS.
Do not merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the appearance of the expanded mobile navigation menu with clearer contrast, refined translucency, blur, borders, and theme-aware styling.
  * Added accessibility-friendly fallbacks for reduced transparency, forced colors, and reduced motion settings.
  * Increased visibility of the expanded menu button background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->