### PR TITLE
fix: paint What’s New latest banner from the first card

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -2004,6 +2004,12 @@ describe('identity copy', () => {
     expect(page).toContain('toVisitorChangelogTitle');
     expect(page).toContain('toVisitorRelease');
     expect(page).toContain('ContactCTA');
+    expect(page).toContain('fetchGitHubReleases');
+    expect(page).toContain("method: 'POST'");
+    expect(page).toContain("fetch('/api/release-summary'");
+    expect(page).toContain('tag !== latest.version');
+    expect(page).toContain('paintSummary(groundedReleaseSummary(latest.version, latest.body, latest.title))');
+    expect(page).not.toContain('LATEST_RELEASE_SNAPSHOT');
     expect(page).toContain('View ${release.version} on GitHub');
     expect(page).toContain(':global(.release-link:focus-visible)');
     expect(page).toContain(':global(.release-status a:focus-visible)');

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -2008,7 +2008,9 @@ describe('identity copy', () => {
     expect(page).toContain("method: 'POST'");
     expect(page).toContain("fetch('/api/release-summary'");
     expect(page).toContain('tag !== latest.version');
-    expect(page).toContain('paintSummary(groundedReleaseSummary(latest.version, latest.body, latest.title))');
+    expect(page).toContain(
+      'paintSummary(groundedReleaseSummary(latest.version, latest.body, latest.title))'
+    );
     expect(page).not.toContain('LATEST_RELEASE_SNAPSHOT');
     expect(page).toContain('View ${release.version} on GitHub');
     expect(page).toContain(':global(.release-link:focus-visible)');

--- a/src/pages/whats-new.astro
+++ b/src/pages/whats-new.astro
@@ -70,7 +70,6 @@ const schema = {
 </BaseLayout>
 
 <script>
-  import { LATEST_RELEASE_SNAPSHOT } from '../data/latest-release';
   import {
     RELEASES_PAGE_URL,
     fetchGitHubReleases,
@@ -96,35 +95,44 @@ const schema = {
     summaryContainer.replaceChildren(tldr);
   };
 
-  if (summaryContainer instanceof HTMLElement) {
-    fetch('/api/release-summary')
-      .then(async (response) => {
-        if (response.status === 204 || !response.ok) return;
-        let data: unknown;
-        try {
-          data = await response.json();
-        } catch {
-          return;
-        }
-        if (!data || typeof data !== 'object') return;
-        const summary = (data as { summary?: unknown }).summary;
-        const tag = (data as { tag?: unknown }).tag;
-        if (typeof summary !== 'string' || !summary.trim()) return;
-        const source = `${typeof tag === 'string' ? tag : ''}\n${LATEST_RELEASE_SNAPSHOT.body}`;
-        const prepared = prepareReleaseSummary(summary, source);
-        if (prepared) paintSummary(prepared);
-      })
-      .catch(() => {
-        // Fail-open: notes-only fallback still paints with the changelog.
-      });
-  }
-
   if (releaseList instanceof HTMLDivElement) {
     fetchGitHubReleases().then((rawReleases) => {
       const releases = rawReleases.map(toVisitorRelease);
-      if (summaryContainer instanceof HTMLElement && !summaryContainer.hasChildNodes()) {
-        const latest = releases[0] ?? LATEST_RELEASE_SNAPSHOT;
+      const latest = releases[0];
+
+      if (summaryContainer instanceof HTMLElement && latest) {
         paintSummary(groundedReleaseSummary(latest.version, latest.body, latest.title));
+
+        fetch('/api/release-summary', {
+          method: 'POST',
+          headers: { Accept: 'application/json', 'content-type': 'application/json' },
+          body: JSON.stringify({
+            tag: latest.version,
+            version: latest.version,
+            title: latest.title,
+            body: latest.body,
+          }),
+        })
+          .then(async (response) => {
+            if (response.status === 204 || !response.ok) return;
+            let data: unknown;
+            try {
+              data = await response.json();
+            } catch {
+              return;
+            }
+            if (!data || typeof data !== 'object') return;
+            const summary = (data as { summary?: unknown }).summary;
+            const tag = (data as { tag?: unknown }).tag;
+            if (typeof summary !== 'string' || !summary.trim()) return;
+            if (typeof tag === 'string' && tag !== latest.version) return;
+            const source = `${latest.version}\n${latest.body}`;
+            const prepared = prepareReleaseSummary(summary, source);
+            if (prepared) paintSummary(prepared);
+          })
+          .catch(() => {
+            // Grounded banner from the first card already painted.
+          });
       }
 
       if (releases.length === 0) {


### PR DESCRIPTION
Johan+Vera saw the Latest-release banner and the first changelog card disagree on live (banner 2026.08.20.0739, first card 2026.08.15.1720).

Both now come from the same `fetchGitHubReleases` list (`/api/releases`). The banner is `releases[0]`. Optional `/api/release-summary` is a POST of that same card and is dropped unless `tag` matches.

Hire LinkedIn unchanged. Chat layout unchanged. Robots `Disallow: /whats-new/` unchanged.

Stay draft.