### PR TITLE
Content: Clarify award title in biography timeline

### DIFF
--- a/.Jules/content.md
+++ b/.Jules/content.md
@@ -1,0 +1,1 @@
+2026-05-18 - [Biography Track] | Signal: [Clarity] | Lean Update: Expanded truncated award name in biography timeline for consistency with schema metadata.

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -80,7 +80,7 @@ const schema = {
               <p class="where">IFS Cloud</p>
               <p>
                 The <a href="/work/ifs-design-system/">IFS Design System</a>: up to 2x faster
-                delivery, up to 30x ROI, Zeroheight runner-up.
+                delivery, up to 30x ROI, Zeroheight Design System Awards runner-up.
               </p>
             </li>
             <li>


### PR DESCRIPTION
This PR performs a minimal, non-disruptive content update on `src/pages/biography.astro` to expand the truncated award title in the biography timeline for clarity and consistency with structured schema metadata. It also records the change in `.Jules/content.md`. All verification checks passed without issue.

---
*PR created automatically by Jules for task [5638618787321539284](https://jules.google.com/task/5638618787321539284) started by @alehar9320*