### PR TITLE
⚙️ Engine: Optimize SSE chat stream parser & harden CRLF boundaries

### DIFF
--- a/.jules/engine.md
+++ b/.jules/engine.md
@@ -6,3 +6,9 @@
 - **New Utility:** Established `pruneMessages` which implements a sliding window algorithm to maintain conversation history within Cloudflare Workers AI limits (10 messages, 3000 total characters).
 - **TypeScript & Validation:** Leveraged Zod for strict schema validation of chat requests and messages, ensuring runtime safety and defensive error handling.
 - **Performance:** Pruning happens on the edge to minimize payload size sent to the AI model, improving response latency and reliability.
+
+## 2025-05-21 - SSE Stream Parser Optimization & CRLF Boundary Hardening
+
+- **Architectural Shift:** Refactored stateful SSE streaming parser in `src/utils/chat-stream.ts` to handle carriage returns (`\r\n`) during line-by-line parsing rather than performing global string replacements across incoming chunks.
+- **Edge-Case Constraints:** Handled CRLF line endings split across chunk boundaries when streaming response data from Cloudflare Workers AI.
+- **Performance:** Bypassed array joins when processing single-line SSE event payloads (`data: ...`), reducing garbage collection pressure during live avatar streaming.

--- a/src/utils/chat-stream.test.ts
+++ b/src/utils/chat-stream.test.ts
@@ -28,6 +28,21 @@ describe('chat stream parser', () => {
     expect(parser.flush()).toBe('End');
   });
 
+  it('handles CRLF line endings split across buffer boundaries', () => {
+    const parser = createChatStreamParser();
+
+    expect(parser.push('data: {"response":"Hello"}\r')).toBe('');
+    expect(parser.push('\n\r\ndata: {"response":" World"}\r\n\r\n')).toBe('Hello World');
+    expect(parser.flush()).toBe('');
+  });
+
+  it('handles consecutive blank lines and single-line data event fast paths', () => {
+    const parser = createChatStreamParser();
+
+    expect(parser.push('\n\n\ndata: {"response":"Fast"}\n\n\n\n')).toBe('Fast');
+    expect(parser.flush()).toBe('');
+  });
+
   it('ignores invalid and metadata-only SSE payloads', () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const raw =

--- a/src/utils/chat-stream.ts
+++ b/src/utils/chat-stream.ts
@@ -58,12 +58,18 @@ function extractResponseFromPayload(payload: string): string {
 /**
  * Processes a single line of the SSE stream, updating the parser state.
  * @param state - The current parser state.
- * @param line - The line to process.
+ * @param line - The line to process (carriage returns stripped).
  * @returns The extracted text if a full event was completed.
  */
 function consumeLine(state: SseParserState, line: string): string {
   if (line === '') {
-    const payload = state.currentEventLines.join('\n').trim();
+    if (state.currentEventLines.length === 0) {
+      return '';
+    }
+    const payload =
+      state.currentEventLines.length === 1
+        ? state.currentEventLines[0]
+        : state.currentEventLines.join('\n').trim();
     state.currentEventLines = [];
     return extractResponseFromPayload(payload);
   }
@@ -83,19 +89,31 @@ function consumeLine(state: SseParserState, line: string): string {
  * @returns The accumulated parsed text.
  */
 function processBufferedText(state: SseParserState, input: string, isFinalChunk: boolean): string {
-  const normalizedInput = `${state.partialLine}${input}`.replaceAll('\r\n', '\n');
-  const lines = normalizedInput.split('\n');
+  const combined = state.partialLine + input;
+  const lines = combined.split('\n');
   const lastIndex = isFinalChunk ? lines.length : Math.max(lines.length - 1, 0);
   let parsedText = '';
 
   for (let index = 0; index < lastIndex; index += 1) {
-    parsedText += consumeLine(state, lines[index]);
+    let line = lines[index];
+    if (line.endsWith('\r')) {
+      line = line.slice(0, -1);
+    }
+    parsedText += consumeLine(state, line);
   }
 
-  state.partialLine = isFinalChunk ? '' : lines[lines.length - 1];
+  let remaining = isFinalChunk ? '' : lines[lines.length - 1];
+  if (remaining.endsWith('\r')) {
+    remaining = remaining.slice(0, -1);
+  }
+  state.partialLine = remaining;
 
   if (isFinalChunk && state.currentEventLines.length > 0) {
-    parsedText += extractResponseFromPayload(state.currentEventLines.join('\n').trim());
+    const payload =
+      state.currentEventLines.length === 1
+        ? state.currentEventLines[0]
+        : state.currentEventLines.join('\n').trim();
+    parsedText += extractResponseFromPayload(payload);
     state.currentEventLines = [];
   }
 


### PR DESCRIPTION
Optimized the stateful SSE chat streaming parser in `src/utils/chat-stream.ts` to handle CRLF chunk boundaries without string allocation overhead, fast-path single-line data events, and add unit test coverage in `src/utils/chat-stream.test.ts`.

---
*PR created automatically by Jules for task [7828550032775861074](https://jules.google.com/task/7828550032775861074) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming message parsing for Windows-style line endings, including breaks across data chunks.
  * Preserved the exact text of single-line streamed messages while continuing to clean up multi-line messages appropriately.
* **Tests**
  * Added coverage for split line endings and consecutive blank lines in streamed events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->