### PR TITLE
Shorten the colophon visit line and spell out DoD/WoW/MoM/YoY

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -169,8 +169,8 @@ describe('identity copy', () => {
   it('leads the colophon visit trigger with unique visitors and names PostHog', () => {
     const footer = readFileSync('src/components/Footer.astro', 'utf8');
     expect(footer).toContain('formatColophonVisits');
-    expect(footer).toContain('POSTHOG_SOURCE_TITLE');
-    expect(footer).toContain('POSTHOG_SOURCE_LABEL');
+    expect(footer).toContain('formatColophonVisitsTitle');
+    expect(footer).toContain("trigger.addEventListener('focus'");
     expect(footer).toContain('shouldShowVisitCount(row.uniqueVisitors)');
     expect(footer).not.toContain('formatPageviewCount(data.pageviews)');
     expect(footer).not.toContain('white-space: nowrap');

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -43,9 +43,7 @@ const currentYear = new Date().getFullYear();
 <script>
   import {
     formatColophonVisits,
-    formatVisitGlance,
-    POSTHOG_SOURCE_LABEL,
-    POSTHOG_SOURCE_TITLE,
+    formatColophonVisitsTitle,
     shouldShowVisitCount,
     type VisitGlance,
   } from '../utils/visit-stats';
@@ -94,13 +92,13 @@ const currentYear = new Date().getFullYear();
           return;
         }
 
-        const lines = formatVisitGlance(data);
+        const title = formatColophonVisitsTitle(data);
         trigger.textContent = formatColophonVisits(data);
-        trigger.title = POSTHOG_SOURCE_TITLE;
-        trigger.setAttribute('aria-label', POSTHOG_SOURCE_LABEL);
-        all.textContent = lines.all;
-        last7d.textContent = lines.last7d;
-        first.textContent = lines.firstSeen;
+        trigger.title = title;
+        trigger.setAttribute('aria-label', title);
+        all.textContent = title;
+        last7d.textContent = '';
+        first.textContent = '';
         visitStats.hidden = false;
         document.body.append(panel);
 
@@ -134,6 +132,14 @@ const currentYear = new Date().getFullYear();
           setOpen(panel.hidden);
         });
 
+        trigger.addEventListener('focus', () => {
+          setOpen(true);
+        });
+        trigger.addEventListener('blur', (event) => {
+          const next = event.relatedTarget;
+          if (next instanceof Node && (trigger.contains(next) || panel.contains(next))) return;
+          setOpen(false);
+        });
         trigger.addEventListener('pointerenter', (event) => {
           if (event.pointerType !== 'mouse') return;
           openedByHover = true;

--- a/src/utils/visit-stats.test.ts
+++ b/src/utils/visit-stats.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   formatColophonVisits,
+  formatColophonVisitsTitle,
   formatPageviewCount,
   formatUniqueVisitorCount,
   formatVisitGlance,
@@ -211,9 +212,9 @@ describe('formatColophonVisits', () => {
     uniqueVisitorsYoY: 0,
   };
 
-  it('leads with unique visitors and prefixes every hard figure with up to', () => {
+  it('leads with unique visitors and does not repeat up to on every token', () => {
     expect(formatColophonVisits(glance)).toBe(
-      'up to 12 unique visitors · DoD up to +25% · WoW up to -10% · YoY up to 0%'
+      'up to 12 unique visitors · DoD +25% · WoW -10% · YoY 0%'
     );
   });
 
@@ -239,5 +240,25 @@ describe('formatColophonVisits', () => {
         uniqueVisitorsYoY: null,
       })
     ).toBe('up to 1 unique visitor');
+  });
+});
+
+describe('formatColophonVisitsTitle', () => {
+  const glance = {
+    pageviews: 94,
+    uniqueVisitors: 12,
+    firstSeen: '2026-08-14T07:03:00.000Z',
+    pageviews7d: 20,
+    uniqueVisitors7d: 8,
+    uniqueVisitorsDoD: 25,
+    uniqueVisitorsWoW: -10,
+    uniqueVisitorsMoM: null,
+    uniqueVisitorsYoY: 0,
+  };
+
+  it('spells out DoD/WoW/MoM/YoY and names PostHog EU without inventing missing periods', () => {
+    expect(formatColophonVisitsTitle(glance)).toBe(
+      'up to 12 unique visitors. DoD day over day +25%. WoW week over week -10%. YoY year over year 0%. Source: PostHog, eu.posthog.com'
+    );
   });
 });

--- a/src/utils/visit-stats.ts
+++ b/src/utils/visit-stats.ts
@@ -152,14 +152,21 @@ export function formatVisitGlance(glance: VisitGlance): {
 
 export function formatSignedPercent(percent: number): string {
   const rounded = Math.round(percent);
-  if (rounded === 0) return 'up to 0%';
+  if (rounded === 0) return '0%';
   const sign = rounded > 0 ? '+' : '';
-  return `up to ${sign}${rounded}%`;
+  return `${sign}${rounded}%`;
 }
+
+export const PERIOD_WORDS = {
+  DoD: 'day over day',
+  WoW: 'week over week',
+  MoM: 'month over month',
+  YoY: 'year over year',
+} as const;
 
 export function formatColophonVisits(glance: VisitGlance): string {
   const parts = [formatUniqueVisitorCount(glance.uniqueVisitors)];
-  const periods: Array<[string, number | null]> = [
+  const periods: Array<[keyof typeof PERIOD_WORDS, number | null]> = [
     ['DoD', glance.uniqueVisitorsDoD],
     ['WoW', glance.uniqueVisitorsWoW],
     ['MoM', glance.uniqueVisitorsMoM],
@@ -170,4 +177,20 @@ export function formatColophonVisits(glance: VisitGlance): string {
     parts.push(`${label} ${formatSignedPercent(value)}`);
   }
   return parts.join(' · ');
+}
+
+export function formatColophonVisitsTitle(glance: VisitGlance): string {
+  const parts = [formatUniqueVisitorCount(glance.uniqueVisitors)];
+  const periods: Array<[keyof typeof PERIOD_WORDS, number | null]> = [
+    ['DoD', glance.uniqueVisitorsDoD],
+    ['WoW', glance.uniqueVisitorsWoW],
+    ['MoM', glance.uniqueVisitorsMoM],
+    ['YoY', glance.uniqueVisitorsYoY],
+  ];
+  for (const [label, value] of periods) {
+    if (value === null || !Number.isFinite(value)) continue;
+    parts.push(`${label} ${PERIOD_WORDS[label]} ${formatSignedPercent(value)}`);
+  }
+  parts.push(POSTHOG_SOURCE_TITLE);
+  return parts.join('. ');
 }


### PR DESCRIPTION
Closes #684

Shorter visible colophon: unique visitors still lead, one `up to`, then `DoD +600% · WoW +32%` without repeating `up to`. Hover and keyboard focus spell out day over day / week over week / month over month / year over year and name PostHog EU (`eu.posthog.com`). Fail-open #646 stays. One `.group` row. API math unchanged.

Parent: 0293fed1b50a4840a8930a05769675585f5d01b1

Stay draft. Overlay 69ca717 stays. Hire LinkedIn. Stay off #687.