### PR TITLE
⚡ Bolt: lazy load chat avatar image

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@ Action: Added fetchpriority="high" and decoding="async" to the hero images in sr
 2026-05-30 - Icon Payload Pruning
 Learning: Inlined SVG icons in Astro components contribute directly to the HTML payload size. Commenting out unused icons in a shared IconPaths configuration reduces the bytes served per page and the memory footprint of the Cloudflare Worker.
 Action: Commented out unused icons in src/components/IconPaths.ts and updated related tests. Use grep -r to periodically audit icon usage across the codebase.
+
+2026-06-15 - Chat Avatar Image Lazy Loading
+Learning: Global layout components like the Chat widget contain images (e.g., the 253KB portrait PNG avatar) that are not needed on initial page load when the chat is hidden or closed. Adding loading="lazy" and decoding="async" defers image fetching until required and avoids main-thread decoding contention during initial page render.
+Action: Explicitly add loading="lazy" and decoding="async" to non-critical UI images embedded in global site components like Chat.astro.

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -80,7 +80,16 @@
     <p id="chat-remaining" class="chat-remaining" aria-live="polite" hidden></p>
   </div>
   <form id="chat-form" class="chat-form">
-    <img src="/assets/portrait.png" alt="" class="chat-header-avatar" width="40" height="40" />
+    <!-- ⚡ Bolt Optimization: loading="lazy" defers fetching the 253KB portrait PNG on page load when chat is closed, while decoding="async" prevents main thread decoding contention. -->
+    <img
+      src="/assets/portrait.png"
+      alt=""
+      class="chat-header-avatar"
+      width="40"
+      height="40"
+      loading="lazy"
+      decoding="async"
+    />
     <input type="text" id="chat-input" required autocomplete="off" />
     <button type="submit" aria-label="Send message">
       <svg


### PR DESCRIPTION
### What
Lazy load the 253KB portrait image (`/assets/portrait.png`) in `src/components/Chat.astro` using `loading="lazy"` and `decoding="async"`.

### Why
The Chat component is docked at the bottom of the page and its avatar image (`/assets/portrait.png`) was missing `loading="lazy"` and `decoding="async"`. Without lazy loading, the browser fetches and decodes this image immediately during initial page load, competing with critical assets and consuming main-thread CPU time.

### Impact
Defers 253KB image payload fetching and CPU decoding work off the initial critical rendering path on page load.

### How to verify
1. Run `npm run format:check` and `npm run lint`
2. Run `npm run test`
3. Run `npm run build`
4. Inspect `src/components/Chat.astro` to confirm `loading="lazy"` and `decoding="async"` are applied to `img[src="/assets/portrait.png"]`.

---
*PR created automatically by Jules for task [3113147199081176147](https://jules.google.com/task/3113147199081176147) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved Chat widget loading by deferring the header avatar image until needed.
  * Enabled asynchronous image decoding to reduce initial rendering work.
* **Documentation**
  * Documented the avatar image loading improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->