### PR TITLE
Content: Clean redundant duplicate summary in IFS Design System case

### DIFF
--- a/.Jules/content.md
+++ b/.Jules/content.md
@@ -1,0 +1,1 @@
+## 2026-03-29 - [Work Portfolio] | Signal: [Stale] | Lean Update: [Removed redundant duplicate summary sentence in ifs-design-system.md (<10% content delta)]

--- a/src/content/work/ifs-design-system.md
+++ b/src/content/work/ifs-design-system.md
@@ -37,6 +37,4 @@ The system now runs at IFS Cloud scale. Developers and designers use it to ship 
 - **Up to 30x ROI** on the initial investment
 - **Zeroheight Design System Awards** runner-up
 
-The system now runs at IFS Cloud scale. Developers and designers use it to ship a consistent experience across Cloud.
-
 <a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">Get in touch on LinkedIn</a>


### PR DESCRIPTION
Removed redundant trailing duplicate summary sentence in `src/content/work/ifs-design-system.md` (<10% content character delta) and logged the update in `.Jules/content.md`.

---
*PR created automatically by Jules for task [17387529948469841837](https://jules.google.com/task/17387529948469841837) started by @alehar9320*