### PR TITLE
feat: dock the twin to a compact bottom bar on scroll

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -567,6 +567,9 @@ describe('identity copy', () => {
     expect(chat).toContain('if (window.scrollY > 160) dockChat()');
     expect(chat).toContain("chatDock?.addEventListener('click'");
     expect(chat).toContain('setChatExpanded(true)');
+    expect(chat).toContain('prefers-reduced-motion: reduce');
+    expect(chat).toContain('transition: none');
+    expect(chat).toContain('.chat-dock {');
     expect(dockHtml).not.toContain('portrait.png');
     expect(dockHtml).not.toContain('chat-header-avatar');
     expect(dockHtml).not.toContain('<img');

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -551,6 +551,57 @@ describe('identity copy', () => {
     expect(chat).not.toContain('data-hire-surface');
   });
 
+  it('docks the open sheet to a compact bottom bar on scroll, not a FAB or right column', () => {
+    const chat = readFileSync('src/components/Chat.astro', 'utf8');
+    const home = readFileSync('src/pages/index.astro', 'utf8');
+    const nav = readFileSync('src/components/Nav.astro', 'utf8');
+    const dockHtml = chat.slice(chat.indexOf('id="chat-dock"'), chat.indexOf('id="chat-scrim"'));
+    expect(chat).toContain('id="chat-dock"');
+    expect(chat).toContain('class="chat-dock"');
+    expect(chat).toContain('chat-dock-handle');
+    expect(chat).toContain('min-height: 3.25rem');
+    expect(chat).toContain('.chat-container.is-docked .chat-toggle');
+    expect(chat).toContain('.chat-container.is-docked:not(.is-open):not(.is-prominent) .chat-dock');
+    expect(chat).toContain("chatContainer?.classList.add('is-docked')");
+    expect(chat).toContain('setChatExpanded(false)');
+    expect(chat).toContain('if (window.scrollY > 160) dockChat()');
+    expect(chat).toContain("chatDock?.addEventListener('click'");
+    expect(chat).toContain('setChatExpanded(true)');
+    expect(dockHtml).not.toContain('portrait.png');
+    expect(dockHtml).not.toContain('chat-header-avatar');
+    expect(dockHtml).not.toContain('<img');
+    expect(chat).not.toContain('chat-toggle-portrait');
+    expect(chat).not.toContain('min(32rem, calc(50vw - 2rem))');
+    expect(chat).not.toContain('top: 5.5rem');
+    expect(chat).not.toContain('50vw');
+    expect(chat).not.toContain('--prominent-phone-top');
+    expect(chat).not.toContain('layoutProminentPhone');
+    expect(chat).toContain('border-radius: 1rem 1rem 0 0');
+    expect(chat).toContain('max-width: 36rem');
+    expect(chat).toContain('height: 62dvh');
+    expect(chat).toContain('min-height: 55dvh');
+    expect(chat).toContain('max-height: 70dvh');
+    expect(chat).toContain('hsla(0, 0%, 0%, 0.28)');
+    expect(chat).toContain('padding: 0.75rem 1rem');
+    expect(chat).toContain('chat-header-avatar');
+    expect(chat).not.toContain('chat-welcome-portrait');
+    expect(chat).not.toContain('message-avatar');
+    expect(chat).not.toContain('status-dot');
+    expect(chat).toContain('id="chat-clear"');
+    expect(chat).toContain('chat-followups');
+    expect(chat).toContain('How do I get in touch on LinkedIn?');
+    expect(chat).toContain('What did the IFS design system change?');
+    expect(chat).toContain("I'm an AI with his context.");
+    expect(nav).toContain('hsla(var(--gray-999-basis), 0.9)');
+    expect(nav).toContain('backdrop-filter: blur(40px) saturate(140%)');
+    expect(home).toContain('https://www.linkedin.com/in/alehar/');
+    expect(home).toContain('Get in touch');
+    expect(home).toContain('Hero title="Product Manager, Developer Experience at IFS"');
+    expect(home).not.toContain('mailto:');
+    expect(chat).not.toContain('mailto:');
+    expect(chat).not.toContain('data-hire-surface');
+  });
+
   it('keeps the chat FAB off the 2x/30x/Zeroheight proof on the design system case on a phone', () => {
     const slug = readFileSync('src/pages/work/[...slug].astro', 'utf8');
     const ds = readFileSync('src/content/work/ifs-design-system.md', 'utf8');

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -28,6 +28,18 @@
     <span role="tooltip" id="status-tooltip" class="status-tooltip"></span>
   </button>
 
+  <button
+    type="button"
+    id="chat-dock"
+    class="chat-dock"
+    aria-label="Open chat"
+    aria-expanded="false"
+    aria-controls="chat-window"
+  >
+    <span class="chat-dock-handle" aria-hidden="true"></span>
+    <span class="chat-dock-label">Chat</span>
+  </button>
+
   <button type="button" id="chat-scrim" class="chat-scrim" hidden aria-label="Dismiss chat"
   ></button>
 
@@ -126,6 +138,15 @@
     justify-content: flex-end;
   }
 
+  .chat-container.is-docked:not(.is-open):not(.is-prominent) {
+    inset: auto 0 0 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-end;
+    pointer-events: none;
+  }
+
   .chat-toggle {
     position: relative;
     width: var(--chat-fab-size);
@@ -157,8 +178,58 @@
   }
 
   .chat-container.is-prominent .chat-toggle,
-  .chat-container.is-open .chat-toggle {
+  .chat-container.is-open .chat-toggle,
+  .chat-container.is-docked .chat-toggle {
     display: none;
+  }
+
+  .chat-dock {
+    display: none;
+    pointer-events: auto;
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    max-width: 36rem;
+    min-height: 3.25rem;
+    padding: 0.75rem 1rem calc(0.75rem + env(safe-area-inset-bottom, 0px));
+    border: 1px solid var(--gray-800);
+    border-bottom: 0;
+    border-radius: 1rem 1rem 0 0;
+    background-color: hsla(var(--gray-999-basis), 0.7);
+    color: var(--gray-200);
+    cursor: pointer;
+    box-shadow: var(--shadow-sm);
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    font-family: inherit;
+    font-size: 0.75rem;
+    font-weight: 500;
+    backdrop-filter: blur(16px) saturate(180%);
+    -webkit-backdrop-filter: blur(16px) saturate(180%);
+  }
+
+  .chat-container.is-docked:not(.is-open):not(.is-prominent) .chat-dock {
+    display: flex;
+  }
+
+  .chat-dock-handle {
+    width: 2.5rem;
+    height: 0.25rem;
+    border-radius: 999px;
+    background: var(--gray-600);
+  }
+
+  .chat-dock-label {
+    line-height: 1;
+  }
+
+  .chat-dock:hover,
+  .chat-dock:focus-visible {
+    outline: 2px solid var(--accent-regular);
+    outline-offset: 4px;
+    color: var(--gray-0);
   }
 
   .chat-scrim {
@@ -317,7 +388,8 @@
   }
 
   @media (max-width: 49.99em) {
-    .chat-window {
+    .chat-window,
+    .chat-dock {
       width: 100%;
       max-width: none;
     }
@@ -501,6 +573,7 @@
 
   const chatContainer = document.getElementById('chat-container');
   const chatToggle = document.getElementById('chat-toggle');
+  const chatDock = document.getElementById('chat-dock');
   const chatWindow = document.getElementById('chat-window');
   const chatClose = document.getElementById('chat-close');
   const chatClear = document.getElementById('chat-clear');
@@ -666,6 +739,7 @@
 
   const setChatExpanded = (expand: boolean) => {
     chatToggle?.setAttribute('aria-expanded', String(expand));
+    chatDock?.setAttribute('aria-expanded', String(expand));
     chatWindow?.classList.toggle('hidden', !expand);
     chatContainer?.classList.toggle('is-open', expand);
     if (chatScrim) chatScrim.hidden = !expand;
@@ -695,7 +769,11 @@
     } else {
       setChatExpanded(false);
     }
-    (chatToggle as HTMLElement)?.focus();
+    if (chatContainer?.classList.contains('is-docked') && chatDock) {
+      (chatDock as HTMLElement).focus();
+    } else {
+      (chatToggle as HTMLElement)?.focus();
+    }
   }
 
   function initConversationalFold() {
@@ -735,6 +813,11 @@
     if (!isExpanded) {
       trackHireEvent('chat_opened', 'fab');
     }
+  });
+
+  chatDock?.addEventListener('click', () => {
+    setChatExpanded(true);
+    trackHireEvent('chat_opened', 'dock');
   });
 
   chatClose?.addEventListener('click', () => {

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -412,9 +412,11 @@
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .chat-window {
+    .chat-window,
+    .chat-dock {
       animation: none;
       transform: none;
+      transition: none;
     }
   }
 
@@ -817,7 +819,7 @@
 
   chatDock?.addEventListener('click', () => {
     setChatExpanded(true);
-    trackHireEvent('chat_opened', 'dock');
+    trackHireEvent('chat_opened', 'fab');
   });
 
   chatClose?.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- After the visitor scrolls (`scrollY > 160`), the open bottom sheet docks to a compact bottom bar with a handle — not a right column, not a leftover 62dvh sheet, and not a floating FAB as the docked chrome.
- Reopen from the bar is the same slice 1 bottom sheet (full width on phone, max-width 36rem centered on desktop, height 62dvh / 55–70dvh, top radius 1rem, light scrim, bubbles, 1rem inset, one header portrait).
- Docked chrome is a handle + quiet “Chat” label. No `portrait.png` on the docked bar. FAB stays for non-home pages only. Overlay/Nav and #597 are untouched. Hire still LinkedIn.

## Test plan
- [x] `npx vitest run src/__tests__/identity.test.ts`
- [x] `npx vitest run`
- [ ] Confirm `/` first view still opens the bottom sheet (H1 + Get in touch + sheet)
- [ ] Confirm scroll docks to a compact bottom bar/handle, not a FAB face and not a right column
- [ ] Confirm reopen from the bar is the same bottom sheet
- [ ] Confirm no portrait on docked chrome; one header portrait only in the open sheet
- [ ] Confirm Clear, starters, and follow-ups (including `How do I get in touch on LinkedIn?`) still appear
- [ ] Confirm LinkedIn hire still points at https://www.linkedin.com/in/alehar/
- [ ] Confirm desktop pill nav and mobile menu overlay unchanged
- [ ] Stay draft until Johan+Vera PASS a freeze SHA

Draft until Johan+Vera PASS.
Do not merge.
Stay off #597.