### PR TITLE
fix: name Zeroheight Design System Awards on the biography timeline

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -54,6 +54,12 @@ describe('identity copy', () => {
     expect(twin).toContain('up to 30x ROI');
   });
 
+  it('lets the Biography timeline name Zeroheight Design System Awards runner-up', () => {
+    const bio = readFileSync('src/pages/biography.astro', 'utf8');
+    expect(bio).toContain('Zeroheight Design System Awards runner-up.');
+    expect(bio).not.toContain(', Zeroheight runner-up.');
+  });
+
   it('keeps spaces around TL;DR strong terms (Astro drops newline-only spaces)', () => {
     const work = sources.find((s) => s.path.endsWith('work.astro'))!.text;
     expect(work).toContain("{' '}<strong>IFS</strong>");

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -80,7 +80,7 @@ const schema = {
               <p class="where">IFS Cloud</p>
               <p>
                 The <a href="/work/ifs-design-system/">IFS Design System</a>: up to 2x faster
-                delivery, up to 30x ROI, Zeroheight runner-up.
+                delivery, up to 30x ROI, Zeroheight Design System Awards runner-up.
               </p>
             </li>
             <li>


### PR DESCRIPTION
clean cut of Jules #640 kernel (not a cherry-pick). Biography timeline only. No .Jules/content.md. Overlay frost 69ca717 stays. Hire LinkedIn.