### PR TITLE
🎨 Palette: Secure external social links in footer navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,5 +1,11 @@
 # Palette 🎨 - UX & Accessibility Journal
 
+## 2026-05-20 - Securing External Social Links in Footer Navigation
+
+**Learning:** External links to third-party services (such as LinkedIn, IFS Blog, and GitHub in footer navigation) should open in a new tab using `target="_blank"` paired with `rel="noopener noreferrer"`. This prevents tab-jacking security risks while offering non-disruptive navigation that preserves the user's active session on the portfolio site.
+
+**Action:** Added `target="_blank" rel="noopener noreferrer"` attributes to all social media links in `src/components/Footer.astro`.
+
 ## 2026-05-17 - Enhancing Content Selection and Standardizing Focus Spatiality
 
 **Learning:** Using `user-select: none` on informational badges (like `Pill`) creates unnecessary friction for users trying to copy text for reference. Additionally, consistent `outline-offset: 4px` across all interactive elements (including theme toggles and cards) reinforces a predictable spatial model for keyboard users. Adding `target="_blank"` with `rel="noopener noreferrer"` to external informational links (like the Astro framework link in the footer) ensures a non-disruptive navigation experience that preserves the user's session.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -39,9 +39,17 @@ const showUpcoming = UPCOMING.length > 0;
     </div>
   </div>
   <p class="socials">
-    <a href="https://www.linkedin.com/in/alehar/"> LinkedIn</a>
-    <a href="https://blog.ifs.com/author/alexander-harenstam/"> IFS Blog</a>
-    <a href="https://github.com/alehar9320"> GitHub</a>
+    <a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">
+      LinkedIn</a
+    >
+    <a
+      href="https://blog.ifs.com/author/alexander-harenstam/"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      IFS Blog</a
+    >
+    <a href="https://github.com/alehar9320" target="_blank" rel="noopener noreferrer"> GitHub</a>
   </p>
 </footer>
 <div class="visit-panel" id="visit-glance-panel" hidden>


### PR DESCRIPTION
Adds target="_blank" and rel="noopener noreferrer" attributes to social media links (LinkedIn, IFS Blog, GitHub) in src/components/Footer.astro to ensure secure and non-disruptive navigation to external services, and logs learnings in .Jules/palette.md.

---
*PR created automatically by Jules for task [7080902149323049950](https://jules.google.com/task/7080902149323049950) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * External social links in the footer now open safely in a new browser tab.
  * Improved protection when navigating to third-party websites from footer links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->