### PR TITLE
fix: drop redundant Outcome sentence on user behavior analytics

### DIFF
--- a/src/content/work/user-behavior-analytics.md
+++ b/src/content/work/user-behavior-analytics.md
@@ -25,6 +25,6 @@ As Product Manager, Developer Experience at IFS, I worked on user behavior analy
 
 ## Outcome
 
-Usage telemetry so IFS Cloud roadmap decisions rest on how people actually use the product. Roadmap decisions rest on that usage.
+Usage telemetry so IFS Cloud roadmap decisions rest on how people actually use the product.
 
 <a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>


### PR DESCRIPTION
## Summary
- One-line copy fix under Outcome on `/work/user-behavior-analytics/`: drop the trailing "Roadmap decisions rest on that usage." The lead Outcome sentence already says that.
- LinkedIn hire path unchanged (`https://www.linkedin.com/in/alehar/`, Get in touch on LinkedIn).
- No Jules journal. Does not touch Chat, overlay frost, copilots, CallToAction, flags, or #597.

Human rewrite of closed Jules #608. Branched from `9bcc5bf`. Stay draft until Johan+Vera PASS.

## Test plan
- [ ] Outcome on https://me.alehar.workers.dev/work/user-behavior-analytics/ no longer repeats "Roadmap decisions rest on that usage."
- [ ] Intro paragraph still contains that sentence
- [ ] LinkedIn CTA still present
- [ ] Identity tests green
- [ ] Workers Builds green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed a redundant sentence from the User Behavior Analytics documentation to improve clarity and conciseness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->