### PR TITLE
feat: add What's New to nav

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -125,7 +125,7 @@ describe('identity copy', () => {
   it('drops Latest Updates from the footer and keeps What’s New', () => {
     const footer = readFileSync('src/components/Footer.astro', 'utf8');
     expect(footer).not.toContain('Latest Updates');
-    expect(footer).not.toContain('/whats-new');
+    expect(footer).toContain('<a href="/whats-new/">What\'s New</a>');
     expect(footer).toContain('https://www.linkedin.com/in/alehar/');
     expect(footer).not.toContain('mailto:');
     expect(existsSync('src/pages/whats-new.astro')).toBe(true);
@@ -937,6 +937,8 @@ describe('identity copy', () => {
     const nav = readFileSync('src/components/Nav.astro', 'utf8');
     expect(nav).not.toContain('Strategic Portfolio');
     expect(nav).toContain("{ label: 'Work', href: '/work/' }");
+    expect(nav).toContain("{ label: \"What's New\", href: '/whats-new/' }");
+    expect(nav).toContain("{ label: 'Contact', href: '/contact/', event: 'hire_cta_click', surface: 'nav' }");
   });
 
   it('lets the open mobile menu sheet use a denser 0.90 frost overlay', () => {

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -125,7 +125,7 @@ describe('identity copy', () => {
   it('drops Latest Updates from the footer and keeps What’s New', () => {
     const footer = readFileSync('src/components/Footer.astro', 'utf8');
     expect(footer).not.toContain('Latest Updates');
-    expect(footer).toContain('<a href="/whats-new/">What\'s New</a>');
+    expect(footer).toContain('href="/whats-new/"');
     expect(footer).toContain('https://www.linkedin.com/in/alehar/');
     expect(footer).not.toContain('mailto:');
     expect(existsSync('src/pages/whats-new.astro')).toBe(true);
@@ -937,8 +937,8 @@ describe('identity copy', () => {
     const nav = readFileSync('src/components/Nav.astro', 'utf8');
     expect(nav).not.toContain('Strategic Portfolio');
     expect(nav).toContain("{ label: 'Work', href: '/work/' }");
-    expect(nav).toContain("{ label: \"What's New\", href: '/whats-new/' }");
-    expect(nav).toContain("{ label: 'Contact', href: '/contact/', event: 'hire_cta_click', surface: 'nav' }");
+    expect(nav).toContain("What's New");
+    expect(nav).toContain("href: '/whats-new/'");
   });
 
   it('lets the open mobile menu sheet use a denser 0.90 frost overlay', () => {

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -17,6 +17,7 @@ const currentYear = new Date().getFullYear();
     </p>
     <p>&copy; {currentYear} Alexander Härenstam</p>
     <div class="colophon">
+      <a href="/whats-new/">What's New</a>
       <span class="visit-stats" data-visit-stats hidden>
         <button
           type="button"

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -12,6 +12,7 @@ const textLinks: { label: string; href: string; event?: string; surface?: string
   { label: 'Home', href: '/' },
   { label: 'Work', href: '/work/' },
   { label: 'Biography', href: '/biography/' },
+  { label: "What's New", href: '/whats-new/' },
   { label: 'Contact', href: '/contact/', event: 'hire_cta_click', surface: 'nav' },
 ];
 


### PR DESCRIPTION
## Summary
- Add What's New → `/whats-new/` to Nav `textLinks` (Home, Work, Biography, What's New, Contact).
- Quiet footer colophon link to the same path.
- Robots `Disallow: /whats-new/` unchanged. Noindex / sitemap omit stay.
- LinkedIn hire unchanged. Does not touch Chat.astro, #618, overlay, copilots, or #597.

Tiny PR from `a856286` (#610). Stay draft.

## Test plan
- [ ] Nav shows What's New on phone + desktop and opens `/whats-new/`
- [ ] Footer colophon has a quiet What's New link
- [ ] `public/robots.txt` still has `Disallow: /whats-new/`
- [ ] Identity tests green
- [ ] Workers Builds green