### PR TITLE
Open footer socials in a new tab with noopener (#706)

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -378,6 +378,23 @@ describe('identity copy', () => {
     expect(footer).not.toContain('source-link');
   });
 
+  it('opens footer socials with noopener so the site window stays', () => {
+    const footer = readFileSync('src/components/Footer.astro', 'utf8');
+    const socials = footer.slice(footer.indexOf('class="socials"'), footer.indexOf('</footer>'));
+    expect(socials).toContain('https://www.linkedin.com/in/alehar/');
+    expect(socials).toContain('https://blog.ifs.com/author/alexander-harenstam/');
+    expect(socials).toContain('https://github.com/alehar9320');
+    expect([...socials.matchAll(/target="_blank"/g)]).toHaveLength(3);
+    expect([...socials.matchAll(/rel="noopener noreferrer"/g)]).toHaveLength(3);
+    expect(socials).not.toContain('journal');
+    expect(socials).not.toContain("What's New");
+    expect(footer).toContain('showUpcoming');
+    expect(footer).toContain('href="/this-site/"');
+    expect(footer).toContain('href="/whats-new/"');
+    expect(footer).not.toContain("What's New</a>{' · '}<a href=\"/roadmap/\">Upcoming</a>");
+    expect(footer).not.toContain('mailto:');
+  });
+
   it('drops Instagram and Facebook from site socials and keeps LinkedIn hire', () => {
     const nav = readFileSync('src/components/Nav.astro', 'utf8');
     const footer = readFileSync('src/components/Footer.astro', 'utf8');

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -39,9 +39,17 @@ const showUpcoming = UPCOMING.length > 0;
     </div>
   </div>
   <p class="socials">
-    <a href="https://www.linkedin.com/in/alehar/"> LinkedIn</a>
-    <a href="https://blog.ifs.com/author/alexander-harenstam/"> IFS Blog</a>
-    <a href="https://github.com/alehar9320"> GitHub</a>
+    <a href="https://www.linkedin.com/in/alehar/" target="_blank" rel="noopener noreferrer">
+      LinkedIn</a
+    >
+    <a
+      href="https://blog.ifs.com/author/alexander-harenstam/"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      IFS Blog</a
+    >
+    <a href="https://github.com/alehar9320" target="_blank" rel="noopener noreferrer"> GitHub</a>
   </p>
 </footer>
 <div class="visit-panel" id="visit-glance-panel" hidden>


### PR DESCRIPTION
Closes #706.

One draft from live `33ad61e`. Footer `.socials` only: LinkedIn, IFS Blog, and GitHub get `target="_blank" rel="noopener noreferrer"`. Same three URLs. Hire LinkedIn stays https://www.linkedin.com/in/alehar/. No journal / What's New row. Colophon untouched (What's New · This site; Upcoming stays omitted). Overlay `69ca717` stays. Do not revert #690. Do not restack #698. Stay off #597 and #691.

Stay draft until Nick freeze SHA + hashed `*-me.alehar.workers.dev` preview. Johan+Vera PASS. Do not merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated footer social links to open safely in a new browser tab.
  - Added LinkedIn, IFS Blog, and GitHub links while excluding unrelated links.
  - Preserved the existing footer navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->