### PR TITLE
feat: open the twin as a bottom sheet with bubbles

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -288,7 +288,7 @@ describe('identity copy', () => {
   it('shows a Live / Not live signal on the chat header', () => {
     const chat = readFileSync('src/components/Chat.astro', 'utf8');
     expect(chat).toContain('chat-live-label');
-    expect(chat).toContain('class="status-dot"');
+    expect(chat).not.toContain('status-dot');
     expect(chat).toContain("idle: 'Live'");
     expect(chat).toContain("error: 'Not live'");
     expect(chat).not.toContain("idle: 'Available'");
@@ -446,11 +446,14 @@ describe('identity copy', () => {
     expect(home).toContain('https://www.linkedin.com/in/alehar/');
     expect(home).toContain('Get in touch');
     expect(home).not.toContain('mailto:');
-    expect(chat).toContain('chat-welcome-portrait');
+    expect(chat).toContain('chat-header-avatar');
     expect(chat).toContain('/assets/portrait.png');
-    expect(chat).toContain(
-      'alt="Alexander Härenstam smiling in a red plaid shirt and tortoise shell glasses"'
-    );
+    expect(chat).toContain('class="chat-header-avatar"');
+    expect(chat).toContain('width="40"');
+    expect(chat).toContain('height="40"');
+    expect(chat).toContain('alt=""');
+    expect(chat).not.toContain('chat-welcome-portrait');
+    expect(chat).not.toContain('message-avatar');
     expect(chat).not.toContain('chat-toggle-portrait');
     expect(chat).not.toContain('mailto:');
   });
@@ -458,11 +461,14 @@ describe('identity copy', () => {
   it('makes the twin the first-view chat with a headshot, follow-ups, and a docked FAB', () => {
     const chat = readFileSync('src/components/Chat.astro', 'utf8');
     const home = readFileSync('src/pages/index.astro', 'utf8');
-    expect(chat).toContain('chat-welcome-portrait');
+    expect(chat).not.toContain('chat-welcome-portrait');
     expect(chat).toContain('/assets/portrait.png');
-    expect(chat).toContain('class="chat-header-avatar" width="64" height="64"');
+    expect(chat).toContain('class="chat-header-avatar"');
+    expect(chat).toContain('width="40"');
+    expect(chat).toContain('height="40"');
     expect(chat).toContain('chat-followups');
     expect(chat).toContain('showFollowUps');
+    expect(chat).toContain('How do I get in touch on LinkedIn?');
     expect(chat).toContain('is-prominent');
     expect(chat).toContain('is-docked');
     expect(chat).toContain('dockChat');
@@ -475,15 +481,74 @@ describe('identity copy', () => {
     expect(home).toContain('Hero title="Product Manager, Developer Experience at IFS"');
     expect(home).not.toContain('mailto:');
     expect(chat).toContain('has-prominent-chat');
-    expect(chat).toContain('min(32rem, calc(50vw - 2rem))');
-    expect(chat).toContain('--prominent-phone-top');
-    expect(chat).toContain('layoutProminentPhone');
-    expect(chat).toContain('cta-hint');
+    expect(chat).toContain('border-radius: 1rem 1rem 0 0');
+    expect(chat).toContain('max-width: 36rem');
+    expect(chat).toContain('height: 62dvh');
+    expect(chat).toContain('translateY(100%)');
+    expect(chat).not.toContain('min(32rem, calc(50vw - 2rem))');
+    expect(chat).not.toContain('top: 5.5rem');
+    expect(chat).not.toContain('50vw');
+    expect(chat).not.toContain('--prominent-phone-top');
+    expect(chat).not.toContain('layoutProminentPhone');
+    expect(home).toContain('cta-hint');
     expect(home).toContain('Get in touch');
     expect(home).toContain('LinkedIn · replies from me');
     expect(home).toContain('body.has-prominent-chat');
+    expect(home).toContain('padding-bottom: 62dvh');
+    expect(home).not.toContain('padding-right: min(34rem, 48vw)');
     expect(home).toContain('proof-card');
     expect(home).toContain('Hero title="Product Manager, Developer Experience at IFS"');
+  });
+
+  it('opens the twin as a bottom sheet with bubbles and one header portrait', () => {
+    const chat = readFileSync('src/components/Chat.astro', 'utf8');
+    const home = readFileSync('src/pages/index.astro', 'utf8');
+    const nav = readFileSync('src/components/Nav.astro', 'utf8');
+    expect(chat).toContain('border-radius: 1rem 1rem 0 0');
+    expect(chat).toContain('max-width: 36rem');
+    expect(chat).toContain('height: 62dvh');
+    expect(chat).toContain('min-height: 55dvh');
+    expect(chat).toContain('max-height: 70dvh');
+    expect(chat).toContain('translateY(100%)');
+    expect(chat).toContain('translateY(0)');
+    expect(chat).toContain('220ms');
+    expect(chat).toContain('hsla(0, 0%, 0%, 0.28)');
+    expect(chat).toContain('id="chat-scrim"');
+    expect(chat).not.toContain('min(32rem, calc(50vw - 2rem))');
+    expect(chat).not.toContain('top: 5.5rem');
+    expect(chat).not.toContain('50vw');
+    expect(chat).toContain('padding: 0.75rem 1rem');
+    expect(chat).toContain('border-radius: 1rem 1rem 4px 1rem');
+    expect(chat).toContain('border-radius: 1rem 1rem 1rem 4px');
+    expect(chat).toContain('max-width: 80%');
+    expect(chat).toContain('gap: 0.5rem');
+    expect(chat).toContain('.chat-header {\n    padding: 1rem;');
+    expect(chat).toContain('.chat-form {\n    padding: 1rem;');
+    expect(chat).not.toContain('padding: 0.5rem 1rem 1rem');
+    expect(chat).toContain('min-height: 44px');
+    expect(chat).toContain('border-radius: 0.75rem');
+    expect(chat).toContain('width: 2.5rem');
+    expect(chat).toContain('chat-header-avatar');
+    expect(chat).not.toContain('chat-welcome-portrait');
+    expect(chat).not.toContain('message-avatar');
+    expect(chat).not.toContain('chat-toggle-portrait');
+    expect(chat).not.toContain('status-dot');
+    expect(chat).toContain('id="chat-clear"');
+    expect(chat).toContain('chat-followups');
+    expect(chat).toContain('How do I get in touch on LinkedIn?');
+    expect(chat).toContain('What did the IFS design system change?');
+    expect(chat).toContain("I'm an AI with his context.");
+    expect(chat).not.toContain('Ask about the work');
+    expect(chat).toContain('prefers-reduced-motion: reduce');
+    expect(chat).toContain('transform: none');
+    expect(nav).toContain('hsla(var(--gray-999-basis), 0.9)');
+    expect(nav).toContain('backdrop-filter: blur(40px) saturate(140%)');
+    expect(home).toContain('https://www.linkedin.com/in/alehar/');
+    expect(home).toContain('Get in touch');
+    expect(home).toContain('Hero title="Product Manager, Developer Experience at IFS"');
+    expect(home).not.toContain('mailto:');
+    expect(chat).not.toContain('mailto:');
+    expect(chat).not.toContain('data-hire-surface');
   });
 
   it('keeps the chat FAB off the 2x/30x/Zeroheight proof on the design system case on a phone', () => {

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -28,59 +28,63 @@
     <span role="tooltip" id="status-tooltip" class="status-tooltip"></span>
   </button>
 
+  <button type="button" id="chat-scrim" class="chat-scrim" hidden aria-label="Dismiss chat"
+  ></button>
+
   <div id="chat-window" class="chat-window hidden">
     <div class="chat-header">
-      <div class="chat-header-profile">
-        <img src="/assets/portrait.png" alt="" class="chat-header-avatar" width="64" height="64" />
-        <span class="chat-header-copy">
-          <span class="chat-header-name"></span>
-          <span class="chat-live" id="chat-live">
-            <span class="status-dot" aria-hidden="true"></span>
-            <span class="chat-live-label" id="chat-live-label">Live</span>
+      <div class="chat-grab" aria-hidden="true"></div>
+      <div class="chat-header-bar">
+        <div class="chat-header-profile">
+          <img
+            src="/assets/portrait.png"
+            alt=""
+            class="chat-header-avatar"
+            width="40"
+            height="40"
+          />
+          <span class="chat-header-copy">
+            <span class="chat-header-name"></span>
+            <span class="chat-live" id="chat-live">
+              <span class="chat-live-label" id="chat-live-label">Live</span>
+            </span>
           </span>
-        </span>
-      </div>
-      <div class="chat-header-actions">
-        <button type="button" id="chat-clear" class="chat-clear" aria-label="Clear conversation">
-          Clear
-        </button>
-        <button id="chat-close" class="chat-close" aria-label="Close chat">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg
-          >
-        </button>
+        </div>
+        <div class="chat-header-actions">
+          <button type="button" id="chat-clear" class="chat-clear" aria-label="Clear conversation">
+            Clear
+          </button>
+          <button id="chat-close" class="chat-close" aria-label="Close chat">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"><path d="M18 6 6 18"></path><path d="m6 6 12 12"></path></svg
+            >
+          </button>
+        </div>
       </div>
     </div>
     <div id="status-announcer" class="sr-only" aria-live="polite" role="status"></div>
     <div id="chat-messages" class="chat-messages" aria-live="polite">
       <section class="message assistant-message welcome-message" aria-label="About this chat">
-        <img
-          src="/assets/portrait.png"
-          alt="Alexander Härenstam smiling in a red plaid shirt and tortoise shell glasses"
-          class="chat-welcome-portrait"
-          width="96"
-          height="96"
-        />
         <h2>Alexander's digital twin</h2>
         <p>
           DevEx, Industrial AI, or background. I'm an AI with his context. I can get things wrong.
         </p>
-        <div id="chat-suggestions" class="chat-suggestions">
-          <button type="button" class="chat-suggestion">
-            What did the IFS design system change?
-          </button>
-          <button type="button" class="chat-suggestion">How do you work as a PM?</button>
-          <button type="button" class="chat-suggestion">What's the Industrial AI bet?</button>
-        </div>
       </section>
+      <div id="chat-suggestions" class="chat-suggestions">
+        <button type="button" class="chat-suggestion">
+          What did the IFS design system change?
+        </button>
+        <button type="button" class="chat-suggestion">How do you work as a PM?</button>
+        <button type="button" class="chat-suggestion">What's the Industrial AI bet?</button>
+      </div>
     </div>
     <div id="typing-indicator" class="typing-indicator hidden">Alexander is typing...</div>
     <p id="chat-remaining" class="chat-remaining" aria-live="polite" hidden></p>
@@ -113,6 +117,15 @@
     font-family: var(--font-body);
   }
 
+  .chat-container.is-open,
+  .chat-container.is-prominent {
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-end;
+  }
+
   .chat-toggle {
     position: relative;
     width: var(--chat-fab-size);
@@ -143,8 +156,25 @@
     outline-offset: 4px;
   }
 
-  .chat-container.is-prominent .chat-toggle {
+  .chat-container.is-prominent .chat-toggle,
+  .chat-container.is-open .chat-toggle {
     display: none;
+  }
+
+  .chat-scrim {
+    display: none;
+    position: absolute;
+    inset: 0;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    background: hsla(0, 0%, 0%, 0.28);
+    cursor: pointer;
+  }
+
+  .chat-container.is-open .chat-scrim,
+  .chat-container.is-prominent .chat-scrim {
+    display: block;
   }
 
   /* Tooltip */
@@ -171,6 +201,21 @@
   }
 
   /* Header layout */
+  .chat-header-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+  }
+
+  .chat-grab {
+    width: 2.5rem;
+    height: 0.25rem;
+    border-radius: 999px;
+    background: var(--gray-600);
+    margin: 0 auto 0.75rem;
+  }
+
   .chat-header-profile {
     display: flex;
     align-items: center;
@@ -178,8 +223,8 @@
   }
 
   .chat-header-avatar {
-    width: 4rem;
-    height: 4rem;
+    width: 2.5rem;
+    height: 2.5rem;
     border-radius: 50%;
     object-fit: cover;
     object-position: top;
@@ -209,51 +254,12 @@
     line-height: 1;
   }
 
-  .status-dot {
-    display: inline-block;
-    width: 0.5rem;
-    height: 0.5rem;
-    border-radius: 50%;
-    flex-shrink: 0;
-    background-color: var(--status-idle);
-    box-shadow: 0 0 6px var(--status-idle);
-    transition:
-      background-color 0.3s ease,
-      box-shadow 0.3s ease;
-  }
-
-  .status-dot.loading {
-    background-color: var(--status-loading);
-    box-shadow: 0 0 6px var(--status-loading);
-    animation: status-pulse 1.2s ease-in-out infinite;
-  }
-
-  .status-dot.error {
-    background-color: var(--status-error);
-    box-shadow: 0 0 6px var(--status-error);
-  }
-
-  @keyframes status-pulse {
-    0%,
-    100% {
-      opacity: 1;
-    }
-    50% {
-      opacity: 0.4;
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .status-dot.loading {
-      animation: none;
-    }
-  }
-
   .chat-suggestions {
     display: flex;
     flex-direction: column;
     gap: 0.375rem;
-    margin-top: 0.75rem;
+    margin-top: 0.25rem;
+    align-self: stretch;
   }
 
   .chat-suggestions.hidden {
@@ -291,57 +297,52 @@
   }
 
   .chat-window {
-    position: absolute;
-    bottom: 4.5rem;
-    right: 0;
-    width: 20rem;
-    height: 30rem;
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    max-width: 36rem;
+    height: 62dvh;
+    min-height: 55dvh;
+    max-height: 70dvh;
     background-color: hsla(var(--gray-999-basis), 0.7);
     border: 1px solid var(--gray-800);
-    border-radius: 1rem;
+    border-bottom: 0;
+    border-radius: 1rem 1rem 0 0;
     box-shadow: var(--shadow-lg);
     display: flex;
     flex-direction: column;
     overflow: hidden;
     backdrop-filter: blur(16px) saturate(180%);
-  }
-
-  .chat-container.is-prominent {
-    top: 5.5rem;
-    right: var(--chat-fab-offset);
-    bottom: var(--chat-fab-offset);
-    left: auto;
-  }
-
-  .chat-container.is-prominent .chat-window {
-    bottom: 0;
-    width: min(32rem, calc(50vw - 2rem));
-    height: calc(100dvh - 7rem);
-    max-height: calc(100dvh - 7rem);
+    transform: translateY(0);
   }
 
   @media (max-width: 49.99em) {
-    .chat-container.is-prominent {
-      top: var(--prominent-phone-top, 52dvh);
-      bottom: var(--chat-fab-offset);
-      right: var(--chat-fab-offset);
-      left: var(--chat-fab-offset);
-    }
-
-    .chat-container.is-prominent .chat-window {
+    .chat-window {
       width: 100%;
-      height: 100%;
-      max-height: none;
-      bottom: 0;
+      max-width: none;
     }
   }
 
   @media (prefers-reduced-motion: no-preference) {
+    .chat-container.is-open .chat-window:not(.hidden),
+    .chat-container.is-prominent .chat-window:not(.hidden) {
+      animation: chat-sheet-in 220ms ease;
+    }
+  }
+
+  @keyframes chat-sheet-in {
+    from {
+      transform: translateY(100%);
+    }
+    to {
+      transform: translateY(0);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
     .chat-window {
-      transition:
-        width 0.25s ease,
-        height 0.25s ease,
-        bottom 0.25s ease;
+      animation: none;
+      transform: none;
     }
   }
 
@@ -354,8 +355,7 @@
     background-color: var(--gray-900);
     color: var(--gray-0);
     display: flex;
-    justify-content: space-between;
-    align-items: center;
+    flex-direction: column;
     border-bottom: 1px solid var(--gray-800);
   }
 
@@ -397,13 +397,19 @@
     overflow-y: auto;
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.5rem;
+  }
+
+  .user-message + .assistant-message,
+  .assistant-message + .user-message,
+  .user-message + .ai-message,
+  .ai-message + .user-message {
+    margin-top: 0.25rem;
   }
 
   .message {
-    max-width: 85%;
-    padding: 0.5rem 0.75rem;
-    border-radius: 0.5rem;
+    max-width: 80%;
+    padding: 0.75rem 1rem;
     font-size: 0.875rem;
     line-height: 1.4;
   }
@@ -412,47 +418,19 @@
     align-self: flex-end;
     background-color: var(--accent-regular);
     color: white;
+    border-radius: 1rem 1rem 4px 1rem;
   }
 
-  .ai-message {
-    align-self: flex-start;
-    background-color: var(--gray-800);
-    color: var(--gray-100);
-  }
-
+  .ai-message,
   .assistant-message {
     align-self: flex-start;
     background-color: var(--gray-800);
     color: var(--gray-100);
-    display: flex;
-    align-items: flex-start;
-    gap: 0.5rem;
-  }
-
-  .message-avatar {
-    width: 40px;
-    height: 40px;
-    border-radius: 50%;
-    object-fit: cover;
-    object-position: top;
-    flex-shrink: 0;
+    border-radius: 1rem 1rem 1rem 4px;
   }
 
   .welcome-message {
-    max-width: 90%;
-    flex-direction: column;
-    gap: 0;
-  }
-
-  .chat-welcome-portrait {
-    width: 6rem;
-    height: 6rem;
-    border-radius: 50%;
-    object-fit: cover;
-    object-position: top;
-    flex-shrink: 0;
-    margin-bottom: 0.75rem;
-    border: 1px solid var(--gray-700);
+    max-width: 80%;
   }
 
   .welcome-message h2 {
@@ -465,7 +443,7 @@
 
   .welcome-message p {
     margin: 0;
-    color: var(--gray-200);
+    color: var(--gray-100);
   }
 
   .typing-indicator {
@@ -488,16 +466,17 @@
   }
 
   .chat-form {
-    padding: 0.5rem 1rem 1rem;
+    padding: 1rem;
     display: flex;
     gap: 0.5rem;
   }
 
   .chat-form input {
     flex: 1;
-    padding: 0.5rem;
+    min-height: 44px;
+    padding: 0.5rem 1rem;
     border: 1px solid var(--gray-800);
-    border-radius: 0.25rem;
+    border-radius: 0.75rem;
     background: var(--gray-900);
     color: var(--gray-0);
   }
@@ -506,19 +485,13 @@
     background-color: var(--accent-regular);
     color: white;
     border: none;
-    border-radius: 0.25rem;
+    border-radius: 0.75rem;
     padding: 0.5rem;
+    min-width: 44px;
     cursor: pointer;
     display: flex;
     align-items: center;
     justify-content: center;
-  }
-
-  @media (max-width: 400px) {
-    .chat-window {
-      width: calc(100vw - 4rem);
-      height: 70vh;
-    }
   }
 </style>
 
@@ -540,8 +513,8 @@
 
   const statusTooltip = document.getElementById('status-tooltip');
   const statusAnnouncer = document.getElementById('status-announcer');
-  const statusDot = document.querySelector('.status-dot');
   const liveLabel = document.getElementById('chat-live-label');
+  const chatScrim = document.getElementById('chat-scrim');
 
   const FOLD_DISMISSED_KEY = 'chat-fold-dismissed';
   const FOLLOW_UP_PROMPTS = [
@@ -574,10 +547,6 @@
     if (statusTooltip) statusTooltip.textContent = tooltipLabels[state];
     if (statusAnnouncer) statusAnnouncer.textContent = statusLabels[state];
     if (liveLabel) liveLabel.textContent = liveLabels[state];
-    if (statusDot) {
-      statusDot.classList.remove('idle', 'loading', 'error', 'limited');
-      statusDot.classList.add(state);
-    }
   }
 
   function applyRemaining(response: Response) {
@@ -675,28 +644,11 @@
   function appendMessage(role: string, content: string) {
     const messageDiv = document.createElement('div');
     messageDiv.className = `message ${role}-message`;
-
-    let textTarget: HTMLElement = messageDiv;
-
-    if (role === 'assistant') {
-      const avatar = document.createElement('img');
-      avatar.className = 'message-avatar';
-      avatar.src = '/assets/portrait.png';
-      avatar.alt = '';
-      avatar.width = 40;
-      avatar.height = 40;
-      const text = document.createElement('span');
-      text.className = 'message-text';
-      text.textContent = content;
-      messageDiv.append(avatar, text);
-      textTarget = text;
-    } else {
-      messageDiv.textContent = content;
-    }
+    messageDiv.textContent = content;
 
     chatMessages?.appendChild(messageDiv);
     chatMessages?.scrollTo(0, chatMessages.scrollHeight);
-    return textTarget;
+    return messageDiv;
   }
 
   // Load history
@@ -715,6 +667,8 @@
   const setChatExpanded = (expand: boolean) => {
     chatToggle?.setAttribute('aria-expanded', String(expand));
     chatWindow?.classList.toggle('hidden', !expand);
+    chatContainer?.classList.toggle('is-open', expand);
+    if (chatScrim) chatScrim.hidden = !expand;
     if (expand) {
       chatInput?.focus();
       setStatus('idle');
@@ -727,30 +681,10 @@
     return path === '/' || path === '' || path === '/index';
   }
 
-  function layoutProminentPhone() {
-    if (!chatContainer?.classList.contains('is-prominent')) {
-      chatContainer?.style.removeProperty('--prominent-phone-top');
-      return;
-    }
-    if (window.matchMedia('(min-width: 50em)').matches) {
-      chatContainer.style.removeProperty('--prominent-phone-top');
-      return;
-    }
-    const hire = document.querySelector('.cta-hint') || document.querySelector('.hero-actions');
-    if (!(hire instanceof HTMLElement)) return;
-    const gap = 12;
-    const minTwin = 10 * 16; // keep a usable twin
-    const bottomLimit = window.innerHeight - 8;
-    const belowHire = Math.ceil(hire.getBoundingClientRect().bottom + gap);
-    const top = Math.min(belowHire, bottomLimit - minTwin);
-    chatContainer.style.setProperty('--prominent-phone-top', `${Math.max(top, 0)}px`);
-  }
-
   function dockChat() {
     chatContainer?.classList.remove('is-prominent');
     chatContainer?.classList.add('is-docked');
     document.body.classList.remove('has-prominent-chat');
-    chatContainer?.style.removeProperty('--prominent-phone-top');
     setChatExpanded(false);
     sessionStorage.setItem(FOLD_DISMISSED_KEY, '1');
   }
@@ -781,9 +715,6 @@
     chatContainer.classList.add('is-prominent');
     setChatExpanded(true);
     document.body.classList.add('has-prominent-chat');
-    layoutProminentPhone();
-    requestAnimationFrame(layoutProminentPhone);
-    window.addEventListener('resize', layoutProminentPhone);
     window.addEventListener(
       'scroll',
       () => {
@@ -807,6 +738,10 @@
   });
 
   chatClose?.addEventListener('click', () => {
+    dismissProminentChat();
+  });
+
+  chatScrim?.addEventListener('click', () => {
     dismissProminentChat();
   });
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -235,15 +235,13 @@ const schema = {
     }
   }
 
-  @media (min-width: 50em) {
-    :global(body.has-prominent-chat) .first-screen {
-      padding-right: min(34rem, 48vw);
-    }
+  :global(body.has-prominent-chat) .first-screen {
+    padding-bottom: 62dvh;
+    justify-content: flex-start;
   }
 
   @media (max-width: 49.99em) {
     :global(body.has-prominent-chat) .first-screen {
-      padding-bottom: var(--chat-fab-offset);
       gap: 0.75rem;
     }
     :global(body.has-prominent-chat) .hero-copy {


### PR DESCRIPTION
## Summary
- Open chat is a bottom sheet from the bottom edge (full width on phone `< 50em`, max-width 36rem centered on desktop, height 62dvh). Not a right column, not a `50vw` side panel. Light scrim; tap scrim or Close dismisses to docked/closed. Motion is `translateY(100%)` → `0` in 220ms; `prefers-reduced-motion: reduce` is instant with no translate.
- User/assistant messages are bubbles (asymmetric radius, `0.75rem 1rem` pad, ~80% max-width). Welcome is the first assistant bubble with the live honest twin line. Starter chips stay under it. Existing post-reply follow-ups stay (three starters plus `How do I get in touch on LinkedIn?`).
- One portrait in the open sheet: `.chat-header-avatar` ~2.5rem. No welcome portrait, no message avatars, no FAB portrait, no `.status-dot`. Header / transcript / composer share 1rem inset. Composer input radius 0.75rem, min-height 44px. Home first view still auto-opens the twin; H1 + Get in touch stay. Overlay/Nav and #597 are untouched.

## Test plan
- [x] `npx vitest run src/__tests__/identity.test.ts`
- [x] `npx vitest run`
- [ ] Confirm `/` first view: H1 + Get in touch + open bottom sheet, no second hero face
- [ ] Confirm open chat is a bottom sheet, not a right column
- [ ] Confirm bubbles (asymmetric radius, 0.75rem 1rem pad) and no per-message portrait
- [ ] Confirm one header portrait, no welcome/FAB/message faces, no green status-dot
- [ ] Confirm Clear, starter chips, and post-reply follow-ups still appear
- [ ] Confirm welcome still starts with `DevEx, Industrial AI, or background.`
- [ ] Confirm LinkedIn hire still points at https://www.linkedin.com/in/alehar/
- [ ] Confirm desktop pill nav and mobile menu overlay unchanged
- [ ] Confirm `prefers-reduced-motion: reduce` does not slide the sheet
- [ ] Stay draft until Johan+Vera PASS a freeze SHA

Draft until Johan+Vera PASS.
Do not merge.
Stay off #597.