### PR TITLE
⚙️ Engine: Harden releases API with Worker token support, KV caching, and snapshot fallback

### DIFF
--- a/.jules/engine.md
+++ b/.jules/engine.md
@@ -1,5 +1,11 @@
 # ⚙️ Engine Journal
 
+## 2025-05-21 - Hardened Releases API with Worker Token Support, KV Caching, and Snapshot Fallback
+
+- **Architectural Shift:** Upgraded `/api/releases` and `fetchGitHubReleases` to support authenticated edge fetching using `GITHUB_TOKEN` from Cloudflare Worker environment bindings, bypassing unauthenticated IP rate limits on the edge.
+- **Edge Resilience & Caching:** Integrated `CHAT_STORE` KV caching (1-hour TTL) into `/api/releases` and added a graceful fallback to `LATEST_RELEASE_SNAPSHOT` when GitHub API is unreachable or rate-limited.
+- **TypeScript & Optimization:** Maintained strict type safety (`SiteReleaseSchema.array().safeParse`) for KV validation and streamlined release normalization into a clean, single-pass visitor copy transformation.
+
 ## 2025-05-14 - Centralized Chat Logic & Pruning
 
 - **Architectural Shift:** Centralized chat-related constants and logic into `src/utils/chat-logic.ts` to ensure consistency between the API and potential future client-side pruning.

--- a/src/__tests__/github-releases.test.ts
+++ b/src/__tests__/github-releases.test.ts
@@ -246,6 +246,23 @@ describe('github releases utility', () => {
     vi.unstubAllGlobals();
   });
 
+  it('uses explicitly provided token in options parameter', async () => {
+    vi.stubGlobal('process', undefined);
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+    await fetchGitHubReleases(fetchMock as typeof fetch, undefined, { token: 'explicit-token' });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'token explicit-token',
+        }),
+      })
+    );
+
+    vi.unstubAllGlobals();
+  });
+
   it('rejects invalid GitHub API URLs', async () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const fetchMock = vi.fn();

--- a/src/__tests__/releases-api.test.ts
+++ b/src/__tests__/releases-api.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { env as workerEnv } from 'cloudflare:workers';
+import { LATEST_RELEASE_SNAPSHOT } from '../data/latest-release';
+import { GET, RELEASES_CACHE_KEY, type ReleasesEnv } from '../pages/api/releases';
+import * as githubReleases from '../utils/github-releases';
+import { toVisitorRelease } from '../utils/visitor-changelog';
+
+describe('releases API', () => {
+  const mockRelease: githubReleases.SiteRelease = {
+    body: '- 1234567 feat: new feature (#100)',
+    publishedAt: '2026-08-15T12:00:00Z',
+    title: 'v2026.08.15',
+    url: 'https://github.com/example/releases/v2026.08.15',
+    version: 'v2026.08.15',
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    const bindings = workerEnv as ReleasesEnv;
+    delete bindings.CHAT_STORE;
+    delete bindings.GITHUB_TOKEN;
+  });
+
+  it('fetches GitHub releases and returns visitor-formatted releases', async () => {
+    vi.spyOn(githubReleases, 'fetchGitHubReleases').mockResolvedValue([mockRelease]);
+
+    const response = await GET({} as Parameters<typeof GET>[0]);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('content-type')).toBe('application/json');
+
+    const json = (await response.json()) as githubReleases.SiteRelease[];
+    expect(json).toHaveLength(1);
+    expect(json[0].version).toBe('v2026.08.15');
+    expect(json[0].body).toContain('New feature');
+  });
+
+  it('falls back to LATEST_RELEASE_SNAPSHOT when fetchGitHubReleases returns empty', async () => {
+    vi.spyOn(githubReleases, 'fetchGitHubReleases').mockResolvedValue([]);
+
+    const response = await GET({} as Parameters<typeof GET>[0]);
+
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as githubReleases.SiteRelease[];
+    expect(json).toHaveLength(1);
+    expect(json[0].version).toBe(LATEST_RELEASE_SNAPSHOT.version);
+  });
+
+  it('serves cached releases from CHAT_STORE KV on hit', async () => {
+    const cachedVisitorRelease = [toVisitorRelease(mockRelease)];
+    const mockGet = vi.fn().mockResolvedValue(JSON.stringify(cachedVisitorRelease));
+    const mockPut = vi.fn();
+
+    const bindings = workerEnv as ReleasesEnv;
+    bindings.CHAT_STORE = {
+      get: mockGet,
+      put: mockPut,
+    } as unknown as KVNamespace;
+
+    const fetchSpy = vi.spyOn(githubReleases, 'fetchGitHubReleases');
+
+    const response = await GET({} as Parameters<typeof GET>[0]);
+
+    expect(response.status).toBe(200);
+    expect(mockGet).toHaveBeenCalledWith(RELEASES_CACHE_KEY);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    const json = (await response.json()) as githubReleases.SiteRelease[];
+    expect(json).toEqual(cachedVisitorRelease);
+  });
+
+  it('fetches from GitHub and caches in CHAT_STORE KV on cache miss', async () => {
+    const mockGet = vi.fn().mockResolvedValue(null);
+    const mockPut = vi.fn().mockResolvedValue(undefined);
+
+    const bindings = workerEnv as ReleasesEnv;
+    bindings.CHAT_STORE = {
+      get: mockGet,
+      put: mockPut,
+    } as unknown as KVNamespace;
+
+    vi.spyOn(githubReleases, 'fetchGitHubReleases').mockResolvedValue([mockRelease]);
+
+    const response = await GET({} as Parameters<typeof GET>[0]);
+
+    expect(response.status).toBe(200);
+    expect(mockGet).toHaveBeenCalledWith(RELEASES_CACHE_KEY);
+    expect(mockPut).toHaveBeenCalledWith(
+      RELEASES_CACHE_KEY,
+      expect.any(String),
+      expect.objectContaining({ expirationTtl: 3600 })
+    );
+  });
+
+  it('passes GITHUB_TOKEN binding to fetchGitHubReleases when provided', async () => {
+    const bindings = workerEnv as ReleasesEnv;
+    bindings.GITHUB_TOKEN = 'worker-secret-token';
+
+    const fetchSpy = vi
+      .spyOn(githubReleases, 'fetchGitHubReleases')
+      .mockResolvedValue([mockRelease]);
+
+    await GET({} as Parameters<typeof GET>[0]);
+
+    expect(fetchSpy).toHaveBeenCalledWith(expect.any(Function), undefined, {
+      token: 'worker-secret-token',
+    });
+  });
+
+  it('handles KV store errors gracefully and proceeds to fetch and return releases', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const mockGet = vi.fn().mockRejectedValue(new Error('KV read failure'));
+
+    const bindings = workerEnv as ReleasesEnv;
+    bindings.CHAT_STORE = {
+      get: mockGet,
+      put: vi.fn(),
+    } as unknown as KVNamespace;
+
+    vi.spyOn(githubReleases, 'fetchGitHubReleases').mockResolvedValue([mockRelease]);
+
+    const response = await GET({} as Parameters<typeof GET>[0]);
+
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as githubReleases.SiteRelease[];
+    expect(json).toHaveLength(1);
+    expect(json[0].version).toBe('v2026.08.15');
+  });
+
+  it('catches fatal errors and returns snapshot fallback release', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(githubReleases, 'fetchGitHubReleases').mockRejectedValue(new Error('Fatal exception'));
+
+    const response = await GET({} as Parameters<typeof GET>[0]);
+
+    expect(response.status).toBe(200);
+    const json = (await response.json()) as githubReleases.SiteRelease[];
+    expect(json).toHaveLength(1);
+    expect(json[0].version).toBe(LATEST_RELEASE_SNAPSHOT.version);
+  });
+});

--- a/src/pages/api/releases.ts
+++ b/src/pages/api/releases.ts
@@ -1,5 +1,11 @@
 import type { APIRoute } from 'astro';
-import { fetchGitHubReleases } from '../../utils/github-releases';
+import { env } from 'cloudflare:workers';
+import { LATEST_RELEASE_SNAPSHOT } from '../../data/latest-release';
+import {
+  fetchGitHubReleases,
+  SiteReleaseSchema,
+  type SiteRelease,
+} from '../../utils/github-releases';
 import { toVisitorChangelogTitle, toVisitorRelease } from '../../utils/visitor-changelog';
 
 const jsonHeaders = {
@@ -12,10 +18,52 @@ const jsonHeaders = {
 } as const;
 
 export const prerender = false;
+export const RELEASES_CACHE_KEY = 'github-releases:v1:latest';
+
+export interface ReleasesEnv {
+  CHAT_STORE?: KVNamespace;
+  GITHUB_TOKEN?: string;
+}
+
+function readEnv(): ReleasesEnv {
+  try {
+    if (env && typeof env === 'object') return env as ReleasesEnv;
+  } catch {
+    // cloudflare:workers env is the only binding surface after adapter v13.
+  }
+  return {};
+}
 
 export const GET: APIRoute = async () => {
   try {
-    const releases = (await fetchGitHubReleases()).map((release) => {
+    const bindings = readEnv();
+    const store = bindings.CHAT_STORE;
+
+    if (store) {
+      try {
+        const cached = await store.get(RELEASES_CACHE_KEY);
+        if (cached) {
+          const parsed = JSON.parse(cached);
+          const validation = SiteReleaseSchema.array().safeParse(parsed);
+          if (validation.success && validation.data.length > 0) {
+            return new Response(JSON.stringify(validation.data), { headers: jsonHeaders });
+          }
+        }
+      } catch (cacheError: unknown) {
+        console.error({ event: 'releases_cache_read_error', error: String(cacheError) });
+      }
+    }
+
+    const fetchedReleases = await fetchGitHubReleases(
+      fetch,
+      undefined,
+      bindings.GITHUB_TOKEN ? { token: bindings.GITHUB_TOKEN } : undefined
+    );
+
+    const baseReleases: SiteRelease[] =
+      fetchedReleases.length > 0 ? fetchedReleases : [LATEST_RELEASE_SNAPSHOT];
+
+    const releases = baseReleases.map((release) => {
       const visitor = toVisitorRelease(release);
       return {
         ...visitor,
@@ -29,9 +77,19 @@ export const GET: APIRoute = async () => {
           .join('\n'),
       };
     });
+
+    if (store && releases.length > 0) {
+      try {
+        await store.put(RELEASES_CACHE_KEY, JSON.stringify(releases), { expirationTtl: 3600 });
+      } catch (cacheError: unknown) {
+        console.error({ event: 'releases_cache_write_error', error: String(cacheError) });
+      }
+    }
+
     return new Response(JSON.stringify(releases), { headers: jsonHeaders });
   } catch (error: unknown) {
     console.error({ event: 'releases_api_error', error: String(error) });
-    return new Response(JSON.stringify([]), { headers: jsonHeaders });
+    const fallback = [toVisitorRelease(LATEST_RELEASE_SNAPSHOT)];
+    return new Response(JSON.stringify(fallback), { headers: jsonHeaders });
   }
 };

--- a/src/utils/github-releases.ts
+++ b/src/utils/github-releases.ts
@@ -1,3 +1,4 @@
+import { env } from 'cloudflare:workers';
 import { z } from 'zod';
 
 export const GitHubReleaseApiItemSchema = z.object({
@@ -70,14 +71,24 @@ export function normalizeRelease(release: GitHubReleaseApiItem): SiteRelease | n
 }
 
 /**
+ * Options for fetching GitHub releases.
+ */
+export interface FetchReleasesOptions {
+  /** Optional GitHub API personal access token or worker secret. */
+  token?: string;
+}
+
+/**
  * Fetches and validates a list of non-prerelease items from the GitHub Releases API.
  * @param {typeof fetch} [fetchImpl=fetch] - The fetch implementation to use (useful for testing).
  * @param {string} [url=RELEASES_API_URL] - The GitHub API endpoint to fetch from.
+ * @param {FetchReleasesOptions} [options] - Additional options including token.
  * @returns {Promise<SiteRelease[]>} A promise resolving to an array of normalized site releases.
  */
 export async function fetchGitHubReleases(
   fetchImpl: typeof fetch = fetch,
-  url: string = RELEASES_API_URL
+  url: string = RELEASES_API_URL,
+  options?: FetchReleasesOptions
 ): Promise<SiteRelease[]> {
   if (typeof window !== 'undefined' && url === RELEASES_API_URL) {
     // Same-origin /api/releases is cheap. Skip sessionStorage so a new GitHub
@@ -103,11 +114,26 @@ export async function fetchGitHubReleases(
     return [];
   }
 
-  let githubToken: string | undefined;
-  try {
-    githubToken = typeof process !== 'undefined' ? process.env.GITHUB_TOKEN : undefined;
-  } catch {
-    githubToken = undefined;
+  let githubToken: string | undefined = options?.token?.trim();
+  if (!githubToken) {
+    try {
+      const globalProcess = (globalThis as { process?: { env?: Record<string, string> } }).process;
+      githubToken = globalProcess?.env?.GITHUB_TOKEN;
+    } catch {
+      githubToken = undefined;
+    }
+  }
+  if (!githubToken) {
+    try {
+      if (env && typeof env === 'object' && 'GITHUB_TOKEN' in env) {
+        const workerToken = (env as { GITHUB_TOKEN?: unknown }).GITHUB_TOKEN;
+        if (typeof workerToken === 'string') {
+          githubToken = workerToken.trim();
+        }
+      }
+    } catch {
+      // cloudflare:workers env fallback
+    }
   }
 
   // Defensive check to ensure we only fetch from the trusted GitHub API domain


### PR DESCRIPTION
Hardened the releases API endpoint and utility with Cloudflare Workers GITHUB_TOKEN support to prevent rate-limiting, added KV store caching (1-hour TTL), resilient fallback to LATEST_RELEASE_SNAPSHOT, and added full Vitest unit test coverage.

---
*PR created automatically by Jules for task [11333801495376012254](https://jules.google.com/task/11333801495376012254) started by @alehar9320*