### PR TITLE
Content: Fix redundant phrasing in user-behavior-analytics case

### DIFF
--- a/.Jules/content.md
+++ b/.Jules/content.md
@@ -1,0 +1,3 @@
+## Content Journal
+
+2026-03-30 - [Content Track] | Signal: Redundant Copy | Lean Update: Removed 36-character redundant sentence in Outcome section of user-behavior-analytics.md (~5% delta).

--- a/src/content/work/user-behavior-analytics.md
+++ b/src/content/work/user-behavior-analytics.md
@@ -25,6 +25,6 @@ As Product Manager, Developer Experience at IFS, I worked on user behavior analy
 
 ## Outcome
 
-Usage telemetry so IFS Cloud roadmap decisions rest on how people actually use the product. Roadmap decisions rest on that usage.
+Usage telemetry so IFS Cloud roadmap decisions rest on how people actually use the product.
 
 <a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>


### PR DESCRIPTION
Content agent maintenance:
- Removed a duplicate trailing sentence under ## Outcome in `src/content/work/user-behavior-analytics.md`.
- Recorded journal log entry in `.Jules/content.md`.
- Verified via unit tests, linter, Prettier formatter, and Astro build.

---
*PR created automatically by Jules for task [4983062051675211676](https://jules.google.com/task/4983062051675211676) started by @alehar9320*