### PR TITLE
Positioning: current DevEx role stays true, adjacent hireable pictures

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -103,7 +103,7 @@ describe('identity copy', () => {
     expect(home).toContain('not only DevEx');
     expect(home).toContain('Chalmers software engineering');
     expect(home).toContain('MEI');
-    expect(home).toContain('eight years at IFS');
+    expect(home.replace(/\s+/g, ' ')).toContain('eight years at IFS');
     expect(home).toContain('IFS Design System');
     expect(home).toContain('copilots, analytics, and thesis');
     expect(home).toContain('https://www.linkedin.com/in/alehar/');

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -93,6 +93,29 @@ describe('identity copy', () => {
     expect(cta).not.toContain('high-impact');
   });
 
+  it('keeps the current DevEx role true and names adjacent hireable pictures in visitor language', () => {
+    const home = readFileSync('src/pages/index.astro', 'utf8');
+    expect(home).toContain('Hero title="Product Manager, Developer Experience at IFS"');
+    expect(home).toContain('class="hero-dek"');
+    expect(home).toContain('developer platforms');
+    expect(home).toContain('design systems');
+    expect(home).toContain('Industrial AI copilots');
+    expect(home).toContain('not only DevEx');
+    expect(home).toContain('Chalmers software engineering');
+    expect(home).toContain('MEI');
+    expect(home).toContain('eight years at IFS');
+    expect(home).toContain('IFS Design System');
+    expect(home).toContain('copilots, analytics, and thesis');
+    expect(home).toContain('https://www.linkedin.com/in/alehar/');
+    expect(home).toContain('Get in touch');
+    expect(home).not.toContain('mailto:');
+    expect(home).not.toMatch(/\bVP\b/);
+    expect(home).not.toContain('Head of');
+    expect(home).not.toContain('Director');
+    expect((home.match(/class="proof-card"/g) || []).length).toBe(1);
+    expect((home.match(/class="hero-dek"/g) || []).length).toBe(1);
+  });
+
   it('keeps the chat FAB off Earlier work and the biography timeline on a phone', () => {
     const work = readFileSync('src/pages/work.astro', 'utf8');
     const bio = readFileSync('src/pages/biography.astro', 'utf8');

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -72,6 +72,12 @@ const schema = {
     <header class="hero">
       <div class="hero-copy">
         <Hero title="Product Manager, Developer Experience at IFS" align="start">
+          <p class="hero-dek">
+            Also hireable for product work across developer platforms, design systems, and
+            Industrial AI copilots, not only DevEx. Chalmers software engineering and MEI,
+            eight years at IFS, the IFS Design System, plus copilots, analytics, and thesis
+            work.
+          </p>
           <div class="hero-actions">
             <CallToAction
               href={linkedinHref}
@@ -128,6 +134,15 @@ const schema = {
     flex-direction: column;
     gap: 1.25rem;
     width: 100%;
+  }
+
+  .hero-dek {
+    margin: 0;
+    max-width: 42ch;
+    font-size: var(--text-sm);
+    font-weight: 400;
+    color: var(--gray-200);
+    line-height: 1.45;
   }
 
   .hero-actions {
@@ -228,6 +243,10 @@ const schema = {
     .hero-actions {
       justify-content: flex-start;
       align-items: flex-start;
+    }
+
+    .hero-dek {
+      max-width: 48ch;
     }
 
     .proof-card {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -74,9 +74,8 @@ const schema = {
         <Hero title="Product Manager, Developer Experience at IFS" align="start">
           <p class="hero-dek">
             Also hireable for product work across developer platforms, design systems, and
-            Industrial AI copilots, not only DevEx. Chalmers software engineering and MEI,
-            eight years at IFS, the IFS Design System, plus copilots, analytics, and thesis
-            work.
+            Industrial AI copilots, not only DevEx. Chalmers software engineering and MEI, eight
+            years at IFS, the IFS Design System, plus copilots, analytics, and thesis work.
           </p>
           <div class="hero-actions">
             <CallToAction


### PR DESCRIPTION
Closes #690.

Home hero keeps H1 `Product Manager, Developer Experience at IFS`. One supporting dek (not chips, not a card stack) names the four adjacent hireable pictures in visitor language: product work, developer platforms, design systems, Industrial AI copilots. Bridge uses only published proof (Chalmers SE, MEI, eight years at IFS, IFS Design System, copilots / analytics / thesis).

Stay draft. Overlay `69ca717` stays. Hire LinkedIn https://www.linkedin.com/in/alehar/. Stay off #687 and #691. Do not merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a hero-section message highlighting availability for product work across developer platforms, design systems, and Industrial AI copilots.
  - Added responsive styling to improve presentation across screen sizes.

- **Tests**
  - Added coverage verifying the homepage displays the current role, hiring context, experience highlights, proof content, and LinkedIn contact details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->