### PR TITLE
Keep first view identity and hire; dock chat until open (#710)

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -703,6 +703,40 @@ describe('identity copy', () => {
     expect(chat).not.toContain('data-hire-surface');
   });
 
+  it('keeps first paint identity and hire, docks chat until open', () => {
+    const chat = readFileSync('src/components/Chat.astro', 'utf8');
+    const home = readFileSync('src/pages/index.astro', 'utf8');
+    const hero = readFileSync('src/components/Hero.astro', 'utf8');
+    expect(chat).toContain('First paint is identity + hire');
+    expect(chat).toContain('100dvh only after is-open');
+    expect(chat).toContain("classList.add('is-docked')");
+    expect(chat).not.toContain("classList.add('is-prominent')");
+    expect(chat).toContain('height: 100dvh');
+    expect(chat).toContain('.chat-container.is-open:not(.is-prominent)');
+    expect(chat).toContain('is-docked');
+    expect(chat).not.toContain('mailto:');
+    expect(home).toContain('Hero title="Product Manager, Developer Experience at IFS"');
+    expect(home).toContain('class="hero-dek"');
+    expect((home.match(/class="hero-dek"/g) || []).length).toBe(1);
+    expect(home).toContain(
+      'Also hireable for product work across developer platforms, design systems, and'
+    );
+    expect(home).toContain('Industrial AI copilots, not only DevEx.');
+    expect(home).toContain('class="hero-bridge"');
+    expect(home.replace(/\s+/g, ' ')).toContain('eight years at IFS');
+    expect(home).toContain('Chalmers software engineering');
+    expect(home).toContain('Get in touch');
+    expect(home).toContain('LinkedIn · replies from me');
+    expect(home).toContain('https://www.linkedin.com/in/alehar/');
+    expect(home).toContain('proof-card');
+    expect(home).toContain('Zeroheight runner-up');
+    expect(home).not.toContain('mailto:');
+    expect(home).not.toMatch(/\bVP\b/);
+    expect(hero).toContain('font-size: var(--text-xl)');
+    expect(hero).toContain('font-size: var(--text-5xl)');
+    expect(hero).not.toContain("variant = 'primary'");
+  });
+
   it('makes phone talking a full-page chat and keeps desktop stage locks', () => {
     const chat = readFileSync('src/components/Chat.astro', 'utf8');
     const home = readFileSync('src/pages/index.astro', 'utf8');

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -853,12 +853,6 @@
     }
   };
 
-  function isHomePath() {
-    const raw = location.pathname || '';
-    const path = raw.replace(/\/index\.html?$/, '').replace(/\/+$/, '') || '/';
-    return path === '/' || path === '' || path === '/index';
-  }
-
   function dockChat() {
     chatContainer?.classList.remove('is-prominent');
     chatContainer?.classList.add('is-docked');

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -336,9 +336,8 @@
       width: 100%;
     }
 
-    /* Phone talking = full page, not a padded rounded sheet over the site. */
-    .chat-container.is-open:not(.is-prominent),
-    .chat-container.is-prominent {
+    /* Phone talking = full page only after is-open. First paint stays docked. */
+    .chat-container.is-open:not(.is-prominent) {
       inset: 0;
       padding-top: 0;
       max-height: none;
@@ -347,8 +346,7 @@
       justify-content: stretch;
     }
 
-    .chat-container.is-open:not(.is-prominent) .chat-window,
-    .chat-container.is-prominent .chat-window {
+    .chat-container.is-open:not(.is-prominent) .chat-window {
       flex: 1 1 auto;
       height: auto;
       min-height: 0;
@@ -360,8 +358,7 @@
       -webkit-backdrop-filter: none;
     }
 
-    .chat-container.is-open .chat-form,
-    .chat-container.is-prominent .chat-form {
+    .chat-container.is-open:not(.is-prominent) .chat-form {
       border-radius: 0;
       border-left: 0;
       border-right: 0;
@@ -880,23 +877,10 @@
       document.body.classList.remove('has-prominent-chat');
       return;
     }
-    if (!isHomePath()) {
-      chatContainer.classList.add('is-docked');
-      document.body.classList.remove('has-prominent-chat');
-      return;
-    }
-    if (sessionStorage.getItem(FOLD_DISMISSED_KEY) === '1') {
-      chatContainer.classList.add('is-docked');
-      document.body.classList.remove('has-prominent-chat');
-      return;
-    }
-    if (window.scrollY > 160) {
-      dockChat();
-      return;
-    }
-    chatContainer.classList.add('is-prominent');
-    chatWindow?.classList.remove('hidden');
-    document.body.classList.add('has-prominent-chat');
+    // First paint is identity + hire. Docked composer. 100dvh only after is-open.
+    chatContainer.classList.remove('is-prominent');
+    chatContainer.classList.add('is-docked');
+    document.body.classList.remove('has-prominent-chat');
     window.addEventListener(
       'scroll',
       () => {

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -30,7 +30,9 @@ const { align = 'center', tagline, title, variant = 'secondary' } = Astro.props;
   }
 
   .title {
-    font-size: var(--text-3xl);
+    font-size: var(--text-xl);
+    line-height: 1.2;
+    max-width: none;
     color: var(--gray-0);
   }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -74,8 +74,7 @@ const schema = {
         <Hero title="Product Manager, Developer Experience at IFS" align="start">
           <p class="hero-dek">
             Also hireable for product work across developer platforms, design systems, and
-            Industrial AI copilots, not only DevEx. Chalmers software engineering and MEI, eight
-            years at IFS, the IFS Design System, plus copilots, analytics, and thesis work.
+            Industrial AI copilots, not only DevEx.
           </p>
           <div class="hero-actions">
             <CallToAction
@@ -104,6 +103,10 @@ const schema = {
             <p class="proof-affordance">Read the case</p>
           </a>
         </section>
+        <p class="hero-bridge">
+          Chalmers software engineering and MEI, eight years at IFS, the IFS Design System, plus
+          copilots, analytics, and thesis work.
+        </p>
       </div>
     </header>
   </main>
@@ -141,6 +144,15 @@ const schema = {
     font-size: var(--text-sm);
     font-weight: 400;
     color: var(--gray-200);
+    line-height: 1.45;
+  }
+
+  .hero-bridge {
+    margin: 0;
+    max-width: 42ch;
+    font-size: var(--text-sm);
+    font-weight: 400;
+    color: var(--gray-300);
     line-height: 1.45;
   }
 


### PR DESCRIPTION
Closes #710.

One draft from live `cdedf0a`. First viewport is who he is and how to hire him. Chat never covers the hire path.

- 375 first paint: docked composer, not 100dvh chat. Talking 100dvh only after `is-open`.
- H1 stays `Product Manager, Developer Experience at IFS` (phone type/layout only).
- Dek first view is the locked #690 sentence. Bridge (Chalmers / eight years / DS / thesis) sits below.
- 1280: Get in touch + `LinkedIn · replies from me` uncovered. Composer on the bottom edge. No 36dvh sheet on first paint.
- Overlay `69ca717` stays. Hire LinkedIn https://www.linkedin.com/in/alehar/. One portrait. No glow/glass. Do not clone Get in touch into the panel. Do not restack #698 #691 #597. Do not rewrite /this-site/ or colophon.

Stay draft until Nick freeze SHA + hashed `*-me.alehar.workers.dev` preview. Johan+Vera PASS. Do not merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the homepage introduction to highlight industrial AI copilots.
  - Added supporting context beneath the proof card.

- **Bug Fixes**
  - Improved mobile chat behavior so it remains docked until explicitly opened, then expands to fullscreen.

- **Style**
  - Refined hero typography with a smaller, tighter title treatment and improved responsive presentation.

- **Tests**
  - Added coverage for homepage identity, hiring content, hero messaging, responsive typography, and initial chat behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->