### PR TITLE
Add Chat :focus-visible rings (#715)

### DIFF
--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -297,6 +297,11 @@
     color: var(--gray-0);
   }
 
+  .chat-suggestion:focus-visible {
+    outline: 2px solid var(--accent-regular);
+    outline-offset: 4px;
+  }
+
   .chat-window {
     position: relative;
     z-index: 1;
@@ -460,6 +465,12 @@
   .chat-close:hover,
   .chat-close:focus-visible {
     color: var(--gray-0);
+  }
+
+  .chat-clear:focus-visible,
+  .chat-close:focus-visible {
+    outline: 2px solid var(--accent-regular);
+    outline-offset: 4px;
   }
 
   .chat-close {
@@ -630,6 +641,12 @@
     display: flex;
     align-items: center;
     justify-content: center;
+  }
+
+  .chat-form input:focus-visible,
+  .chat-form button:focus-visible {
+    outline: 2px solid var(--accent-regular);
+    outline-offset: 4px;
   }
 </style>
 


### PR DESCRIPTION
Kernel of closed #715 only. Not a Jules reopen.

Chat `:focus-visible` rings on `.chat-clear`, `.chat-close`, `.chat-suggestion`, `#chat-input` (`.chat-form input`), and send (`.chat-form button`):

`outline: 2px solid var(--accent-regular); outline-offset: 4px;`

Matches `.chat-toggle` / `.chat-explore-card-open`. No `scale()`. No journal. No `.Jules/palette.md`.

Stay draft until hashed preview. Overlay 69ca717 stays. Hire LinkedIn. Live d171a77 stands. Stay off #698 #691 #597 #616. Ericsson stays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added clear, accent-colored focus indicators for keyboard navigation in the chat interface.
  * Improved focus visibility for suggestion buttons, header controls, and chat form fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->