### PR TITLE
fix: drop the duplicate “posts” in LinkedIn context

### DIFF
--- a/context/author-linkedin.md
+++ b/context/author-linkedin.md
@@ -140,7 +140,7 @@ Create a post
 Posts
 
 Comments
-Loaded 9 Posts posts
+Loaded 9 Posts
 View Alexander Härenstam’s graphic link
 Alexander Härenstam
 • YouVerified • You


### PR DESCRIPTION
Clean cut. context/author-linkedin.md only. No .Janitor journal. Overlay frost 69ca717 stays. Hire LinkedIn.