### PR TITLE
🎨 Palette: Preserve session context on external social and release links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,5 +1,11 @@
 # Palette 🎨 - UX & Accessibility Journal
 
+## 2026-05-20 - Preserving Navigational Session Context for External Social Links
+
+**Learning:** External links to third-party platforms (like LinkedIn, IFS Blog, and GitHub) should open in a new tab with `target="_blank"` and `rel="noopener noreferrer"`. This prevents disruptive tab navigation, preserves the user's active session and scroll position on the portfolio, and eliminates reverse tab-nabbing security risks.
+
+**Action:** Added `target="_blank"` and `rel="noopener noreferrer"` attributes to external social links in `Nav.astro` and `Footer.astro`, as well as static and dynamic GitHub Releases links in `whats-new.astro`.
+
 ## 2026-05-17 - Enhancing Content Selection and Standardizing Focus Spatiality
 
 **Learning:** Using `user-select: none` on informational badges (like `Pill`) creates unnecessary friction for users trying to copy text for reference. Additionally, consistent `outline-offset: 4px` across all interactive elements (including theme toggles and cards) reinforces a predictable spatial model for keyboard users. Adding `target="_blank"` with `rel="noopener noreferrer"` to external informational links (like the Astro framework link in the footer) ensures a non-disruptive navigation experience that preserves the user's session.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -29,9 +29,17 @@ const currentYear = new Date().getFullYear();
     </div>
   </div>
   <p class="socials">
-    <a href="https://www.linkedin.com/in/alehar/"> LinkedIn</a>
-    <a href="https://blog.ifs.com/author/alexander-harenstam/"> IFS Blog</a>
-    <a href="https://github.com/alehar9320"> GitHub</a>
+    <a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">
+      LinkedIn</a
+    >
+    <a
+      href="https://blog.ifs.com/author/alexander-harenstam/"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      IFS Blog</a
+    >
+    <a href="https://github.com/alehar9320" target="_blank" rel="noopener noreferrer"> GitHub</a>
   </p>
 </footer>
 <div class="visit-panel" id="visit-glance-panel" hidden>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -89,7 +89,14 @@ const isCurrentPage = (href: string) => {
       <div class="socials">
         {
           iconLinks.map(({ href, icon, label, event, surface }) => (
-            <a href={href} class="social" data-hire-event={event} data-hire-surface={surface}>
+            <a
+              href={href}
+              class="social"
+              target="_blank"
+              rel="noopener noreferrer"
+              data-hire-event={event}
+              data-hire-surface={surface}
+            >
               <span class="sr-only">{label}</span>
               <Icon icon={icon} />
             </a>
@@ -120,7 +127,14 @@ const isCurrentPage = (href: string) => {
       <div class="socials">
         {
           iconLinks.map(({ href, icon, label, event, surface }) => (
-            <a href={href} class="social" data-hire-event={event} data-hire-surface={surface}>
+            <a
+              href={href}
+              class="social"
+              target="_blank"
+              rel="noopener noreferrer"
+              data-hire-event={event}
+              data-hire-surface={surface}
+            >
               <span class="sr-only">{label}</span>
               <Icon icon={icon} />
             </a>

--- a/src/pages/whats-new.astro
+++ b/src/pages/whats-new.astro
@@ -58,7 +58,11 @@ const schema = {
         <noscript>
           <p class="release-status">
             Release history is available on
-            <a href="https://github.com/alehar9320/astro-cloudflare-personal-website/releases">
+            <a
+              href="https://github.com/alehar9320/astro-cloudflare-personal-website/releases"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               GitHub Releases
             </a>.
           </p>
@@ -133,6 +137,8 @@ const schema = {
         empty.textContent = 'Site updates are currently unavailable.';
         const link = document.createElement('a');
         link.href = RELEASES_PAGE_URL;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
         link.textContent = 'View GitHub Releases';
         empty.appendChild(document.createTextNode(' '));
         empty.appendChild(link);
@@ -179,6 +185,8 @@ const schema = {
 
         const link = document.createElement('a');
         link.href = release.url;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
         link.className = 'release-link';
         link.textContent = 'View on GitHub';
         article.appendChild(link);


### PR DESCRIPTION
Adds target="_blank" and rel="noopener noreferrer" to external social links in Nav.astro and Footer.astro, and release links in whats-new.astro, preserving session context and enhancing security.

---
*PR created automatically by Jules for task [6117612786305901993](https://jules.google.com/task/6117612786305901993) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - External social, blog, and GitHub Releases links now open in a new browser tab.
  - Added safer handling for newly opened links to protect the current page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->