### PR TITLE
Add /this-site/ twin explainer beside What's New (#688)

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -186,9 +186,38 @@ describe('identity copy', () => {
     expect(page).toContain("Astro.redirect('/')");
     expect(footer).toContain('showUpcoming');
     expect(footer).toContain('href="/whats-new/"');
+    expect(footer).toContain('href="/this-site/"');
+    expect(footer).toContain('This site');
     expect(footer).not.toContain("What's New</a>{' · '}<a href=\"/roadmap/\">Upcoming</a>");
+    expect(sitemap).toContain("'/this-site/'");
     expect(sitemap).toContain('UPCOMING.length > 0');
     expect(whatsNew).toContain('What you can see on this site lately.');
+  });
+
+  it('ships /this-site/ as the twin explainer and keeps Upcoming omitted', () => {
+    expect(existsSync('src/pages/this-site.astro')).toBe(true);
+    const page = readFileSync('src/pages/this-site.astro', 'utf8').replace(/\s+/g, ' ');
+    const home = readFileSync('src/pages/index.astro', 'utf8');
+    const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    const whatsNew = readFileSync('src/pages/whats-new.astro', 'utf8');
+    expect(page).toContain('Hero title="This site"');
+    expect(page).toContain('Product Manager, Developer Experience at IFS');
+    expect(page).toContain('digital twin');
+    expect(page).toContain('AI with his context');
+    expect(page).toContain('It can get things wrong.');
+    expect(page).toContain('It is not him.');
+    expect(page).toContain('ContactCTA');
+    expect(page).not.toContain('mailto:');
+    expect(page).not.toContain('/roadmap/');
+    expect(page).not.toContain('Upcoming');
+    expect(page).not.toMatch(/\\bVP\\b/);
+    expect(footer).toContain('href="/this-site/"');
+    expect(footer).toContain('href="/whats-new/"');
+    expect(footer).toContain('showUpcoming');
+    expect(home).toContain('class="hero-dek"');
+    expect(home).toContain('Hero title="Product Manager, Developer Experience at IFS"');
+    expect(whatsNew).toContain('What you can see on this site lately.');
+    expect(whatsNew).not.toContain('href="/this-site/"');
   });
 
   it('puts a middot inside the hidden footer visit-stats span', () => {
@@ -1796,6 +1825,7 @@ describe('identity copy', () => {
     expect(sitemap).toContain("'/work/'");
     expect(sitemap).toContain("'/biography/'");
     expect(sitemap).toContain("'/contact/'");
+    expect(sitemap).toContain("'/this-site/'");
     expect(sitemap).toContain('UPCOMING.length > 0');
     expect(sitemap).toContain('ifs-design-system');
     expect(sitemap).not.toContain('/experimental/manifesto');

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -20,7 +20,7 @@ const showUpcoming = UPCOMING.length > 0;
     </p>
     <p>&copy; {currentYear} Alexander Härenstam</p>
     <div class="colophon">
-      <a href="/whats-new/">What's New</a>{
+      <a href="/whats-new/">What's New</a>{' · '}<a href="/this-site/">This site</a>{
         showUpcoming && (
           <>
             {' · '}

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -11,6 +11,7 @@ const staticPaths = [
   '/work/',
   '/biography/',
   '/contact/',
+  '/this-site/',
   ...(UPCOMING.length > 0 ? ['/roadmap/'] : []),
 ];
 

--- a/src/pages/this-site.astro
+++ b/src/pages/this-site.astro
@@ -1,0 +1,57 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import ContactCTA from '../components/ContactCTA.astro';
+import Hero from '../components/Hero.astro';
+
+const dek = 'What this site is, and what the chat in the corner is.';
+const pageTitle = 'This site | Product Manager, Developer Experience at IFS';
+---
+
+<BaseLayout
+  title={pageTitle}
+  ogTitle={pageTitle}
+  description={`${dek} Product Manager, Developer Experience at IFS. Get in touch on LinkedIn.`}
+>
+  <div class="stack gap-20">
+    <main id="main-content" class="this-site stack gap-8">
+      <Hero title="This site" tagline={dek} align="start" />
+      <div class="copy stack gap-4">
+        <p>
+          This is Alexander Härenstam's personal site. He is a Product Manager, Developer Experience
+          at IFS.
+        </p>
+        <p>
+          The chat at the bottom is his digital twin. It is an AI with his context. It can get
+          things wrong. It is not him.
+        </p>
+        <p>What's New is what you can see on this site lately.</p>
+      </div>
+    </main>
+    <ContactCTA />
+  </div>
+</BaseLayout>
+
+<style>
+  .this-site {
+    width: min(52rem, calc(100vw - 3rem));
+    margin-inline: auto;
+    padding-bottom: var(--chat-fab-clearance);
+  }
+
+  .copy {
+    max-width: 46ch;
+  }
+
+  .copy p {
+    margin: 0;
+    color: var(--gray-200);
+    font-size: var(--text-lg);
+    line-height: 1.5;
+  }
+
+  @media (min-width: 50em) {
+    .this-site {
+      padding-bottom: 0;
+    }
+  }
+</style>


### PR DESCRIPTION
Closes #688.

One draft from live `dd6cf3a9`. New `/this-site/`: this is Alexander Härenstam's personal site (Product Manager, Developer Experience at IFS). The docked chat is his digital twin — an AI with his context. It can get things wrong. It is not him. Hire / get in touch is LinkedIn only: https://www.linkedin.com/in/alehar/. What's New pointer stays shipped lately. Do not advertise Upcoming.

Colophon: What's New · This site. Upcoming stays omitted while the list is empty. Sitemap includes `/this-site/`. Overlay `69ca717` stays. Do not revert #690. Stay off #597 and #691.

Stay draft until Nick freeze SHA + hashed `*-me.alehar.workers.dev` preview. Johan+Vera PASS. Do not merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new “This site” page explaining the site, its AI chat experience, and how to get in touch.
  - Added a “This site” link to the footer for easier discovery.
  - Included the page in the site sitemap to improve indexing and navigation.
- **Bug Fixes**
  - Ensured upcoming content remains excluded from visitor-facing navigation and sitemap content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->