### PR TITLE
⚡ Bolt: lazy load chat avatar image in Chat.astro

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@ Action: Added fetchpriority="high" and decoding="async" to the hero images in sr
 2026-05-30 - Icon Payload Pruning
 Learning: Inlined SVG icons in Astro components contribute directly to the HTML payload size. Commenting out unused icons in a shared IconPaths configuration reduces the bytes served per page and the memory footprint of the Cloudflare Worker.
 Action: Commented out unused icons in src/components/IconPaths.ts and updated related tests. Use grep -r to periodically audit icon usage across the codebase.
+
+2026-06-01 - Chat Avatar Deferred Loading
+Learning: Offscreen assets rendered in floating widgets or drawer forms (such as the 250KB avatar image inside Chat.astro) can block critical network bandwidth if loaded eagerly on initial page load. Explicitly adding loading="lazy" and decoding="async" defers image fetching until the chat panel/form becomes visible or active.
+Action: Added loading="lazy" and decoding="async" to the portrait image tag in src/components/Chat.astro.

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -80,7 +80,16 @@
     <p id="chat-remaining" class="chat-remaining" aria-live="polite" hidden></p>
   </div>
   <form id="chat-form" class="chat-form">
-    <img src="/assets/portrait.png" alt="" class="chat-header-avatar" width="40" height="40" />
+    <!-- Lazy load avatar image to defer loading non-critical offscreen asset until chat interface is active -->
+    <img
+      src="/assets/portrait.png"
+      alt=""
+      class="chat-header-avatar"
+      width="40"
+      height="40"
+      loading="lazy"
+      decoding="async"
+    />
     <input type="text" id="chat-input" required autocomplete="off" />
     <button type="submit" aria-label="Send message">
       <svg


### PR DESCRIPTION
### What
Added `loading="lazy"` and `decoding="async"` attributes to the avatar image tag in `src/components/Chat.astro`.

### Why
The 250KB avatar image inside `Chat.astro` is an offscreen asset rendered inside the chat form panel. Loading it eagerly on page load consumes network bandwidth during initial render.

### Impact
Defers fetching and decoding of the 250KB avatar image until the chat interface is interacted with or displayed, reducing initial bandwidth consumption on initial page load.

### How to verify
Run `npm run test` and `npm run build`. Inspect `src/components/Chat.astro` to confirm `loading="lazy"` and `decoding="async"` are applied to the avatar `<img />` tag.

---
*PR created automatically by Jules for task [2765844935865397043](https://jules.google.com/task/2765844935865397043) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved chat loading performance by deferring the header avatar image until it is needed.
  * Enabled asynchronous image decoding to help the chat interface become responsive sooner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->