### PR TITLE
Janitor: Typo & Terminology Alignment

### DIFF
--- a/.Janitor/hygiene.md
+++ b/.Janitor/hygiene.md
@@ -6,6 +6,7 @@
 | 2025-03-24 | worker-configuration.d.ts         | Removed 'the the' typos from documentation comments                                      | Validated   |
 | 2025-03-24 | context/author-linkedin.md        | Normalized Swedish terms (Produktchef, Produktledning) and removed duplicate text blocks | Validated   |
 | 2025-03-24 | src/content/work/master-thesis.md | Improved grammatical phrasing in the concluding paragraph                                | Validated   |
+| 2025-03-24 | context/author-linkedin.md        | Fixed typos (We'll, paperwork, APIs, www.linkedin.com)                                   | Validated   |
 
 ## Spelling Exceptions
 

--- a/context/author-linkedin.md
+++ b/context/author-linkedin.md
@@ -67,7 +67,7 @@ Stand out to employers
 Enhance your profile, craft standout messages, and assess job fit with Premium.
 
 Try Premium for SEK 0
-1-month free trial. Cancel whenever. We’l remind you 7 days before your trial ends.
+1-month free trial. Cancel whenever. We'll remind you 7 days before your trial ends.
 
 Dismiss premium promotion
 
@@ -303,13 +303,13 @@ Lidköping Stenhuggeri App
 Sep 2013 - Present
 Chalmers University of Technology logo
 Associated with Chalmers University of Technology
-Developed an Android application for the company Lidköpings Stenhuggeri which is a masoning firm. The application's goal is to simplify the paper-work within the company.
+Developed an Android application for the company Lidköpings Stenhuggeri which is a masoning firm. The application's goal is to simplify the paperwork within the company.
 Other contributors
 
 5
 Display OS
 Sep 2016 - Jan 2017
-Our vision is a future where we are more and more dependent upon information. Thus, we have created a platform that allows you to get all the information you need, in just a glance, right when you need it. No matter if it's displayed on your tv, your fridge or projected on your wall. This is all made possible by combining a user-friendly GUI with API:s from the world-wide web.
+Our vision is a future where we are more and more dependent upon information. Thus, we have created a platform that allows you to get all the information you need, in just a glance, right when you need it. No matter if it's displayed on your tv, your fridge or projected on your wall. This is all made possible by combining a user-friendly GUI with APIs from the world-wide web.
 Other contributors
 
 Show all 5 projects
@@ -398,7 +398,7 @@ Profile language
 Svenska
 
 Public profile & URL
-ww.linkedin.com/in/alehar
+www.linkedin.com/in/alehar
 
 Who your viewers also viewed
 Private to you Private to you


### PR DESCRIPTION
This pull request applies isolated typo and terminology corrections to `context/author-linkedin.md` (correcting `We’l` -> `We'll`, `paper-work` -> `paperwork`, `API:s` -> `APIs`, and `ww.linkedin.com` -> `www.linkedin.com`) and updates the Janitor hygiene journal (`.Janitor/hygiene.md`). All tests, linting, formatting, type checking, and production builds pass cleanly.

---
*PR created automatically by Jules for task [7267043466816639495](https://jules.google.com/task/7267043466816639495) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected spelling, punctuation, and terminology in the LinkedIn profile text.
  * Fixed the public LinkedIn profile URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->