### PR TITLE
⚡ Kinetic: Add hardware-accelerated image zoom to PortfolioPreview

### DIFF
--- a/.jules/kinetic.md
+++ b/.jules/kinetic.md
@@ -1,5 +1,15 @@
 # Kinetic Journal ⚡
 
+## 2026-08-26 - Hardware-Accelerated Portfolio Card Image Zoom
+
+- **Signal:** Portfolio preview cards lacked internal visual depth during hover and focus interactions.
+- **Action:**
+  - Enhanced `src/components/PortfolioPreview.astro` card image with smooth `transform: scale(1.04)` transition on hover and focus-visible.
+  - Used hardware-accelerated `transform` with a smooth `cubic-bezier(0.22, 1, 0.36, 1)` timing function.
+  - Wrapped hover/focus scale effect in `@media (prefers-reduced-motion: no-preference)` for accessibility compliance.
+- **Tokens Added:**
+  - Card Image Hover Zoom: `scale(1.04)` with `cubic-bezier(0.22, 1, 0.36, 1)`
+
 ## 2025-05-15 - Interactive Glassmorphism for Skills Section
 
 - **Signal:** Standardized skills box lacked interactive affordance and depth.

--- a/src/components/PortfolioPreview.astro
+++ b/src/components/PortfolioPreview.astro
@@ -127,6 +127,14 @@ const isShimmerEnabled = flagsEntry?.data.portfolio_shimmer_v1 ?? false;
     width: 100%;
     height: 100%;
     object-fit: cover;
+    transition: transform 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .card:hover img,
+    .card:focus-visible img {
+      transform: scale(1.04);
+    }
   }
 
   @media (min-width: 50em) {


### PR DESCRIPTION
Implemented an accessible, hardware-accelerated CSS scale animation (`transform: scale(1.04)`) for portfolio card images in `src/components/PortfolioPreview.astro` wrapped in `@media (prefers-reduced-motion: no-preference)`. Documented the pattern in `.jules/kinetic.md`.

---
*PR created automatically by Jules for task [16856077168530285623](https://jules.google.com/task/16856077168530285623) started by @alehar9320*