### PR TITLE
feat: name What’s New GitHub links by release version

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -2005,8 +2005,10 @@ describe('identity copy', () => {
     expect(page).toContain('toVisitorRelease');
     expect(page).toContain('ContactCTA');
     expect(page).toContain('View ${release.version} on GitHub');
-    expect(page).toContain('.release-link:focus-visible');
-    expect(page).toContain('.release-status a:focus-visible');
+    expect(page).toContain(':global(.release-link:focus-visible)');
+    expect(page).toContain(':global(.release-status a:focus-visible)');
+    expect(page).toContain(':global(.release-link:hover)');
+    expect(page).toContain(':global(.release-status a:hover)');
     expect(page).toContain('outline: 2px solid var(--accent-regular)');
     expect(page).toContain('outline-offset: 4px');
     expect(page).not.toContain('target="_blank"');

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -2004,6 +2004,14 @@ describe('identity copy', () => {
     expect(page).toContain('toVisitorChangelogTitle');
     expect(page).toContain('toVisitorRelease');
     expect(page).toContain('ContactCTA');
+    expect(page).toContain('View ${release.version} on GitHub');
+    expect(page).toContain('.release-link:focus-visible');
+    expect(page).toContain('.release-status a:focus-visible');
+    expect(page).toContain('outline: 2px solid var(--accent-regular)');
+    expect(page).toContain('outline-offset: 4px');
+    expect(page).not.toContain('target="_blank"');
+    expect(page).not.toContain("target = '_blank'");
+    expect(page).not.toContain('noopener');
     expect(page).not.toContain('mailto:');
     expect(page).not.toContain('this is not on the site');
     expect(page).not.toContain("this isn't on the site yet");

--- a/src/pages/whats-new.astro
+++ b/src/pages/whats-new.astro
@@ -180,7 +180,7 @@ const schema = {
         const link = document.createElement('a');
         link.href = release.url;
         link.className = 'release-link';
-        link.textContent = 'View on GitHub';
+        link.textContent = `View ${release.version} on GitHub`;
         article.appendChild(link);
 
         fragment.appendChild(article);
@@ -247,9 +247,29 @@ const schema = {
     line-height: 1.6;
   }
 
-  .release-link {
+  .release-link,
+  .release-status a {
     display: inline-block;
     margin-top: 0.25rem;
+    color: var(--link-color);
+    text-decoration: 1px solid underline transparent;
+    text-underline-offset: 0.25em;
+    transition:
+      text-decoration-color var(--theme-transition),
+      color var(--theme-transition);
+  }
+
+  .release-link:hover,
+  .release-status a:hover {
+    text-decoration-color: currentColor;
+  }
+
+  .release-link:focus-visible,
+  .release-status a:focus-visible {
+    text-decoration-color: currentColor;
+    outline: 2px solid var(--accent-regular);
+    outline-offset: 4px;
+    border-radius: 0.25rem;
   }
 
   .commit-hash {

--- a/src/pages/whats-new.astro
+++ b/src/pages/whats-new.astro
@@ -247,8 +247,8 @@ const schema = {
     line-height: 1.6;
   }
 
-  .release-link,
-  .release-status a {
+  :global(.release-link),
+  :global(.release-status a) {
     display: inline-block;
     margin-top: 0.25rem;
     color: var(--link-color);
@@ -259,13 +259,13 @@ const schema = {
       color var(--theme-transition);
   }
 
-  .release-link:hover,
-  .release-status a:hover {
+  :global(.release-link:hover),
+  :global(.release-status a:hover) {
     text-decoration-color: currentColor;
   }
 
-  .release-link:focus-visible,
-  .release-status a:focus-visible {
+  :global(.release-link:focus-visible),
+  :global(.release-status a:focus-visible) {
     text-decoration-color: currentColor;
     outline: 2px solid var(--accent-regular);
     outline-offset: 4px;


### PR DESCRIPTION
Aria kernel of Jules #622, rewritten from main `91fcbf6`.

Release cards show `View ${version} on GitHub`. `.release-link` and `.release-status a` get the hover underline plus `:focus-visible` 2px accent / 4px offset.

Same tab. No `target=_blank`. No `rel=noopener`. No `.Jules/palette.md`. Stay off Jules #622 itself.

Stay draft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release links now display the release version in their visible text.
  * Added clearer hover and keyboard-focus styles for release-status links.
  * Updated link colors and underline animations for light and dark themes.

* **Bug Fixes**
  * External release links no longer include unnecessary new-tab or security attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->