### PR TITLE
⚙️ Engine: Harden KV rate limiting and optimize message pruning

### DIFF
--- a/.jules/engine.md
+++ b/.jules/engine.md
@@ -1,5 +1,11 @@
 # ⚙️ Engine Journal
 
+## 2025-05-21 - Resilient KV Rate Limiting & Non-Mutating Message Windowing
+
+- **Architectural Shift:** Wrapped Cloudflare KV rate-limit counter `store.put` operations in `src/pages/api/chat.ts` inside a defensive `try/catch` block with structured `chat_api_kv_write_error` telemetry logging.
+- **Edge Resilience:** Transient KV storage write errors no longer trigger a 500 status response, allowing active AI text streams to return successfully to the client.
+- **TypeScript Optimization:** Refactored `pruneMessages` in `src/utils/chat-logic.ts` to use non-mutating index window slicing (`startIndex`), eliminating array shifting ($O(N)$ re-indexing) and non-null assertions while preserving exact pruning constraints.
+
 ## 2025-05-14 - Centralized Chat Logic & Pruning
 
 - **Architectural Shift:** Centralized chat-related constants and logic into `src/utils/chat-logic.ts` to ensure consistency between the API and potential future client-side pruning.

--- a/src/__tests__/chat-api.test.ts
+++ b/src/__tests__/chat-api.test.ts
@@ -617,6 +617,28 @@ describe('chat API', () => {
     expect(put).not.toHaveBeenCalled();
   });
 
+  it('gracefully logs telemetry and returns 200 stream when KV store write fails', async () => {
+    const ai = createAi();
+    const get = vi.fn().mockResolvedValue('1');
+    const put = vi.fn().mockRejectedValue(new Error('KV write timeout'));
+    const store = { get, put } as unknown as KVNamespace;
+    const env = { AI: ai, CHAT_STORE: store };
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const response = await POST(
+      createContext(createRequest({ messages: [{ role: 'user', content: 'Hello' }] }), env)
+    );
+
+    expect(response.status).toBe(200);
+    expect(ai.run).toHaveBeenCalled();
+    expect(put).toHaveBeenCalled();
+    const loggedKvError = consoleSpy.mock.calls.find(
+      (call) => call[0]?.event === 'chat_api_kv_write_error'
+    )?.[0];
+    expect(loggedKvError).toBeDefined();
+    expect(loggedKvError.error).toContain('KV write timeout');
+  });
+
   it('returns 429 and skips AI when the site-wide daily cap is reached', async () => {
     const ai = createAi();
     const get = vi.fn().mockImplementation(async (key: string) => {

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -187,10 +187,14 @@ export const POST: APIRoute = async ({ request }) => {
     if (store) {
       hourlyCount += 1;
       dailyCount += 1;
-      await Promise.all([
-        store.put(hourlyKey, hourlyCount.toString(), { expirationTtl: 3600 }),
-        store.put(dailyKey, dailyCount.toString(), dailyPutOptions()),
-      ]);
+      try {
+        await Promise.all([
+          store.put(hourlyKey, hourlyCount.toString(), { expirationTtl: 3600 }),
+          store.put(dailyKey, dailyCount.toString(), dailyPutOptions()),
+        ]);
+      } catch (kvError: unknown) {
+        console.error({ event: 'chat_api_kv_write_error', error: String(kvError) });
+      }
     }
 
     return new Response(stream, {

--- a/src/utils/chat-logic.ts
+++ b/src/utils/chat-logic.ts
@@ -33,15 +33,16 @@ export const ChatRequestSchema = z.object({
  * @returns A pruned array of messages that satisfies all constraints.
  */
 export function pruneMessages(messages: ChatMessage[]): ChatMessage[] {
-  const pruned = messages.slice(-MAX_MESSAGES);
-  let totalLength = pruned.reduce((acc, msg) => acc + msg.content.length, 0);
+  const recent = messages.slice(-MAX_MESSAGES);
+  let totalLength = recent.reduce((acc, msg) => acc + msg.content.length, 0);
+  let startIndex = 0;
 
-  while (pruned.length > 1 && totalLength > MAX_TOTAL_CONTENT_LENGTH) {
-    // biome-ignore lint/style/noNonNullAssertion: loop guard ensures shift() returns an element
-    totalLength -= pruned.shift()!.content.length;
+  while (recent.length - startIndex > 1 && totalLength > MAX_TOTAL_CONTENT_LENGTH) {
+    totalLength -= recent[startIndex].content.length;
+    startIndex += 1;
   }
 
-  return pruned;
+  return startIndex > 0 ? recent.slice(startIndex) : recent;
 }
 
 export const DESIGN_SYSTEM_CHIP = 'What did the IFS design system change?';


### PR DESCRIPTION
### Summary of Changes

1. **Edge KV Write Resilience (`src/pages/api/chat.ts`)**:
   - Wrapped rate-limit KV storage `store.put` operations inside a defensive `try/catch` block.
   - If writing to Cloudflare KV fails (e.g. KV write limit or transient network error), the API logs structured telemetry (`chat_api_kv_write_error`) and returns the 200 OK stream response cleanly to the user instead of returning a 500 error.

2. **Non-Mutating Message Windowing (`src/utils/chat-logic.ts`)**:
   - Refactored `pruneMessages` to use index window slicing (`startIndex`) rather than mutating array `shift()` operations.
   - Removed non-null assertions and array re-indexing while maintaining exact sliding window limits.

3. **Vitest Unit Test Coverage (`src/__tests__/chat-api.test.ts`)**:
   - Added unit test asserting that KV write failures log telemetry and return HTTP 200 stream responses without throwing.

4. **Journal Update (`.jules/engine.md`)**:
   - Updated `.jules/engine.md` documenting the edge resilience and sliding window optimization.

---
*PR created automatically by Jules for task [16087159799881727715](https://jules.google.com/task/16087159799881727715) started by @alehar9320*