### PR TITLE
Flatten padded proof-card; stop advertising it on /roadmap/

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -163,35 +163,35 @@ describe('identity copy', () => {
     expect(page).toContain('What you can see on this site lately.');
   });
 
-  it('ships /roadmap/ with the remaining flatter-first-view upcoming row', () => {
+  it('flattens the home proof affordance and omits flatten from /roadmap/', () => {
     expect(existsSync('src/pages/roadmap.astro')).toBe(true);
     const page = readFileSync('src/pages/roadmap.astro', 'utf8');
     const home = readFileSync('src/pages/index.astro', 'utf8');
     const footer = readFileSync('src/components/Footer.astro', 'utf8');
     const whatsNew = readFileSync('src/pages/whats-new.astro', 'utf8');
-    expect(page).toContain('Hero title="Upcoming"');
-    expect(page).toContain('Product Manager, Developer Experience at IFS');
-    expect(page).toContain('Flatter first view. Boxes only for affordance or grouping.');
-    expect(page).toContain("throw new Error('Roadmap would ship empty.')");
-    expect(page).toContain('ContactCTA');
-    expect(readFileSync('src/components/ContactCTA.astro', 'utf8')).toContain(
-      'https://www.linkedin.com/in/alehar/'
-    );
-    expect(page).not.toContain('mailto:');
-    expect(page).not.toMatch(/\bVP\b/);
-    expect(page).not.toContain('Head of');
-    expect(page).not.toContain('Director');
-    expect(page).not.toContain('#687');
-    expect(page).not.toContain('full-screen');
-    expect(page).not.toContain('fullscreen');
-    expect(page).not.toContain('visit count');
-    expect(page).not.toContain('DoD');
+    expect(home).toContain('class="proof-card"');
+    expect(home).toContain('href="/work/ifs-design-system/"');
+    expect(home).toContain('Read the case');
     expect(home).toContain('class="hero-dek"');
     expect(home).toContain('Hero title="Product Manager, Developer Experience at IFS"');
+    expect(home).not.toContain('background: var(--gradient-subtle)');
+    expect(home).not.toContain('border-radius: 1.5rem');
+    expect(home).not.toContain('box-shadow: var(--shadow-sm)');
+    expect(home).not.toContain('padding: 1.5rem');
+    expect(page).toContain('Hero title="Upcoming"');
+    expect(page).toContain('const upcoming: readonly string[] = []');
+    expect(page).not.toMatch(/upcoming = \['Flatter first view/);
+    expect(page).toContain("throw new Error('Roadmap still promises flatten.')");
+    expect(page).not.toContain("throw new Error('Roadmap would ship empty.')");
+    expect(page).toContain('upcoming.length > 0');
+    expect(page).toContain('ContactCTA');
+    expect(page).not.toContain('mailto:');
+    expect(page).not.toMatch(/\bVP\b/);
+    expect(page).not.toContain('sorry');
+    expect(page).not.toContain('nothing coming');
     expect(footer).toContain('href="/roadmap/"');
     expect(footer).toContain('href="/whats-new/"');
     expect(whatsNew).toContain('What you can see on this site lately.');
-    expect(whatsNew).not.toContain('href="/roadmap/"');
   });
 
   it('puts a middot inside the hidden footer visit-stats span', () => {

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -163,11 +163,14 @@ describe('identity copy', () => {
     expect(page).toContain('What you can see on this site lately.');
   });
 
-  it('flattens the home proof affordance and omits flatten from /roadmap/', () => {
+  it('flattens the home proof affordance and hides empty Upcoming', () => {
     expect(existsSync('src/pages/roadmap.astro')).toBe(true);
+    expect(existsSync('src/data/upcoming.ts')).toBe(true);
     const page = readFileSync('src/pages/roadmap.astro', 'utf8');
+    const upcoming = readFileSync('src/data/upcoming.ts', 'utf8');
     const home = readFileSync('src/pages/index.astro', 'utf8');
     const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    const sitemap = readFileSync('src/pages/sitemap.xml.ts', 'utf8');
     const whatsNew = readFileSync('src/pages/whats-new.astro', 'utf8');
     expect(home).toContain('class="proof-card"');
     expect(home).toContain('href="/work/ifs-design-system/"');
@@ -178,19 +181,13 @@ describe('identity copy', () => {
     expect(home).not.toContain('border-radius: 1.5rem');
     expect(home).not.toContain('box-shadow: var(--shadow-sm)');
     expect(home).not.toContain('padding: 1.5rem');
-    expect(page).toContain('Hero title="Upcoming"');
-    expect(page).toContain('const upcoming: readonly string[] = []');
-    expect(page).not.toMatch(/upcoming = \['Flatter first view/);
+    expect(upcoming).toContain('export const UPCOMING: readonly string[] = []');
     expect(page).toContain("throw new Error('Roadmap still promises flatten.')");
-    expect(page).not.toContain("throw new Error('Roadmap would ship empty.')");
-    expect(page).toContain('upcoming.length > 0');
-    expect(page).toContain('ContactCTA');
-    expect(page).not.toContain('mailto:');
-    expect(page).not.toMatch(/\bVP\b/);
-    expect(page).not.toContain('sorry');
-    expect(page).not.toContain('nothing coming');
-    expect(footer).toContain('href="/roadmap/"');
+    expect(page).toContain("Astro.redirect('/')");
+    expect(footer).toContain('showUpcoming');
     expect(footer).toContain('href="/whats-new/"');
+    expect(footer).not.toContain("What's New</a>{' · '}<a href=\"/roadmap/\">Upcoming</a>");
+    expect(sitemap).toContain('UPCOMING.length > 0');
     expect(whatsNew).toContain('What you can see on this site lately.');
   });
 
@@ -201,11 +198,9 @@ describe('identity copy', () => {
     expect(footer).toContain("What's New");
     expect(footer).toContain('data-visit-stats');
     expect(footer).toContain('hidden');
-    expect(footer).toContain('href="/roadmap/"');
-    expect(footer).toContain('Upcoming');
-    expect(footer).toContain("What's New</a>{' · '}");
-    expect(footer).toContain('href="/roadmap/"');
-    // Space-middot-space as Astro text node so paint is What's New · Upcoming · N (survives Prettier).
+    expect(footer).toContain('showUpcoming');
+    expect(footer).toContain("What's New</a>");
+    // Space-middot-space as Astro text node so paint is What's New · N when Upcoming is hidden.
     expect(footer).toContain("{' · '}");
     expect(footer.slice(footer.indexOf('data-visit-stats'))).toContain("{' · '}");
     // Fail the prior bug: newline/indent then middot (leading space collapsed in paint).
@@ -1801,7 +1796,7 @@ describe('identity copy', () => {
     expect(sitemap).toContain("'/work/'");
     expect(sitemap).toContain("'/biography/'");
     expect(sitemap).toContain("'/contact/'");
-    expect(sitemap).toContain("'/roadmap/'");
+    expect(sitemap).toContain('UPCOMING.length > 0');
     expect(sitemap).toContain('ifs-design-system');
     expect(sitemap).not.toContain('/experimental/manifesto');
     expect(sitemap).not.toContain('/experimental/now');

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,8 @@
 ---
+import { UPCOMING } from '../data/upcoming';
+
 const currentYear = new Date().getFullYear();
+const showUpcoming = UPCOMING.length > 0;
 ---
 
 <footer>
@@ -17,10 +20,14 @@ const currentYear = new Date().getFullYear();
     </p>
     <p>&copy; {currentYear} Alexander Härenstam</p>
     <div class="colophon">
-      <a href="/whats-new/">What's New</a>{' · '}<a href="/roadmap/">Upcoming</a><span
-        class="visit-stats"
-        data-visit-stats
-        hidden
+      <a href="/whats-new/">What's New</a>{
+        showUpcoming && (
+          <>
+            {' · '}
+            <a href="/roadmap/">Upcoming</a>
+          </>
+        )
+      }<span class="visit-stats" data-visit-stats hidden
         >{' · '}<button
           type="button"
           class="visit-trigger"

--- a/src/data/upcoming.ts
+++ b/src/data/upcoming.ts
@@ -1,0 +1,7 @@
+export const FLATTEN_BULLET = 'Flatter first view. Boxes only for affordance or grouping.';
+
+export const UPCOMING: readonly string[] = [];
+
+export function stillPromisesFlatten(items: readonly string[]): boolean {
+  return items.includes(FLATTEN_BULLET);
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -165,16 +165,13 @@ const schema = {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.75rem;
-    padding: 1.5rem;
+    gap: 0.4rem;
+    padding: 0;
     text-decoration: none;
     color: inherit;
-    background: var(--gradient-subtle);
-    border: 1px solid var(--gray-800);
-    border-radius: 1.5rem;
-    box-shadow: var(--shadow-sm);
-    backdrop-filter: blur(16px) saturate(140%);
-    -webkit-backdrop-filter: blur(16px) saturate(140%);
+    background: none;
+    border: 0;
+    box-shadow: none;
   }
 
   .proof-card:focus-visible {
@@ -213,21 +210,6 @@ const schema = {
     text-underline-offset: 0.2em;
   }
 
-  @media (prefers-reduced-motion: no-preference) {
-    .proof-card {
-      transition:
-        transform 0.3s ease,
-        box-shadow 0.3s ease,
-        border-color 0.3s ease;
-    }
-
-    .proof-card:hover,
-    .proof-card:focus-visible {
-      transform: translateY(-2px);
-      box-shadow: var(--shadow-md);
-    }
-  }
-
   @media (min-width: 50em) {
     .first-screen {
       justify-content: center;
@@ -246,10 +228,6 @@ const schema = {
 
     .hero-dek {
       max-width: 48ch;
-    }
-
-    .proof-card {
-      padding: 2.5rem;
     }
   }
 

--- a/src/pages/roadmap.astro
+++ b/src/pages/roadmap.astro
@@ -6,10 +6,10 @@ import Hero from '../components/Hero.astro';
 const dek = 'What is coming next on this site.';
 const pageTitle = 'Upcoming | Product Manager, Developer Experience at IFS';
 
-const upcoming = ['Flatter first view. Boxes only for affordance or grouping.'] as const;
+const upcoming: readonly string[] = [];
 
-if (upcoming.length === 0) {
-  throw new Error('Roadmap would ship empty.');
+if (upcoming.includes('Flatter first view. Boxes only for affordance or grouping.')) {
+  throw new Error('Roadmap still promises flatten.');
 }
 
 const schema = {
@@ -57,9 +57,15 @@ const schema = {
   <div class="stack gap-20">
     <main id="main-content" class="upcoming-page stack gap-8">
       <Hero title="Upcoming" tagline={dek} align="start" />
-      <ul class="upcoming-list">
-        {upcoming.map((line) => <li>{line}</li>)}
-      </ul>
+      {
+        upcoming.length > 0 && (
+          <ul class="upcoming-list">
+            {upcoming.map((line) => (
+              <li>{line}</li>
+            ))}
+          </ul>
+        )
+      }
     </main>
     <ContactCTA />
   </div>

--- a/src/pages/roadmap.astro
+++ b/src/pages/roadmap.astro
@@ -2,14 +2,18 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import ContactCTA from '../components/ContactCTA.astro';
 import Hero from '../components/Hero.astro';
+import { UPCOMING, stillPromisesFlatten } from '../data/upcoming';
 
 const dek = 'What is coming next on this site.';
 const pageTitle = 'Upcoming | Product Manager, Developer Experience at IFS';
+const upcoming = UPCOMING;
 
-const upcoming: readonly string[] = [];
-
-if (upcoming.includes('Flatter first view. Boxes only for affordance or grouping.')) {
+if (stillPromisesFlatten(upcoming)) {
   throw new Error('Roadmap still promises flatten.');
+}
+
+if (upcoming.length === 0) {
+  return Astro.redirect('/');
 }
 
 const schema = {

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,11 +1,18 @@
 import type { APIRoute } from 'astro';
 import { getCollection } from 'astro:content';
+import { UPCOMING } from '../data/upcoming';
 
 export const prerender = true;
 
 const liveOrigin = 'https://me.alehar.workers.dev';
 
-const staticPaths = ['/', '/work/', '/biography/', '/contact/', '/roadmap/'];
+const staticPaths = [
+  '/',
+  '/work/',
+  '/biography/',
+  '/contact/',
+  ...(UPCOMING.length > 0 ? ['/roadmap/'] : []),
+];
 
 function loc(path: string) {
   return `${liveOrigin}${path}`;


### PR DESCRIPTION
Closes #694.

Home proof stays as the IFS Design System case link. Padded-card chrome (gradient, border, radius, shadow, extra padding) is gone. `/roadmap/` no longer lists flatten as upcoming. No invented replacement. Empty upcoming list is omitted (no gap-apology).

Stay draft. Overlay `69ca717` stays. Hire LinkedIn https://www.linkedin.com/in/alehar/. Do not revert #686 #689 #690 #693. Stay off #688 #691 #597. Do not merge.