### PR TITLE
fix: close mobile nav overlay on Escape

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -1043,6 +1043,15 @@ describe('identity copy', () => {
     expect(nav).not.toContain('hsla(var(--gray-999-basis), 0.85)');
   });
 
+  it('closes the mobile nav overlay on Escape and restores focus without leaking the keydown', () => {
+    const nav = readFileSync('src/components/Nav.astro', 'utf8');
+    expect(nav).toContain('AbortController');
+    expect(nav).toContain('disconnectedCallback');
+    expect(nav).toContain('btn.focus()');
+    expect(nav).toContain('Escape');
+    expect(nav).toContain('aria-expanded');
+  });
+
   it('uses honest Earlier work labels, not Platform or copilots-as-product', () => {
     const copilots = readFileSync('src/content/work/ai-coding-copilots.md', 'utf8');
     const analytics = readFileSync('src/content/work/user-behavior-analytics.md', 'utf8');

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -138,6 +138,7 @@ const isCurrentPage = (href: string) => {
 
 <script>
   class MenuButton extends HTMLElement {
+    #keydownAbort?: AbortController;
     constructor() {
       super();
 
@@ -160,6 +161,19 @@ const isCurrentPage = (href: string) => {
       // Toggle menu visibility when the menu button is clicked.
       btn.addEventListener('click', () => setExpanded(menu.hidden === true));
 
+      this.#keydownAbort = new AbortController();
+      window.addEventListener(
+        'keydown',
+        (e: KeyboardEvent) => {
+          if (e.key !== 'Escape') return;
+          if (btn.hidden) return;
+          if (btn.getAttribute('aria-expanded') !== 'true') return;
+          setExpanded(false);
+          btn.focus();
+        },
+        { signal: this.#keydownAbort.signal }
+      );
+
       // Hide menu button for large screens.
       const handleViewports = (e: MediaQueryList | MediaQueryListEvent) => {
         setExpanded(e.matches);
@@ -168,6 +182,9 @@ const isCurrentPage = (href: string) => {
       const mediaQueries = window.matchMedia('(min-width: 50em)');
       handleViewports(mediaQueries);
       mediaQueries.addEventListener('change', handleViewports);
+    }
+    disconnectedCallback() {
+      this.#keydownAbort?.abort();
     }
   }
   customElements.define('menu-button', MenuButton);


### PR DESCRIPTION
Clean cut of Jules #639 kernel (not a cherry-pick). No `.Jules/palette.md`. Overlay frost `69ca717` stays. Hire LinkedIn.

Escape closes the mobile nav overlay and restores focus to the menu button. `AbortController` plus `disconnectedCallback` so the window keydown does not leak. Desktop nav is unchanged (menu button is hidden at `min-width: 50em`).

Stay draft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile navigation accessibility by allowing the open menu to close with the Escape key.
  * Focus now returns to the menu button after the overlay closes.
  * Keyboard handling is properly cleaned up when the navigation is removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->