### PR TITLE
Make phone talking a full-page chat and flatten the first view

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -605,6 +605,37 @@ describe('identity copy', () => {
     expect(chat).not.toContain('data-hire-surface');
   });
 
+  it('makes phone talking a full-page chat and keeps desktop stage locks', () => {
+    const chat = readFileSync('src/components/Chat.astro', 'utf8');
+    const home = readFileSync('src/pages/index.astro', 'utf8');
+    expect(chat).toContain('@media (max-width: 49.99em)');
+    expect(chat).toContain('Phone talking = full page');
+    expect(chat).toContain('height: 100dvh');
+    expect(chat).toContain('padding-top: 0');
+    expect(chat).toContain('max-height: none');
+    expect(chat).toContain('border-radius: 0');
+    expect(chat).toContain('background-color: var(--gray-999)');
+    expect(chat).toContain('.chat-container.is-prominent .chat-header');
+    expect(chat).toContain('display: block');
+    expect(chat).toContain(':global(body.has-prominent-chat)');
+    expect(chat).toContain(':global(body:has(.chat-container.is-open))');
+    expect(chat).toContain('overflow: hidden');
+    // Desktop locks stay in source for ≥50em / identity keep-list.
+    expect(chat).toContain('max-height: 36dvh');
+    expect(chat).toContain('width: min(52rem, calc(100vw - 3rem))');
+    expect(chat).toContain('border-radius: 1rem 1rem 0 0');
+    expect(chat).not.toContain('height: 62dvh');
+    expect(chat).not.toContain('Get in touch');
+    expect(chat).toContain('/assets/portrait.png');
+    expect((chat.match(/class="chat-header-avatar"/g) || []).length).toBe(1);
+    expect(home).toContain('padding-bottom: 36dvh');
+    expect(home).toContain('padding-bottom: 0');
+    expect(home).toContain('https://www.linkedin.com/in/alehar/');
+    expect(home).toContain('Get in touch');
+    expect(home).toContain('Hero title="Product Manager, Developer Experience at IFS"');
+    expect(home).not.toContain('mailto:');
+  });
+
   it('docks the open sheet to a compact bottom bar on scroll, not a FAB or right column', () => {
     const chat = readFileSync('src/components/Chat.astro', 'utf8');
     const home = readFileSync('src/pages/index.astro', 'utf8');

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -119,7 +119,12 @@
 
   .chat-container.is-open:not(.is-prominent) {
     inset: 0;
-    padding-top: 5rem;
+  }
+
+  @media (min-width: 50em) {
+    .chat-container.is-open:not(.is-prominent) {
+      padding-top: 5rem;
+    }
   }
 
   .chat-container.is-prominent {
@@ -329,6 +334,56 @@
     .chat-window,
     .chat-form {
       width: 100%;
+    }
+
+    /* Phone talking = full page, not a padded rounded sheet over the site. */
+    .chat-container.is-open:not(.is-prominent),
+    .chat-container.is-prominent {
+      inset: 0;
+      padding-top: 0;
+      max-height: none;
+      height: 100%;
+      height: 100dvh;
+      justify-content: stretch;
+    }
+
+    .chat-container.is-open:not(.is-prominent) .chat-window,
+    .chat-container.is-prominent .chat-window {
+      flex: 1 1 auto;
+      height: auto;
+      min-height: 0;
+      border-radius: 0;
+      border: 0;
+      box-shadow: none;
+      background-color: var(--gray-999);
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+    }
+
+    .chat-container.is-open .chat-form,
+    .chat-container.is-prominent .chat-form {
+      border-radius: 0;
+      border-left: 0;
+      border-right: 0;
+      box-shadow: none;
+      background-color: var(--gray-999);
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+    }
+
+    /* Collapse control stays visible on phone fullscreen. */
+    .chat-container.is-prominent .chat-header {
+      display: block;
+    }
+
+    .chat-container.is-open .chat-grab,
+    .chat-container.is-prominent .chat-grab {
+      display: none;
+    }
+
+    :global(body.has-prominent-chat),
+    :global(body:has(.chat-container.is-open)) {
+      overflow: hidden;
     }
   }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -242,6 +242,7 @@ const schema = {
 
   @media (max-width: 49.99em) {
     :global(body.has-prominent-chat) .first-screen {
+      padding-bottom: 0;
       gap: 0.75rem;
     }
     :global(body.has-prominent-chat) .hero-copy {


### PR DESCRIPTION
Closes #683

Phone (375 first): talking is fullscreen chat, not a padded rounded sheet over aurora + H1 + colophon. Collapse docks to browse. Expand returns to fullscreen. First impression stays who he is (H1 Product Manager, Developer Experience at IFS) and LinkedIn Get in touch.

Desktop ~1280: composer at the bottom, `min(52rem, calc(100vw - 3rem))`, no 62dvh island, no right column. Overlay 69ca717 stays. Hire LinkedIn. One portrait. Do not clone Get in touch into the panel.

Parent: 5eca29f22923a2183a829e53605c20c619683dd3

Stay draft until Nick freeze SHA + hashed `*-me.alehar.workers.dev` preview. Stay off #684, #597, JSON-LD #612–#615.