### PR TITLE
Janitor: Typo & Terminology Alignment

### DIFF
--- a/.Janitor/hygiene.md
+++ b/.Janitor/hygiene.md
@@ -6,6 +6,8 @@
 | 2025-03-24 | worker-configuration.d.ts         | Removed 'the the' typos from documentation comments                                      | Validated   |
 | 2025-03-24 | context/author-linkedin.md        | Normalized Swedish terms (Produktchef, Produktledning) and removed duplicate text blocks | Validated   |
 | 2025-03-24 | src/content/work/master-thesis.md | Improved grammatical phrasing in the concluding paragraph                                | Validated   |
+| 2025-03-30 | worker-configuration.d.ts         | Removed 'the The' duplicate word typo in JSDoc comments                                  | Validated   |
+| 2025-03-30 | context/author-linkedin.md        | Added missing conjunction 'and' and normalized 'API:s' to 'APIs'                         | Validated   |
 
 ## Spelling Exceptions
 

--- a/context/author-linkedin.md
+++ b/context/author-linkedin.md
@@ -94,7 +94,7 @@ As a strategic thinker and problem solver, I excel in analyzing complex business
 
 Collaboration is at the heart of my approach. I firmly believe that the best outcomes are achieved through effective teamwork and cross-functional collaboration. With my strong interpersonal skills and ability to build relationships across diverse teams, I am adept at bringing stakeholders together to align visions, leverage expertise, and drive projects forward.
 
-In addition to my expertise in product management and business analysis, I possess a unique blend of creative and technical skills. With a background in software technology, I have a deep understanding of the intersection between product, design, technology. I leverage this knowledge to create compelling and user-centric digital solutions that captivate audiences and drive engagement.
+In addition to my expertise in product management and business analysis, I possess a unique blend of creative and technical skills. With a background in software technology, I have a deep understanding of the intersection between product, design, and technology. I leverage this knowledge to create compelling and user-centric digital solutions that captivate audiences and drive engagement.
 
 My commitment to continuous learning and adaptability allows me to thrive in dynamic environments. I am comfortable navigating ambiguity and embrace a fail-fast, learn-fast mentality. To stay on the right course, I also leverage data-driven insights to make informed decisions, ensuring that strategies are grounded in evidence and results.
 
@@ -309,7 +309,7 @@ Other contributors
 5
 Display OS
 Sep 2016 - Jan 2017
-Our vision is a future where we are more and more dependent upon information. Thus, we have created a platform that allows you to get all the information you need, in just a glance, right when you need it. No matter if it's displayed on your tv, your fridge or projected on your wall. This is all made possible by combining a user-friendly GUI with API:s from the world-wide web.
+Our vision is a future where we are more and more dependent upon information. Thus, we have created a platform that allows you to get all the information you need, in just a glance, right when you need it. No matter if it's displayed on your tv, your fridge or projected on your wall. This is all made possible by combining a user-friendly GUI with APIs from the world-wide web.
 Other contributors
 
 Show all 5 projects

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -1506,7 +1506,7 @@ interface ErrorEventErrorEventInit {
 declare class MessageEvent extends Event {
   constructor(type: string, initializer: MessageEventInit);
   /**
-   * The **`data`** read-only property of the The data sent by the message emitter; this can be any data type, depending on what originated this event.
+   * The **`data`** read-only property of the data sent by the message emitter; this can be any data type, depending on what originated this event.
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/data)
    */


### PR DESCRIPTION
Fixed JSDoc duplicate word typo in worker-configuration.d.ts, corrected missing conjunction and Swedish plural abbreviation in context/author-linkedin.md, and documented changes in .Janitor/hygiene.md.

---
*PR created automatically by Jules for task [14141946293102659521](https://jules.google.com/task/14141946293102659521) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved wording and corrected typos in the LinkedIn profile and project description.
  * Clarified documentation for message event data.
  * Added validated hygiene journal entries documenting the corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->