### PR TITLE
Harden SSE chat-stream CRLF boundaries (#714)

### DIFF
--- a/src/utils/chat-stream.test.ts
+++ b/src/utils/chat-stream.test.ts
@@ -28,6 +28,27 @@ describe('chat stream parser', () => {
     expect(parser.flush()).toBe('End');
   });
 
+  it('handles CRLF line endings split across buffer boundaries', () => {
+    const parser = createChatStreamParser();
+
+    expect(parser.push('data: {"response":"Hello"}\r')).toBe('');
+    expect(parser.push('\n\r\ndata: {"response":" World"}\r\n\r\n')).toBe('Hello World');
+    expect(parser.flush()).toBe('');
+  });
+
+  it('handles consecutive blank lines and single-line data event fast paths', () => {
+    const parser = createChatStreamParser();
+
+    expect(parser.push('\n\n\ndata: {"response":"Fast"}\n\n\n\n')).toBe('Fast');
+    expect(parser.flush()).toBe('');
+  });
+
+  it('treats padded [DONE] as the done marker on the single-line path', () => {
+    const raw = `${event('Hi')}data:  [DONE] \n\n`;
+
+    expect(extractAssistantTextFromSse(raw)).toBe('Hi');
+  });
+
   it('ignores invalid and metadata-only SSE payloads', () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const raw =

--- a/src/utils/chat-stream.ts
+++ b/src/utils/chat-stream.ts
@@ -58,12 +58,18 @@ function extractResponseFromPayload(payload: string): string {
 /**
  * Processes a single line of the SSE stream, updating the parser state.
  * @param state - The current parser state.
- * @param line - The line to process.
+ * @param line - The line to process (carriage returns stripped).
  * @returns The extracted text if a full event was completed.
  */
 function consumeLine(state: SseParserState, line: string): string {
   if (line === '') {
-    const payload = state.currentEventLines.join('\n').trim();
+    if (state.currentEventLines.length === 0) {
+      return '';
+    }
+    const payload =
+      state.currentEventLines.length === 1
+        ? state.currentEventLines[0].trim()
+        : state.currentEventLines.join('\n').trim();
     state.currentEventLines = [];
     return extractResponseFromPayload(payload);
   }
@@ -83,19 +89,31 @@ function consumeLine(state: SseParserState, line: string): string {
  * @returns The accumulated parsed text.
  */
 function processBufferedText(state: SseParserState, input: string, isFinalChunk: boolean): string {
-  const normalizedInput = `${state.partialLine}${input}`.replaceAll('\r\n', '\n');
-  const lines = normalizedInput.split('\n');
+  const combined = state.partialLine + input;
+  const lines = combined.split('\n');
   const lastIndex = isFinalChunk ? lines.length : Math.max(lines.length - 1, 0);
   let parsedText = '';
 
   for (let index = 0; index < lastIndex; index += 1) {
-    parsedText += consumeLine(state, lines[index]);
+    let line = lines[index];
+    if (line.endsWith('\r')) {
+      line = line.slice(0, -1);
+    }
+    parsedText += consumeLine(state, line);
   }
 
-  state.partialLine = isFinalChunk ? '' : lines[lines.length - 1];
+  let remaining = isFinalChunk ? '' : lines[lines.length - 1];
+  if (remaining.endsWith('\r')) {
+    remaining = remaining.slice(0, -1);
+  }
+  state.partialLine = remaining;
 
   if (isFinalChunk && state.currentEventLines.length > 0) {
-    parsedText += extractResponseFromPayload(state.currentEventLines.join('\n').trim());
+    const payload =
+      state.currentEventLines.length === 1
+        ? state.currentEventLines[0].trim()
+        : state.currentEventLines.join('\n').trim();
+    parsedText += extractResponseFromPayload(payload);
     state.currentEventLines = [];
   }
 


### PR DESCRIPTION
Kernel of closed #714 only. Not a Jules reopen.

Per-line trailing CR strip after `split('\n')`, skip blank lines, restore `.trim()` on the single-line fast path so padded `[DONE]` still matches `DONE_MARKER`. Tests for split CRLF, consecutive blanks, and padded `[DONE]`.

Files: `src/utils/chat-stream.ts` + `src/utils/chat-stream.test.ts` only. No `.jules/engine.md`. No journal. No `env.d.ts` stubs.

Stay draft. Overlay 69ca717 stays. Hire LinkedIn. Live fbdfd60 stands. Stay off #698 #691 #597.

Closes nothing until freeze + dual PASS (issue #714 is already closed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming event parsing for Windows-style line endings.
  * Correctly handles events split across chunks, consecutive blank lines, and single-line payloads.
  * Recognizes padded completion markers reliably.

* **Tests**
  * Added coverage for edge cases in streamed event processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->