### PR TITLE
Show unique visitors and DoD/WoW/MoM/YoY in the footer colophon

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -166,6 +166,22 @@ describe('identity copy', () => {
     expect(footer).toContain('https://www.linkedin.com/in/alehar/');
   });
 
+  it('leads the colophon visit trigger with unique visitors and names PostHog', () => {
+    const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    expect(footer).toContain('formatColophonVisits');
+    expect(footer).toContain('POSTHOG_SOURCE_TITLE');
+    expect(footer).toContain('POSTHOG_SOURCE_LABEL');
+    expect(footer).toContain('shouldShowVisitCount(row.uniqueVisitors)');
+    expect(footer).not.toContain('formatPageviewCount(data.pageviews)');
+    expect(footer).not.toContain('white-space: nowrap');
+    expect(footer).toContain('.visit-stats:not([hidden])');
+    expect(footer).toContain("{' · '}");
+    expect(footer).toContain('https://www.linkedin.com/in/alehar/');
+    expect(footer).not.toContain('mailto:');
+    expect(footer).toContain('class="colophon"');
+    expect(footer.match(/class="group"/g)?.length).toBe(1);
+  });
+
   it('drops Report an issue from the footer and keeps LinkedIn hire', () => {
     const footer = readFileSync('src/components/Footer.astro', 'utf8');
     expect(footer).not.toContain('Report an issue');

--- a/src/__tests__/visits-api.test.ts
+++ b/src/__tests__/visits-api.test.ts
@@ -16,13 +16,20 @@ describe('visits API', () => {
     delete bindings.POSTHOG_QUERY_HOST;
   });
 
-  it('uses one HogQL query for pageviews, uniques, first seen, and 7d splits', () => {
+  it('uses one HogQL query for uniques, first seen, 7d splits, and period comparisons', () => {
     expect(HOGQL.match(/SELECT/g)?.length).toBe(1);
     expect(HOGQL).toContain("event = '$pageview'");
     expect(HOGQL).toContain('unique_visitors');
     expect(HOGQL).toContain('first_seen');
     expect(HOGQL).toContain('pageviews_7d');
     expect(HOGQL).toContain('INTERVAL 7 DAY');
+    expect(HOGQL).toContain('unique_visitors_1d');
+    expect(HOGQL).toContain('unique_visitors_7d_prev');
+    expect(HOGQL).toContain('unique_visitors_30d');
+    expect(HOGQL).toContain('unique_visitors_365d');
+    expect(HOGQL).toContain('INTERVAL 1 DAY');
+    expect(HOGQL).toContain('INTERVAL 30 DAY');
+    expect(HOGQL).toContain('INTERVAL 365 DAY');
   });
 
   it('returns 204 when the PostHog key is missing', async () => {

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -42,8 +42,10 @@ const currentYear = new Date().getFullYear();
 
 <script>
   import {
-    formatPageviewCount,
+    formatColophonVisits,
     formatVisitGlance,
+    POSTHOG_SOURCE_LABEL,
+    POSTHOG_SOURCE_TITLE,
     shouldShowVisitCount,
     type VisitGlance,
   } from '../utils/visit-stats';
@@ -54,9 +56,9 @@ const currentYear = new Date().getFullYear();
     if (!data || typeof data !== 'object') return false;
     const row = data as VisitGlance;
     return (
-      shouldShowVisitCount(row.pageviews) &&
-      typeof row.uniqueVisitors === 'number' &&
-      Number.isFinite(row.uniqueVisitors) &&
+      shouldShowVisitCount(row.uniqueVisitors) &&
+      typeof row.pageviews === 'number' &&
+      Number.isFinite(row.pageviews) &&
       typeof row.firstSeen === 'string' &&
       Number.isFinite(row.pageviews7d) &&
       Number.isFinite(row.uniqueVisitors7d)
@@ -93,7 +95,9 @@ const currentYear = new Date().getFullYear();
         }
 
         const lines = formatVisitGlance(data);
-        trigger.textContent = formatPageviewCount(data.pageviews);
+        trigger.textContent = formatColophonVisits(data);
+        trigger.title = POSTHOG_SOURCE_TITLE;
+        trigger.setAttribute('aria-label', POSTHOG_SOURCE_LABEL);
         all.textContent = lines.all;
         last7d.textContent = lines.last7d;
         first.textContent = lines.firstSeen;
@@ -254,7 +258,7 @@ const currentYear = new Date().getFullYear();
   }
 
   .visit-trigger {
-    display: inline-block;
+    display: inline;
     appearance: none;
     -webkit-appearance: none;
     margin: 0;
@@ -265,7 +269,6 @@ const currentYear = new Date().getFullYear();
     color: var(--gray-400);
     cursor: pointer;
     touch-action: manipulation;
-    white-space: nowrap;
     text-underline-offset: 0.25em;
     text-decoration: 1px dotted underline transparent;
   }

--- a/src/pages/api/visits.ts
+++ b/src/pages/api/visits.ts
@@ -36,7 +36,14 @@ export const HOGQL = `SELECT
   uniq(distinct_id) AS unique_visitors,
   min(timestamp) AS first_seen,
   countIf(timestamp >= now() - INTERVAL 7 DAY) AS pageviews_7d,
-  uniqIf(distinct_id, timestamp >= now() - INTERVAL 7 DAY) AS unique_visitors_7d
+  uniqIf(distinct_id, timestamp >= now() - INTERVAL 7 DAY) AS unique_visitors_7d,
+  uniqIf(distinct_id, timestamp >= now() - INTERVAL 1 DAY) AS unique_visitors_1d,
+  uniqIf(distinct_id, timestamp >= now() - INTERVAL 2 DAY AND timestamp < now() - INTERVAL 1 DAY) AS unique_visitors_1d_prev,
+  uniqIf(distinct_id, timestamp >= now() - INTERVAL 14 DAY AND timestamp < now() - INTERVAL 7 DAY) AS unique_visitors_7d_prev,
+  uniqIf(distinct_id, timestamp >= now() - INTERVAL 30 DAY) AS unique_visitors_30d,
+  uniqIf(distinct_id, timestamp >= now() - INTERVAL 60 DAY AND timestamp < now() - INTERVAL 30 DAY) AS unique_visitors_30d_prev,
+  uniqIf(distinct_id, timestamp >= now() - INTERVAL 365 DAY) AS unique_visitors_365d,
+  uniqIf(distinct_id, timestamp >= now() - INTERVAL 730 DAY AND timestamp < now() - INTERVAL 365 DAY) AS unique_visitors_365d_prev
 FROM events
 WHERE event = '$pageview' AND timestamp >= toDateTime('1970-01-01 00:00:00')`;
 
@@ -114,7 +121,7 @@ export const GET: APIRoute = async () => {
       }
 
       const glance = parseVisitGlance(payload);
-      if (!glance || !shouldShowVisitCount(glance.pageviews)) {
+      if (!glance || !shouldShowVisitCount(glance.uniqueVisitors)) {
         console.error({ event: 'visits_count_hidden' });
         return empty204();
       }

--- a/src/utils/visit-stats.test.ts
+++ b/src/utils/visit-stats.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it } from 'vitest';
 import {
+  formatColophonVisits,
   formatPageviewCount,
+  formatUniqueVisitorCount,
   formatVisitGlance,
   parseVisitGlance,
   shouldShowVisitCount,
 } from './visit-stats';
+
+const emptyPeriods = {
+  uniqueVisitorsDoD: null,
+  uniqueVisitorsWoW: null,
+  uniqueVisitorsMoM: null,
+  uniqueVisitorsYoY: null,
+};
 
 describe('shouldShowVisitCount', () => {
   it('hides 0', () => {
@@ -42,6 +51,16 @@ describe('formatPageviewCount', () => {
   });
 });
 
+describe('formatUniqueVisitorCount', () => {
+  it('prefixes 1 with up to and uses singular', () => {
+    expect(formatUniqueVisitorCount(1)).toBe('up to 1 unique visitor');
+  });
+
+  it('prefixes 12 with up to and uses plural', () => {
+    expect(formatUniqueVisitorCount(12)).toBe('up to 12 unique visitors');
+  });
+});
+
 describe('parseVisitGlance', () => {
   it('reads a named object row', () => {
     const glance = parseVisitGlance({
@@ -60,6 +79,10 @@ describe('parseVisitGlance', () => {
     expect(glance?.pageviews7d).toBe(20);
     expect(glance?.uniqueVisitors7d).toBe(8);
     expect(glance?.firstSeen).toContain('2026-08-14');
+    expect(glance?.uniqueVisitorsDoD).toBeNull();
+    expect(glance?.uniqueVisitorsWoW).toBeNull();
+    expect(glance?.uniqueVisitorsMoM).toBeNull();
+    expect(glance?.uniqueVisitorsYoY).toBeNull();
   });
 
   it('reads a column-ordered array row', () => {
@@ -73,6 +96,7 @@ describe('parseVisitGlance', () => {
       firstSeen: '2026-08-14T07:03:00.000Z',
       pageviews7d: 20,
       uniqueVisitors7d: 8,
+      ...emptyPeriods,
     });
   });
 
@@ -95,7 +119,56 @@ describe('parseVisitGlance', () => {
       firstSeen: '2026-08-14T07:03:00.000Z',
       pageviews7d: 0,
       uniqueVisitors7d: 0,
+      ...emptyPeriods,
     });
+  });
+
+  it('computes DoD percent from unique visitors and omits a 0 previous', () => {
+    const withChange = parseVisitGlance({
+      results: [
+        {
+          pageviews: 94,
+          unique_visitors: 12,
+          first_seen: '2026-08-14T07:03:00.000Z',
+          pageviews_7d: 20,
+          unique_visitors_7d: 8,
+          unique_visitors_1d: 10,
+          unique_visitors_1d_prev: 8,
+        },
+      ],
+    });
+    expect(withChange?.uniqueVisitorsDoD).toBe(25);
+
+    const zeroPrev = parseVisitGlance({
+      results: [
+        {
+          pageviews: 94,
+          unique_visitors: 12,
+          first_seen: '2026-08-14T07:03:00.000Z',
+          pageviews_7d: 20,
+          unique_visitors_7d: 8,
+          unique_visitors_1d: 10,
+          unique_visitors_1d_prev: 0,
+        },
+      ],
+    });
+    expect(zeroPrev?.uniqueVisitorsDoD).toBeNull();
+  });
+
+  it('computes WoW from unique_visitors_7d vs unique_visitors_7d_prev', () => {
+    const glance = parseVisitGlance({
+      results: [
+        {
+          pageviews: 94,
+          unique_visitors: 12,
+          first_seen: '2026-08-14T07:03:00.000Z',
+          pageviews_7d: 20,
+          unique_visitors_7d: 8,
+          unique_visitors_7d_prev: 4,
+        },
+      ],
+    });
+    expect(glance?.uniqueVisitorsWoW).toBe(100);
   });
 });
 
@@ -106,6 +179,7 @@ describe('formatVisitGlance', () => {
     firstSeen: '2026-05-03T18:34:08.880Z',
     pageviews7d: 213,
     uniqueVisitors7d: 15,
+    ...emptyPeriods,
   };
 
   it('always includes first seen and last 7 days', () => {
@@ -121,5 +195,43 @@ describe('formatVisitGlance', () => {
   it('does not invent 7d numbers when they are zero', () => {
     const lines = formatVisitGlance({ ...glance, pageviews7d: 0, uniqueVisitors7d: 0 });
     expect(lines.last7d).toBe('No visits in the last 7 days');
+  });
+});
+
+describe('formatColophonVisits', () => {
+  const glance = {
+    pageviews: 94,
+    uniqueVisitors: 12,
+    firstSeen: '2026-08-14T07:03:00.000Z',
+    pageviews7d: 20,
+    uniqueVisitors7d: 8,
+    uniqueVisitorsDoD: 25,
+    uniqueVisitorsWoW: -10,
+    uniqueVisitorsMoM: null,
+    uniqueVisitorsYoY: 0,
+  };
+
+  it('leads with unique visitors and prefixes every hard figure with up to', () => {
+    expect(formatColophonVisits(glance)).toBe(
+      'up to 12 unique visitors · DoD up to +25% · WoW up to -10% · YoY up to 0%'
+    );
+  });
+
+  it('omits missing periods and does not invent 0', () => {
+    expect(
+      formatColophonVisits({
+        ...glance,
+        uniqueVisitorsDoD: null,
+        uniqueVisitorsWoW: null,
+        uniqueVisitorsMoM: null,
+        uniqueVisitorsYoY: null,
+      })
+    ).toBe('up to 12 unique visitors');
+  });
+
+  it('uses singular unique visitor for 1', () => {
+    expect(formatColophonVisits({ ...glance, uniqueVisitors: 1, uniqueVisitorsDoD: null, uniqueVisitorsWoW: null, uniqueVisitorsYoY: null })).toBe(
+      'up to 1 unique visitor'
+    );
   });
 });

--- a/src/utils/visit-stats.test.ts
+++ b/src/utils/visit-stats.test.ts
@@ -230,8 +230,14 @@ describe('formatColophonVisits', () => {
   });
 
   it('uses singular unique visitor for 1', () => {
-    expect(formatColophonVisits({ ...glance, uniqueVisitors: 1, uniqueVisitorsDoD: null, uniqueVisitorsWoW: null, uniqueVisitorsYoY: null })).toBe(
-      'up to 1 unique visitor'
-    );
+    expect(
+      formatColophonVisits({
+        ...glance,
+        uniqueVisitors: 1,
+        uniqueVisitorsDoD: null,
+        uniqueVisitorsWoW: null,
+        uniqueVisitorsYoY: null,
+      })
+    ).toBe('up to 1 unique visitor');
   });
 });

--- a/src/utils/visit-stats.ts
+++ b/src/utils/visit-stats.ts
@@ -4,7 +4,14 @@ export type VisitGlance = {
   firstSeen: string;
   pageviews7d: number;
   uniqueVisitors7d: number;
+  uniqueVisitorsDoD: number | null;
+  uniqueVisitorsWoW: number | null;
+  uniqueVisitorsMoM: number | null;
+  uniqueVisitorsYoY: number | null;
 };
+
+export const POSTHOG_SOURCE_LABEL = 'Unique visitors from PostHog (EU)';
+export const POSTHOG_SOURCE_TITLE = 'Source: PostHog, eu.posthog.com';
 
 export function shouldShowVisitCount(count: unknown): count is number {
   return typeof count === 'number' && Number.isFinite(count) && count > 0;
@@ -12,6 +19,10 @@ export function shouldShowVisitCount(count: unknown): count is number {
 
 export function formatPageviewCount(count: number): string {
   return `${count} pageview${count === 1 ? '' : 's'}`;
+}
+
+export function formatUniqueVisitorCount(count: number): string {
+  return `up to ${count} unique visitor${count === 1 ? '' : 's'}`;
 }
 
 function asFiniteNumber(raw: unknown): number | null {
@@ -40,15 +51,23 @@ function valueFromRow(
   key: string,
   index: number
 ): unknown {
-  if (Array.isArray(row)) return row[index];
-  if (row && typeof row === 'object' && key in row) {
+  if (row && typeof row === 'object' && !Array.isArray(row) && key in row) {
     return (row as Record<string, unknown>)[key];
   }
   if (Array.isArray(row) && columns) {
     const colIndex = columns.indexOf(key);
     if (colIndex >= 0) return row[colIndex];
   }
+  if (Array.isArray(row)) return row[index];
   return undefined;
+}
+
+function percentChange(current: number | null, previous: number | null): number | null {
+  if (current === null || previous === null) return null;
+  if (!Number.isFinite(current) || !Number.isFinite(previous)) return null;
+  if (previous <= 0) return null;
+  const pct = ((current - previous) / previous) * 100;
+  return Number.isFinite(pct) ? pct : null;
 }
 
 export function parseVisitGlance(payload: unknown): VisitGlance | null {
@@ -67,6 +86,17 @@ export function parseVisitGlance(payload: unknown): VisitGlance | null {
   const firstSeen = asIsoTimestamp(valueFromRow(row, columnNames, 'first_seen', 2));
   const pageviews7d = asFiniteNumber(valueFromRow(row, columnNames, 'pageviews_7d', 3));
   const uniqueVisitors7d = asFiniteNumber(valueFromRow(row, columnNames, 'unique_visitors_7d', 4));
+  const unique1d = asFiniteNumber(valueFromRow(row, columnNames, 'unique_visitors_1d', 5));
+  const unique1dPrev = asFiniteNumber(valueFromRow(row, columnNames, 'unique_visitors_1d_prev', 6));
+  const unique7dPrev = asFiniteNumber(valueFromRow(row, columnNames, 'unique_visitors_7d_prev', 7));
+  const unique30d = asFiniteNumber(valueFromRow(row, columnNames, 'unique_visitors_30d', 8));
+  const unique30dPrev = asFiniteNumber(
+    valueFromRow(row, columnNames, 'unique_visitors_30d_prev', 9)
+  );
+  const unique365d = asFiniteNumber(valueFromRow(row, columnNames, 'unique_visitors_365d', 10));
+  const unique365dPrev = asFiniteNumber(
+    valueFromRow(row, columnNames, 'unique_visitors_365d_prev', 11)
+  );
 
   if (
     pageviews === null ||
@@ -78,7 +108,17 @@ export function parseVisitGlance(payload: unknown): VisitGlance | null {
     return null;
   }
 
-  return { pageviews, uniqueVisitors, firstSeen, pageviews7d, uniqueVisitors7d };
+  return {
+    pageviews,
+    uniqueVisitors,
+    firstSeen,
+    pageviews7d,
+    uniqueVisitors7d,
+    uniqueVisitorsDoD: percentChange(unique1d, unique1dPrev),
+    uniqueVisitorsWoW: percentChange(uniqueVisitors7d, unique7dPrev),
+    uniqueVisitorsMoM: percentChange(unique30d, unique30dPrev),
+    uniqueVisitorsYoY: percentChange(unique365d, unique365dPrev),
+  };
 }
 
 export function formatFirstSeen(iso: string): string {
@@ -108,4 +148,26 @@ export function formatVisitGlance(glance: VisitGlance): {
     last7d,
     firstSeen: `First seen ${seen}`,
   };
+}
+
+export function formatSignedPercent(percent: number): string {
+  const rounded = Math.round(percent);
+  if (rounded === 0) return 'up to 0%';
+  const sign = rounded > 0 ? '+' : '';
+  return `up to ${sign}${rounded}%`;
+}
+
+export function formatColophonVisits(glance: VisitGlance): string {
+  const parts = [formatUniqueVisitorCount(glance.uniqueVisitors)];
+  const periods: Array<[string, number | null]> = [
+    ['DoD', glance.uniqueVisitorsDoD],
+    ['WoW', glance.uniqueVisitorsWoW],
+    ['MoM', glance.uniqueVisitorsMoM],
+    ['YoY', glance.uniqueVisitorsYoY],
+  ];
+  for (const [label, value] of periods) {
+    if (value === null || !Number.isFinite(value)) continue;
+    parts.push(`${label} ${formatSignedPercent(value)}`);
+  }
+  return parts.join(' · ');
 }


### PR DESCRIPTION
Closes #679

Lead the existing What's New colophon with unique visitors plus DoD/WoW/MoM/YoY. Prefix every hard figure with "up to". Hover/focus names PostHog (EU) as the source. Fail-open on 204 (span stays hidden, no dangling middot, #646 lock).

Parent: da09e2aff035a514067598c1527733355a26aaf9

Stay draft until Nick freeze SHA + hashed `*-me.alehar.workers.dev` preview. Overlay 69ca717 stays. Hire LinkedIn https://www.linkedin.com/in/alehar/. Satisfaction later. Stay off #597.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Footer visit statistics now highlight unique visitors with daily, weekly, monthly, and yearly comparisons.
  * Visit counts include clearer singular/plural formatting, percentage changes, and “up to” summaries when data is incomplete.
  * Visit statistics now include accessible labels and source information.

* **Bug Fixes**
  * Improved handling of missing, zero, and historical visit metrics.
  * Visit data visibility now reflects unique-visitor counts for more accurate reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->