### PR TITLE
Janitor: Typo & Terminology Alignment

### DIFF
--- a/.Janitor/hygiene.md
+++ b/.Janitor/hygiene.md
@@ -6,6 +6,7 @@
 | 2025-03-24 | worker-configuration.d.ts         | Removed 'the the' typos from documentation comments                                      | Validated   |
 | 2025-03-24 | context/author-linkedin.md        | Normalized Swedish terms (Produktchef, Produktledning) and removed duplicate text blocks | Validated   |
 | 2025-03-24 | src/content/work/master-thesis.md | Improved grammatical phrasing in the concluding paragraph                                | Validated   |
+| 2025-03-31 | context/author-linkedin.md        | Removed duplicate word 'Posts posts' from LinkedIn export                                | Validated   |
 
 ## Spelling Exceptions
 

--- a/context/author-linkedin.md
+++ b/context/author-linkedin.md
@@ -140,7 +140,7 @@ Create a post
 Posts
 
 Comments
-Loaded 9 Posts posts
+Loaded 9 Posts
 View Alexander Härenstam’s graphic link
 Alexander Härenstam
 • YouVerified • You


### PR DESCRIPTION
Removed duplicate word 'Posts posts' in context/author-linkedin.md and documented the fix in .Janitor/hygiene.md. All tests, linter checks, and builds pass.

---
*PR created automatically by Jules for task [15664907689616855458](https://jules.google.com/task/15664907689616855458) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the activity heading to remove the duplicated “Posts” wording.
  * The heading now displays as “Loaded 9 Posts.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->