### PR TITLE
🎨 Palette: Standardize focus-visible rings for content links

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,5 +1,11 @@
 # Palette 🎨 - UX & Accessibility Journal
 
+## 2026-05-20 - Standardizing Focus-Visible Rings for Scoped Content Links
+
+**Learning:** Links embedded inside Markdown/content blocks (`.content :global(a)`) often retain browser default focus rings or raw `:focus` styles that trigger on mouse click and lack the signature 4px offset used across the site. Standardizing focus indicators via `:focus-visible` (`outline: 2px solid var(--accent-regular)`, `outline-offset: 4px`, `border-radius: 0.25rem`) provides a predictable, non-intrusive focus experience for keyboard users while eliminating sticky focus outlines on mouse clicks.
+
+**Action:** Replaced `:focus` pseudo-classes with `:focus-visible` for `.content :global(a)` in `biography.astro` and `work/[...slug].astro`, adding standard accent outlines and offsets.
+
 ## 2026-05-17 - Enhancing Content Selection and Standardizing Focus Spatiality
 
 **Learning:** Using `user-select: none` on informational badges (like `Pill`) creates unnecessary friction for users trying to copy text for reference. Additionally, consistent `outline-offset: 4px` across all interactive elements (including theme toggles and cards) reinforces a predictable spatial model for keyboard users. Adding `target="_blank"` with `rel="noopener noreferrer"` to external informational links (like the Astro framework link in the footer) ensures a non-disruptive navigation experience that preserves the user's session.

--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -170,8 +170,14 @@ const schema = {
   }
 
   .content :global(a:hover),
-  .content :global(a:focus) {
+  .content :global(a:focus-visible) {
     text-decoration-color: currentColor;
+  }
+
+  .content :global(a:focus-visible) {
+    outline: 2px solid var(--accent-regular);
+    outline-offset: 4px;
+    border-radius: 0.25rem;
   }
 
   @media (min-width: 50em) {

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -280,13 +280,14 @@ const robots = entry?.id === 'lidkoping-stenhuggeri' ? 'noindex' : undefined;
   }
 
   .back-link:hover,
-  .back-link:focus,
+  .back-link:focus-visible,
   .content :global(a:hover),
-  .content :global(a:focus) {
+  .content :global(a:focus-visible) {
     text-decoration-color: currentColor;
   }
 
-  .back-link:focus-visible {
+  .back-link:focus-visible,
+  .content :global(a:focus-visible) {
     outline: 2px solid var(--accent-regular);
     outline-offset: 4px;
     border-radius: 0.25rem;


### PR DESCRIPTION
Standardized focus-visible states for content links across Biography and Work case studies by applying `outline: 2px solid var(--accent-regular)` with `4px` offset and `0.25rem` border radius on `:focus-visible`. Also documented accessibility learnings in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [7419301366011178643](https://jules.google.com/task/7419301366011178643) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved keyboard navigation by adding clear focus indicators to links in biography and work content.
  * Focus outlines now use the site’s accent color, spacing, and rounded corners.
  * Focus styling appears specifically during keyboard navigation to reduce visual distractions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->