### PR TITLE
Janitor: Typo & Terminology Alignment

### DIFF
--- a/.Janitor/hygiene.md
+++ b/.Janitor/hygiene.md
@@ -1,11 +1,12 @@
 # Janitor Hygiene Journal
 
-| Date       | Corrected File                    | Correction                                                                               | Status      |
-| :--------- | :-------------------------------- | :--------------------------------------------------------------------------------------- | :---------- |
-| 2025-03-24 | N/A                               | Initialized Journal                                                                      | Initialized |
-| 2025-03-24 | worker-configuration.d.ts         | Removed 'the the' typos from documentation comments                                      | Validated   |
-| 2025-03-24 | context/author-linkedin.md        | Normalized Swedish terms (Produktchef, Produktledning) and removed duplicate text blocks | Validated   |
-| 2025-03-24 | src/content/work/master-thesis.md | Improved grammatical phrasing in the concluding paragraph                                | Validated   |
+| Date       | Corrected File                    | Correction                                                                                    | Status      |
+| :--------- | :-------------------------------- | :-------------------------------------------------------------------------------------------- | :---------- |
+| 2025-03-24 | N/A                               | Initialized Journal                                                                           | Initialized |
+| 2025-03-24 | worker-configuration.d.ts         | Removed 'the the' typos from documentation comments                                           | Validated   |
+| 2025-03-24 | context/author-linkedin.md        | Normalized Swedish terms (Produktchef, Produktledning) and removed duplicate text blocks      | Validated   |
+| 2025-03-24 | src/content/work/master-thesis.md | Improved grammatical phrasing in the concluding paragraph                                     | Validated   |
+| 2026-08-25 | context/author-linkedin.md        | Corrected 'We’l' typo to 'We'll' and fixed profile URL prefix 'ww.linkedin' to 'www.linkedin' | Validated   |
 
 ## Spelling Exceptions
 

--- a/context/author-linkedin.md
+++ b/context/author-linkedin.md
@@ -67,7 +67,7 @@ Stand out to employers
 Enhance your profile, craft standout messages, and assess job fit with Premium.
 
 Try Premium for SEK 0
-1-month free trial. Cancel whenever. We’l remind you 7 days before your trial ends.
+1-month free trial. Cancel whenever. We'll remind you 7 days before your trial ends.
 
 Dismiss premium promotion
 
@@ -398,7 +398,7 @@ Profile language
 Svenska
 
 Public profile & URL
-ww.linkedin.com/in/alehar
+www.linkedin.com/in/alehar
 
 Who your viewers also viewed
 Private to you Private to you


### PR DESCRIPTION
Corrected typographical errors in context/author-linkedin.md ('We’l' -> 'We'll' and 'ww.linkedin' -> 'www.linkedin') and logged the updates in .Janitor/hygiene.md. All tests, linter, formatting, and build checks pass successfully.

---
*PR created automatically by Jules for task [16814541224309606016](https://jules.google.com/task/16814541224309606016) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in the LinkedIn profile trial reminder.
  * Fixed the LinkedIn profile URL formatting.
  * Recorded the documentation correction in the project journal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->