### PR TITLE
🎨 Palette: Enhance Release Link Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -44,9 +44,9 @@
 
 ## 2026-05-20 - Enhancing Dynamic Release Link Accessibility & Focus Spatiality
 
-**Learning:** Dynamically rendered links in client-side scripts often bypass standard global link focus rules and accessible external link patterns. Adding `target="_blank"` and `rel="noopener noreferrer"` to client-rendered external links prevents session context loss, while supplying context-rich `aria-label`s (e.g. `View release v1.2.0 on GitHub`) ensures screen reader users navigating links out of context can distinguish identical link text across repeated list cards. Explicitly pairing `:focus-visible` outline rings (2px accent with 4px offset) on custom class links ensures complete keyboard accessibility alignment.
+**Learning:** Dynamically rendered links in client-side scripts often bypass standard global link focus rules and accessible external link patterns. Adding `target="_blank"` and `rel="noopener noreferrer"` to client-rendered external links prevents session context loss. Providing descriptive visible text (e.g. `View ${release.version} on GitHub`) gives both sighted visitors and screen reader users a unique, context-rich link name without needing redundant `aria-label` overrides. Explicitly pairing `:focus-visible` outline rings (2px accent with 4px offset) on custom class links ensures complete keyboard accessibility alignment.
 
-**Action:** Updated client-side link creation logic in `src/pages/whats-new.astro` to include `target="_blank"`, `rel="noopener noreferrer"`, and version-specific `aria-label` attributes for release cards and fallback links. Added explicit `:hover` and `:focus-visible` CSS rules for `.release-link` and `.release-status a`.
+**Action:** Updated client-side link creation logic in `src/pages/whats-new.astro` to include `target="_blank"`, `rel="noopener noreferrer"`, and version-specific visible link text (`View ${release.version} on GitHub`) for release cards. Added explicit `:hover` and `:focus-visible` CSS rules for `.release-link` and `.release-status a`.
 
 ## 2026-05-19 - Optimizing LCP for Portfolio Galleries and Hero Assets
 

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -42,6 +42,12 @@
 
 **Action:** Standardized `outline-offset: 4px` and tactile scaling across `Nav.astro`, `Footer.astro`, and global link styles. Refined `global.css` to gate smooth scrolling behind `prefers-reduced-motion: no-preference`. Ensured site-wide "Skip to Content" functionality by adding `id="main-content"` to all primary page layouts and components.
 
+## 2026-05-20 - Enhancing Dynamic Release Link Accessibility & Focus Spatiality
+
+**Learning:** Dynamically rendered links in client-side scripts often bypass standard global link focus rules and accessible external link patterns. Adding `target="_blank"` and `rel="noopener noreferrer"` to client-rendered external links prevents session context loss, while supplying context-rich `aria-label`s (e.g. `View release v1.2.0 on GitHub`) ensures screen reader users navigating links out of context can distinguish identical link text across repeated list cards. Explicitly pairing `:focus-visible` outline rings (2px accent with 4px offset) on custom class links ensures complete keyboard accessibility alignment.
+
+**Action:** Updated client-side link creation logic in `src/pages/whats-new.astro` to include `target="_blank"`, `rel="noopener noreferrer"`, and version-specific `aria-label` attributes for release cards and fallback links. Added explicit `:hover` and `:focus-visible` CSS rules for `.release-link` and `.release-status a`.
+
 ## 2026-05-19 - Optimizing LCP for Portfolio Galleries and Hero Assets
 
 **Learning:** To optimize Largest Contentful Paint (LCP) in Astro projects, primary visual assets (like hero images) and the first items in repeated galleries should be prioritised by the browser. Applying `loading="eager"` and `fetchpriority="high"` to these elements prevents the browser from delaying their loading, ensuring a faster perceived performance for users.

--- a/src/pages/whats-new.astro
+++ b/src/pages/whats-new.astro
@@ -139,7 +139,6 @@ const schema = {
         link.href = RELEASES_PAGE_URL;
         link.target = '_blank';
         link.rel = 'noopener noreferrer';
-        link.setAttribute('aria-label', 'View GitHub Releases');
         link.textContent = 'View GitHub Releases';
         empty.appendChild(document.createTextNode(' '));
         empty.appendChild(link);
@@ -189,8 +188,7 @@ const schema = {
         link.className = 'release-link';
         link.target = '_blank';
         link.rel = 'noopener noreferrer';
-        link.setAttribute('aria-label', `View release ${release.version} on GitHub`);
-        link.textContent = 'View on GitHub';
+        link.textContent = `View ${release.version} on GitHub`;
         article.appendChild(link);
 
         fragment.appendChild(article);

--- a/src/pages/whats-new.astro
+++ b/src/pages/whats-new.astro
@@ -58,7 +58,11 @@ const schema = {
         <noscript>
           <p class="release-status">
             Release history is available on
-            <a href="https://github.com/alehar9320/astro-cloudflare-personal-website/releases">
+            <a
+              href="https://github.com/alehar9320/astro-cloudflare-personal-website/releases"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
               GitHub Releases
             </a>.
           </p>
@@ -133,6 +137,9 @@ const schema = {
         empty.textContent = 'Site updates are currently unavailable.';
         const link = document.createElement('a');
         link.href = RELEASES_PAGE_URL;
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        link.setAttribute('aria-label', 'View GitHub Releases');
         link.textContent = 'View GitHub Releases';
         empty.appendChild(document.createTextNode(' '));
         empty.appendChild(link);
@@ -180,6 +187,9 @@ const schema = {
         const link = document.createElement('a');
         link.href = release.url;
         link.className = 'release-link';
+        link.target = '_blank';
+        link.rel = 'noopener noreferrer';
+        link.setAttribute('aria-label', `View release ${release.version} on GitHub`);
         link.textContent = 'View on GitHub';
         article.appendChild(link);
 
@@ -247,9 +257,29 @@ const schema = {
     line-height: 1.6;
   }
 
-  .release-link {
+  .release-link,
+  .release-status a {
     display: inline-block;
     margin-top: 0.25rem;
+    color: var(--link-color);
+    text-decoration: 1px solid underline transparent;
+    text-underline-offset: 0.25em;
+    transition:
+      text-decoration-color var(--theme-transition),
+      color var(--theme-transition);
+  }
+
+  .release-link:hover,
+  .release-status a:hover {
+    text-decoration-color: currentColor;
+  }
+
+  .release-link:focus-visible,
+  .release-status a:focus-visible {
+    text-decoration-color: currentColor;
+    outline: 2px solid var(--accent-regular);
+    outline-offset: 4px;
+    border-radius: 0.25rem;
   }
 
   .commit-hash {


### PR DESCRIPTION
Enhance accessibility, security, and focus states for dynamic release links on the What's New page (`src/pages/whats-new.astro`). Adds `target="_blank"`, `rel="noopener noreferrer"`, and unique `aria-label` attributes to release card links while providing explicit `:hover` and `:focus-visible` styling matching the site's Northern Lights aesthetic.

---
*PR created automatically by Jules for task [11015253679689388579](https://jules.google.com/task/11015253679689388579) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Added descriptive, version-specific labels to dynamically generated release links.
  - Improved keyboard visibility with clear focus-visible styling.

- **Security**
  - External release links now open in a new tab with safer link handling.

- **Style**
  - Added consistent hover and focus states for release and status links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->