### PR TITLE
Palette: Improve focus accessibility on Skills cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -47,3 +47,9 @@
 **Learning:** To optimize Largest Contentful Paint (LCP) in Astro projects, primary visual assets (like hero images) and the first items in repeated galleries should be prioritised by the browser. Applying `loading="eager"` and `fetchpriority="high"` to these elements prevents the browser from delaying their loading, ensuring a faster perceived performance for users.
 
 **Action:** Enhanced the `PortfolioPreview` component to support dynamic `loading` and `fetchpriority` props. Updated `index.astro` and `work.astro` to prioritise the first project in their respective galleries. Explicitly added `loading="eager"` to the primary portrait image on the home page.
+
+## 2026-05-20 - Synchronizing Focus Elevation and Link Focus Spatiality in Skills Cards
+
+**Learning:** When interactive elements (such as links) live inside composite container components (like `Skills.astro` cards), keyboard navigation can create a disconnect if only the focused link is styled while the surrounding parent container remains in a static state. Using `:focus-within` on the parent container ensures that focusing an internal link visually elevates the parent container in the exact same manner as hover, maintaining spatial predictability for keyboard users. Adding scoped `:focus-visible` styles with a standardized `outline-offset: 4px` to embedded links completes the focus affordance hierarchy.
+
+**Action:** Updated `src/components/Skills.astro` to include `:focus-within` on the card `.box` containers and added explicit `:focus-visible` styling with `outline-offset: 4px` for internal inline links.

--- a/src/components/Skills.astro
+++ b/src/components/Skills.astro
@@ -55,7 +55,8 @@ const flagsEntry = await getEntry('flags', 'config');
       border-color var(--theme-transition);
   }
 
-  .box:hover {
+  .box:hover,
+  .box:focus-within {
     transform: translateY(-4px);
     border-color: var(--accent-regular);
     box-shadow:
@@ -63,11 +64,18 @@ const flagsEntry = await getEntry('flags', 'config');
       var(--shadow-md);
   }
 
+  .skills a:focus-visible {
+    outline: 2px solid var(--accent-regular);
+    outline-offset: 4px;
+    border-radius: 0.25rem;
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .box {
       transition: none;
     }
-    .box:hover {
+    .box:hover,
+    .box:focus-within {
       transform: none;
     }
   }


### PR DESCRIPTION
Improves accessibility and focus spatiality in `Skills.astro` by adding `:focus-within` elevation to skill card containers and explicit `:focus-visible` styling with a 4px offset to nested links.

---
*PR created automatically by Jules for task [6648461399096950085](https://jules.google.com/task/6648461399096950085) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Skills cards now receive the same visual emphasis when navigated by keyboard focus as they do on hover.
  * Added clear focus outlines for links within Skills cards.
  * Reduced-motion settings now prevent animations during both hover and keyboard focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->