### PR TITLE
Visitor roadmap: remaining flatter first view

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -163,19 +163,53 @@ describe('identity copy', () => {
     expect(page).toContain('What you can see on this site lately.');
   });
 
+  it('ships /roadmap/ with the remaining flatter-first-view upcoming row', () => {
+    expect(existsSync('src/pages/roadmap.astro')).toBe(true);
+    const page = readFileSync('src/pages/roadmap.astro', 'utf8');
+    const home = readFileSync('src/pages/index.astro', 'utf8');
+    const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    const whatsNew = readFileSync('src/pages/whats-new.astro', 'utf8');
+    expect(page).toContain('Hero title="Upcoming"');
+    expect(page).toContain('Product Manager, Developer Experience at IFS');
+    expect(page).toContain('Flatter first view. Boxes only for affordance or grouping.');
+    expect(page).toContain("throw new Error('Roadmap would ship empty.')");
+    expect(page).toContain('ContactCTA');
+    expect(readFileSync('src/components/ContactCTA.astro', 'utf8')).toContain(
+      'https://www.linkedin.com/in/alehar/'
+    );
+    expect(page).not.toContain('mailto:');
+    expect(page).not.toMatch(/\bVP\b/);
+    expect(page).not.toContain('Head of');
+    expect(page).not.toContain('Director');
+    expect(page).not.toContain('#687');
+    expect(page).not.toContain('full-screen');
+    expect(page).not.toContain('fullscreen');
+    expect(page).not.toContain('visit count');
+    expect(page).not.toContain('DoD');
+    expect(home).toContain('class="hero-dek"');
+    expect(home).toContain('Hero title="Product Manager, Developer Experience at IFS"');
+    expect(footer).toContain('href="/roadmap/"');
+    expect(footer).toContain('href="/whats-new/"');
+    expect(whatsNew).toContain('What you can see on this site lately.');
+    expect(whatsNew).not.toContain('href="/roadmap/"');
+  });
+
   it('puts a middot inside the hidden footer visit-stats span', () => {
     const footer = readFileSync('src/components/Footer.astro', 'utf8');
     const cta = readFileSync('src/components/ContactCTA.astro', 'utf8');
     expect(footer).toContain('class="colophon"');
     expect(footer).toContain("What's New");
-    expect(footer).toContain('data-visit-stats hidden');
-    expect(footer).toContain("What's New</a><span");
-    // Space-middot-space as Astro text node so paint is What's New · N (survives Prettier).
+    expect(footer).toContain('data-visit-stats');
+    expect(footer).toContain('hidden');
+    expect(footer).toContain('href="/roadmap/"');
+    expect(footer).toContain('Upcoming');
+    expect(footer).toContain("What's New</a>{' · '}");
+    expect(footer).toContain('href="/roadmap/"');
+    // Space-middot-space as Astro text node so paint is What's New · Upcoming · N (survives Prettier).
     expect(footer).toContain("{' · '}");
-    expect(footer.slice(footer.indexOf('data-visit-stats hidden'))).toContain("{' · '}");
+    expect(footer.slice(footer.indexOf('data-visit-stats'))).toContain("{' · '}");
     // Fail the prior bug: newline/indent then middot (leading space collapsed in paint).
     expect(footer).not.toMatch(/>\s*\n\s+·\s/);
-    expect(footer).not.toMatch(/What's New<\/a>\s*·/);
     expect(cta).toContain('LinkedIn · replies from me');
   });
 
@@ -1767,6 +1801,7 @@ describe('identity copy', () => {
     expect(sitemap).toContain("'/work/'");
     expect(sitemap).toContain("'/biography/'");
     expect(sitemap).toContain("'/contact/'");
+    expect(sitemap).toContain("'/roadmap/'");
     expect(sitemap).toContain('ifs-design-system');
     expect(sitemap).not.toContain('/experimental/manifesto');
     expect(sitemap).not.toContain('/experimental/now');

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -17,7 +17,10 @@ const currentYear = new Date().getFullYear();
     </p>
     <p>&copy; {currentYear} Alexander Härenstam</p>
     <div class="colophon">
-      <a href="/whats-new/">What's New</a><span class="visit-stats" data-visit-stats hidden
+      <a href="/whats-new/">What's New</a>{' · '}<a href="/roadmap/">Upcoming</a><span
+        class="visit-stats"
+        data-visit-stats
+        hidden
         >{' · '}<button
           type="button"
           class="visit-trigger"

--- a/src/pages/roadmap.astro
+++ b/src/pages/roadmap.astro
@@ -1,0 +1,94 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import ContactCTA from '../components/ContactCTA.astro';
+import Hero from '../components/Hero.astro';
+
+const dek = 'What is coming next on this site.';
+const pageTitle = 'Upcoming | Product Manager, Developer Experience at IFS';
+
+const upcoming = ['Flatter first view. Boxes only for affordance or grouping.'] as const;
+
+if (upcoming.length === 0) {
+  throw new Error('Roadmap would ship empty.');
+}
+
+const schema = {
+  '@context': 'https://schema.org',
+  '@graph': [
+    {
+      '@type': 'WebPage',
+      '@id': 'https://me.alehar.workers.dev/roadmap/#webpage',
+      url: 'https://me.alehar.workers.dev/roadmap/',
+      name: pageTitle,
+      description: dek,
+      breadcrumb: {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            name: 'Home',
+            item: 'https://me.alehar.workers.dev/',
+          },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: 'Upcoming',
+            item: 'https://me.alehar.workers.dev/roadmap/',
+          },
+        ],
+      },
+      publisher: {
+        '@type': 'Person',
+        '@id': 'https://me.alehar.workers.dev/#person',
+        name: 'Alexander Härenstam',
+      },
+    },
+  ],
+};
+---
+
+<BaseLayout
+  title={pageTitle}
+  ogTitle={pageTitle}
+  description={`${dek} Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.`}
+>
+  <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
+  <div class="stack gap-20">
+    <main id="main-content" class="upcoming-page stack gap-8">
+      <Hero title="Upcoming" tagline={dek} align="start" />
+      <ul class="upcoming-list">
+        {upcoming.map((line) => <li>{line}</li>)}
+      </ul>
+    </main>
+    <ContactCTA />
+  </div>
+</BaseLayout>
+
+<style>
+  .upcoming-page {
+    width: min(52rem, calc(100vw - 3rem));
+    margin-inline: auto;
+    padding-bottom: var(--chat-fab-clearance);
+  }
+
+  .upcoming-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    color: var(--gray-200);
+    font-size: var(--text-lg);
+    line-height: 1.5;
+    max-width: 42ch;
+  }
+
+  .upcoming-list li {
+    margin: 0;
+  }
+
+  @media (min-width: 50em) {
+    .upcoming-page {
+      padding-bottom: 0;
+    }
+  }
+</style>

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -5,7 +5,7 @@ export const prerender = true;
 
 const liveOrigin = 'https://me.alehar.workers.dev';
 
-const staticPaths = ['/', '/work/', '/biography/', '/contact/'];
+const staticPaths = ['/', '/work/', '/biography/', '/contact/', '/roadmap/'];
 
 function loc(path: string) {
   return `${liveOrigin}${path}`;


### PR DESCRIPTION
Closes #687.

Remaining scope only: `/roadmap/` lists the one upcoming row still true on live `67540fc` — flatter first view, boxes only for affordance or grouping. Shipped chat and visit-count bullets are omitted. No invented replacements. Page throws if that remaining row is gone.

Colophon: What's New · Upcoming. Sitemap includes `/roadmap/`. What's New stays shipped history. Home identity copy from #690 is not reverted.

Stay draft. Overlay `69ca717` stays. Hire LinkedIn https://www.linkedin.com/in/alehar/. Do not revert #686 #689 #690. Stay off #691 #597. Do not merge.