### PR TITLE
⚡ Bolt: Defer loading and decoding of chat drawer avatar image

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@ Action: Added fetchpriority="high" and decoding="async" to the hero images in sr
 2026-05-30 - Icon Payload Pruning
 Learning: Inlined SVG icons in Astro components contribute directly to the HTML payload size. Commenting out unused icons in a shared IconPaths configuration reduces the bytes served per page and the memory footprint of the Cloudflare Worker.
 Action: Commented out unused icons in src/components/IconPaths.ts and updated related tests. Use grep -r to periodically audit icon usage across the codebase.
+
+2026-06-12 - Universal Drawer Image Lazy Loading
+Learning: Universal drawer or widget components included across all site pages (such as the Chat drawer avatar in BaseLayout) can trigger unnecessary early resource downloads if images lack lazy loading flags. Explicitly setting loading="lazy" and decoding="async" prevents high-resolution or secondary image assets from competing with LCP assets and main-thread layout work.
+Action: Added loading="lazy" and decoding="async" to the avatar image in src/components/Chat.astro.

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -80,7 +80,16 @@
     <p id="chat-remaining" class="chat-remaining" aria-live="polite" hidden></p>
   </div>
   <form id="chat-form" class="chat-form">
-    <img src="/assets/portrait.png" alt="" class="chat-header-avatar" width="40" height="40" />
+    <!-- ⚡ Bolt: Defer image download and decoding off main thread for initial page renders -->
+    <img
+      src="/assets/portrait.png"
+      alt=""
+      class="chat-header-avatar"
+      width="40"
+      height="40"
+      loading="lazy"
+      decoding="async"
+    />
     <input type="text" id="chat-input" required autocomplete="off" />
     <button type="submit" aria-label="Send message">
       <svg


### PR DESCRIPTION
### What
Added `loading="lazy"` and `decoding="async"` to the chat header avatar image (`/assets/portrait.png`) in `src/components/Chat.astro`.

### Why
`Chat.astro` is included across all pages via `BaseLayout.astro`. Previously, `<img src="/assets/portrait.png">` lacked lazy loading and decoding attributes, causing the 250KB+ image to be fetched and decoded immediately during initial page render even when the chat drawer was closed or off-screen.

### Impact
- Defers network fetch and asynchronous decoding off the main thread during initial page load.
- Lowers network contention for above-the-fold Largest Contentful Paint (LCP) critical assets.

### How to verify
Run `npm run build && npm run test` to verify zero build or test regressions.

---
*PR created automatically by Jules for task [16183114813640736470](https://jules.google.com/task/16183114813640736470) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved chat drawer avatar loading with lazy loading and asynchronous image decoding.
  * Helps the chat interface load images more efficiently without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->