### PR TITLE
docs: ADR 0001 Cloudflare prod, Render for Jules

### DIFF
--- a/docs/adr/0001-cloudflare-production-render-jules.md
+++ b/docs/adr/0001-cloudflare-production-render-jules.md
@@ -1,0 +1,18 @@
+# ADR 0001: Cloudflare as production, Render as Jules test env
+
+- Status: Accepted
+- Date: 2026-08-24
+
+## Context
+
+The site can build two ways: Cloudflare Workers (static + `@astrojs/cloudflare`) or a Node standalone server when `RENDER=true` (`@astrojs/node`). Prod already runs at https://me.alehar.workers.dev/. We need a clear split so Google Jules can debug against a Node environment without treating that path as a second production or failover.
+
+## Decision
+
+Production is Cloudflare Workers only. Render is a test environment for Google Jules (Node server via `render.yaml`). It is not a second prod and not a failover.
+
+## Consequences
+
+- Ship and operate prod on the Cloudflare Worker (`wrangler.jsonc`, `src/cloudflare-worker.ts`).
+- Keep the Render Node path for Jules debugging only; expect AI/KV and other Workers bindings to be absent or stubbed there (`src/env/cloudflare-workers.node.ts`).
+- Docs and ops language should call Cloudflare production and Render the Jules test env.


### PR DESCRIPTION
Production is Cloudflare Workers only (https://me.alehar.workers.dev/). Render remains a Node test environment so Google Jules can debug — not a second prod and not a failover.

This ADR records that split and the consequences for ops and the Render stub env.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an architecture decision record documenting the split between the production and testing environments.
  * Clarified deployment responsibilities and platform-specific runtime considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->