### PR TITLE
Label llms.txt What's New (#717)

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -24,5 +24,5 @@ Recruiter keywords (not a fake title): Product Management, Developer Experience,
 - [User behavior analytics](https://me.alehar.workers.dev/work/user-behavior-analytics/): Telemetry narrative.
 - [Lidköping Stenhuggeri](https://me.alehar.workers.dev/work/lidkoping-stenhuggeri/): Early Android work. Demoted.
 - [Chalmers master's thesis](https://me.alehar.workers.dev/work/master-thesis/): Chalmers, 2017. Earlier work, not an equal card.
-- [Latest updates](https://me.alehar.workers.dev/whats-new/): Changelog.
+- [What's New](https://me.alehar.workers.dev/whats-new/): Changelog.
 - [GitHub](https://github.com/alehar9320/astro-cloudflare-personal-website): Source.


### PR DESCRIPTION
Kernel of closed #717 only. Not a Jules reopen.

`public/llms.txt`: `[Latest updates]` becomes `[What's New]`. URL stays `https://me.alehar.workers.dev/whats-new/`.

Ericsson stays in README. No journal. No `.Jules/content.md`.

Stay draft. Overlay 69ca717 stays. Hire LinkedIn. Live 6e43d52 stands. Stay off #698 #691 #597 #616.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed the optional changelog link from “Latest updates” to “What’s New.”
  * The link URL and description remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->