### PR TITLE
Blend chat and UI into one conversational stage (#741)

### DIFF
--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -561,6 +561,10 @@
     background-color: var(--gray-900);
   }
 
+  .chat-explore-card.is-linkedin {
+    padding: 1rem;
+  }
+
   .chat-explore-card-title {
     margin: 0;
     color: var(--gray-0);
@@ -587,6 +591,43 @@
   .chat-explore-card-open:focus-visible {
     outline: 2px solid var(--accent-regular);
     outline-offset: 4px;
+  }
+
+  .chat-explore-card-primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 0.15rem;
+    padding: 0.5rem 0.9rem;
+    border-radius: 0.5rem;
+    background-color: var(--accent-regular);
+    color: white;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    text-decoration: none;
+    border: none;
+    cursor: pointer;
+  }
+
+  .chat-explore-card-primary:hover,
+  .chat-explore-card-primary:focus-visible {
+    outline: 2px solid var(--accent-regular);
+    outline-offset: 4px;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .chat-explore-card {
+      animation: chat-card-in 0.2s ease-out;
+    }
+  }
+
+  @keyframes chat-card-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
   }
 
   .thinking-indicator {
@@ -895,8 +936,13 @@
 
   function appendExploreCard(card: ExploreCard) {
     if (!chatMessages) return;
+    // Density: one stage card in the recent turn — archive prior cards.
+    chatMessages.querySelectorAll('.chat-explore-card').forEach((el) => el.remove());
+
+    const isLinkedIn = card.variant === 'linkedin';
     const article = document.createElement('article');
     article.className = 'chat-explore-card';
+    if (isLinkedIn) article.classList.add('is-linkedin');
     applyAstroScope(article);
     article.setAttribute('aria-label', card.title);
 
@@ -912,11 +958,22 @@
 
     const open = document.createElement('a');
     open.className = 'chat-explore-card-open';
+    if (isLinkedIn) open.className = 'chat-explore-card-primary';
     applyAstroScope(open);
     open.href = card.href;
     open.textContent = 'Open';
+    if (card.actionLabel) open.textContent = card.actionLabel;
+    if (isLinkedIn || card.href.startsWith('http')) {
+      open.target = '_blank';
+      open.rel = 'noopener noreferrer';
+    }
 
-    article.append(title, line, open);
+    // LinkedIn confirm is unstacked: title + one primary only (no quiet line).
+    if (isLinkedIn) {
+      article.append(title, open);
+    } else {
+      article.append(title, line, open);
+    }
     chatMessages.appendChild(article);
     chatMessages.scrollTo(0, chatMessages.scrollHeight);
   }

--- a/src/utils/chat-explore.test.ts
+++ b/src/utils/chat-explore.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
 import { DESIGN_SYSTEM_CHIP } from './chat-logic';
-import { EXPLORE_CARDS, exploreCardForQuestion } from './chat-explore';
+import {
+  EXPLORE_CARDS,
+  LINKEDIN_CONFIRM,
+  LINKEDIN_HREF,
+  exploreCardForQuestion,
+} from './chat-explore';
 
 describe('exploreCardForQuestion', () => {
   it('offers the IFS Design System card for the live design-system chip', () => {
@@ -26,14 +31,16 @@ describe('exploreCardForQuestion', () => {
     );
   });
 
-  it('keeps Open as a route on the card, not a hire path', () => {
+  it('keeps action cards on published routes and LinkedIn confirm on the hire path', () => {
     expect(EXPLORE_CARDS.designSystem.href).toBe('/work/ifs-design-system/');
+    expect(EXPLORE_CARDS.designSystem.actionLabel).toBe('View the case');
     expect(EXPLORE_CARDS.copilots.href).toBe('/work/ai-coding-copilots/');
     expect(EXPLORE_CARDS.analytics.href).toBe('/work/user-behavior-analytics/');
     expect(EXPLORE_CARDS.thesis.href).toBe('/work/master-thesis/');
     expect(EXPLORE_CARDS.biography.href).toBe('/biography/');
     expect(EXPLORE_CARDS.work.href).toBe('/work/');
-    expect(exploreCardForQuestion('How do I get in touch on LinkedIn?')).toBeNull();
+    expect(exploreCardForQuestion('How do I get in touch on LinkedIn?')).toEqual(LINKEDIN_CONFIRM);
+    expect(exploreCardForQuestion('How do I get in touch on LinkedIn?')?.href).toBe(LINKEDIN_HREF);
     expect(exploreCardForQuestion('What is your email?')).toBeNull();
     expect(exploreCardForQuestion('Can I download a CV?')).toBeNull();
   });
@@ -53,5 +60,11 @@ describe('exploreCardForQuestion', () => {
     expect(EXPLORE_CARDS.biography.line).toBe('Product Manager, Developer Experience at IFS.');
     expect(EXPLORE_CARDS.work.title).toBe('Work');
     expect(EXPLORE_CARDS.work.line).toBe('The IFS Design System case, then earlier work.');
+    expect(LINKEDIN_CONFIRM.title).toBe('Continue the conversation on LinkedIn');
+    expect(LINKEDIN_CONFIRM.line).toBe('');
+    expect(LINKEDIN_CONFIRM.actionLabel).toBe('Continue on LinkedIn');
+    expect(LINKEDIN_CONFIRM.variant).toBe('linkedin');
+    expect(LINKEDIN_CONFIRM.line).not.toContain('from me');
+    expect(LINKEDIN_CONFIRM.title).not.toContain('from me');
   });
 });

--- a/src/utils/chat-explore.ts
+++ b/src/utils/chat-explore.ts
@@ -2,6 +2,19 @@ export type ExploreCard = {
   title: string;
   line: string;
   href: string;
+  /** action = secondary soft card; linkedin = in-stream confirm with one primary */
+  variant?: 'action' | 'linkedin';
+  actionLabel?: string;
+};
+
+export const LINKEDIN_HREF = 'https://www.linkedin.com/in/alehar/';
+
+export const LINKEDIN_CONFIRM: ExploreCard = {
+  title: 'Continue the conversation on LinkedIn',
+  line: '',
+  href: LINKEDIN_HREF,
+  variant: 'linkedin',
+  actionLabel: 'Continue on LinkedIn',
 };
 
 export const EXPLORE_CARDS = {
@@ -9,31 +22,43 @@ export const EXPLORE_CARDS = {
     title: 'IFS Design System',
     line: 'From the first version to IFS Cloud.',
     href: '/work/ifs-design-system/',
+    variant: 'action',
+    actionLabel: 'View the case',
   },
   copilots: {
     title: 'Internal AI coding copilots',
     line: 'Internal AI coding copilots for IFS engineering teams.',
     href: '/work/ai-coding-copilots/',
+    variant: 'action',
+    actionLabel: 'Open',
   },
   analytics: {
     title: 'User behavior analytics',
     line: 'Usage telemetry for IFS Cloud roadmap decisions.',
     href: '/work/user-behavior-analytics/',
+    variant: 'action',
+    actionLabel: 'Open',
   },
   thesis: {
     title: "Chalmers master's thesis",
     line: "Chalmers master's thesis, 2017.",
     href: '/work/master-thesis/',
+    variant: 'action',
+    actionLabel: 'Open',
   },
   biography: {
     title: 'Biography',
     line: 'Product Manager, Developer Experience at IFS.',
     href: '/biography/',
+    variant: 'action',
+    actionLabel: 'Open',
   },
   work: {
     title: 'Work',
     line: 'The IFS Design System case, then earlier work.',
     href: '/work/',
+    variant: 'action',
+    actionLabel: 'Open',
   },
 } as const satisfies Record<string, ExploreCard>;
 
@@ -41,17 +66,24 @@ export function exploreCardForQuestion(lastUserMessage: string): ExploreCard | n
   const question = lastUserMessage.trim().toLowerCase();
   if (!question) return null;
 
+  // Email / CV stay off — no public email, no placeholder CV.
   if (
-    question.includes('linkedin') ||
-    question.includes('get in touch') ||
-    question.includes('hire') ||
-    /\bcontact\b/.test(question) ||
     question.includes('email') ||
     question.includes('cv') ||
     question.includes('résumé') ||
     question.includes('resume')
   ) {
     return null;
+  }
+
+  // Hire / LinkedIn / contact → in-stream LinkedIn confirm (one primary, unstacked).
+  if (
+    question.includes('linkedin') ||
+    question.includes('get in touch') ||
+    question.includes('hire') ||
+    /\bcontact\b/.test(question)
+  ) {
+    return LINKEDIN_CONFIRM;
   }
 
   if (


### PR DESCRIPTION
## Summary
- One common stage: thread + inline cards + composer (`#741` / Johan craft bar)
- In-thread soft suggestion/action after assistant (IFS Design System → Open proof)
- LinkedIn confirm in the stream: one primary, href `https://www.linkedin.com/in/alehar/`, not a Get in touch clone, not a modal
- Density: one stage card in the recent turn; fade-in; focus 2px accent offset 4px; no scale/glow
- Runtime `data-astro-cid` stamp on dynamic card nodes (same lesson as #742)
- Keep #710 + #740. Overlay `69ca717`. Hire LinkedIn. Live baseline `17cfd31`.

## Test plan
- [ ] 375 + ~1280: first paint #710 PASS
- [ ] Chip send: #740 user bubble + thinking … PASS
- [ ] Design-system chip → soft in-thread Open proof card
- [ ] LinkedIn follow-up → in-stream Continue on LinkedIn (one primary)
- [ ] Composer stays bottom; no modal; no cloned Get in touch in panel

Stay draft. Do not merge until Nick freeze + Johan+Vera dual PASS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LinkedIn contact guidance for relevant questions, including a direct profile link.
  * Explore cards now support custom action labels and improved external-link behavior.
  * Added a specialized LinkedIn card layout with a prominent action button.

* **Bug Fixes**
  * New explore cards now replace older cards cleanly instead of accumulating.
  * Improved card animations, focus states, and hover styling for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->