### PR TITLE
fix: middot between What’s New and the pageview count

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -146,8 +146,12 @@ describe('identity copy', () => {
     expect(footer).toContain('class="colophon"');
     expect(footer).toContain("What's New");
     expect(footer).toContain('data-visit-stats hidden');
-    expect(footer.slice(footer.indexOf('data-visit-stats hidden'))).toContain(' · ');
     expect(footer).toContain("What's New</a><span");
+    // Space-middot-space as Astro text node so paint is What's New · N (survives Prettier).
+    expect(footer).toContain("{' · '}");
+    expect(footer.slice(footer.indexOf('data-visit-stats hidden'))).toContain("{' · '}");
+    // Fail the prior bug: newline/indent then middot (leading space collapsed in paint).
+    expect(footer).not.toMatch(/>\s*\n\s+·\s/);
     expect(footer).not.toMatch(/What's New<\/a>\s*·/);
     expect(cta).toContain('LinkedIn · replies from me');
   });

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -140,6 +140,18 @@ describe('identity copy', () => {
     expect(page).toContain('What you can see on this site lately.');
   });
 
+  it('puts a middot inside the hidden footer visit-stats span', () => {
+    const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    const cta = readFileSync('src/components/ContactCTA.astro', 'utf8');
+    expect(footer).toContain('class="colophon"');
+    expect(footer).toContain("What's New");
+    expect(footer).toContain('data-visit-stats hidden');
+    expect(footer.slice(footer.indexOf('data-visit-stats hidden'))).toContain(' · ');
+    expect(footer).toContain("What's New</a><span");
+    expect(footer).not.toMatch(/What's New<\/a>\s*·/);
+    expect(cta).toContain('LinkedIn · replies from me');
+  });
+
   it('drops Report an issue from the footer and keeps LinkedIn hire', () => {
     const footer = readFileSync('src/components/Footer.astro', 'utf8');
     expect(footer).not.toContain('Report an issue');

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -156,6 +156,16 @@ describe('identity copy', () => {
     expect(cta).toContain('LinkedIn · replies from me');
   });
 
+  it('keeps Footer .visit-stats display:inline only when not [hidden]', () => {
+    const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    expect(footer).toContain('.visit-stats:not([hidden])');
+    expect(footer).toContain('display: inline');
+    // Bare .visit-stats { display: inline } overrides UA [hidden]{display:none}.
+    expect(footer).not.toMatch(/\.visit-stats\s*\{\s*display:\s*inline/);
+    expect(footer).toContain("{' · '}");
+    expect(footer).toContain('https://www.linkedin.com/in/alehar/');
+  });
+
   it('drops Report an issue from the footer and keeps LinkedIn hire', () => {
     const footer = readFileSync('src/components/Footer.astro', 'utf8');
     expect(footer).not.toContain('Report an issue');

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -244,8 +244,11 @@ const currentYear = new Date().getFullYear();
     line-height: 1.5;
   }
 
-  .visit-stats {
+  .visit-stats:not([hidden]) {
     display: inline;
+  }
+
+  .visit-stats {
     color: inherit;
     font-size: inherit;
   }

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -17,9 +17,8 @@ const currentYear = new Date().getFullYear();
     </p>
     <p>&copy; {currentYear} Alexander Härenstam</p>
     <div class="colophon">
-      <a href="/whats-new/">What's New</a>
-      <span class="visit-stats" data-visit-stats hidden>
-        <button
+      <a href="/whats-new/">What's New</a><span class="visit-stats" data-visit-stats hidden>
+        · <button
           type="button"
           class="visit-trigger"
           data-visit-count

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -17,8 +17,8 @@ const currentYear = new Date().getFullYear();
     </p>
     <p>&copy; {currentYear} Alexander Härenstam</p>
     <div class="colophon">
-      <a href="/whats-new/">What's New</a><span class="visit-stats" data-visit-stats hidden>
-        · <button
+      <a href="/whats-new/">What's New</a><span class="visit-stats" data-visit-stats hidden
+        >{' · '}<button
           type="button"
           class="visit-trigger"
           data-visit-count


### PR DESCRIPTION
Footer .colophon only. Visible `What's New · 1905 pageviews`. Same middot as hire. No dangling middot when the count is hidden. Overlay frost 69ca717 stays. Hire LinkedIn. Did not restyle the count or move What’s New.