### PR TITLE
Content: Refresh timeline label in biography page

### DIFF
--- a/.Jules/content.md
+++ b/.Jules/content.md
@@ -1,0 +1,7 @@
+# Content Journal
+
+This journal tracks content updates, signals for stale content, and downscoping rationale for Alexander Härenstam's personal website.
+
+## Log
+
+2025-02-23 - [Biography Track] | Signal: [Stale] | Lean Update: Refreshed tenure timeline label in biography page from "Eight years at IFS" to "8+ years at IFS" to align with profile context.

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -75,7 +75,7 @@ const schema = {
               <p>I work on Developer Experience at IFS, including internal AI coding copilots.</p>
             </li>
             <li>
-              <p class="when">Eight years at IFS</p>
+              <p class="when">8+ years at IFS</p>
               <h3>Design systems, DevEx, and Industrial AI</h3>
               <p class="where">IFS Cloud</p>
               <p>


### PR DESCRIPTION
Refreshed stale timeline label on the biography page and logged the update in .Jules/content.md.

---
*PR created automatically by Jules for task [16321041487452268922](https://jules.google.com/task/16321041487452268922) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Updated the biography timeline label from “Eight years at IFS” to “8+ years at IFS.”
  * Added a content journal documenting this update and related content maintenance notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->