### PR TITLE
⚡ Kinetic: Portfolio Card Image Zoom & Accessibility Upgrade

### DIFF
--- a/.jules/kinetic.md
+++ b/.jules/kinetic.md
@@ -1,5 +1,15 @@
 # Kinetic Journal ⚡
 
+## 2025-05-22 - Portfolio Card Image Zoom & Accessibility Upgrade
+
+- **Signal:** Portfolio preview card images lacked dynamic visual affordance on card hover/focus.
+- **Action:**
+  - Enhanced `src/components/PortfolioPreview.astro` with hardware-accelerated `transform: scale(1.04)` transition on `.card:hover img` and `.card:focus-visible img`.
+  - Added `@media (prefers-reduced-motion: reduce)` rules to disable card translation, image zoom, and shimmer keyframe animations.
+- **Tokens Added:**
+  - Image Zoom Scale: `scale(1.04)`
+  - Transition Easing: `cubic-bezier(0.22, 1, 0.36, 1)`
+
 ## 2025-05-15 - Interactive Glassmorphism for Skills Section
 
 - **Signal:** Standardized skills box lacked interactive affordance and depth.

--- a/src/components/PortfolioPreview.astro
+++ b/src/components/PortfolioPreview.astro
@@ -127,6 +127,33 @@ const isShimmerEnabled = flagsEntry?.data.portfolio_shimmer_v1 ?? false;
     width: 100%;
     height: 100%;
     object-fit: cover;
+    transition: transform 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .card:hover img,
+  .card:focus-visible img {
+    transform: scale(1.04);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .card,
+    img {
+      transition: none;
+    }
+
+    .card:hover,
+    .card:focus-visible {
+      transform: none;
+    }
+
+    .card:hover img,
+    .card:focus-visible img {
+      transform: none;
+    }
+
+    .card.shimmer:hover::after {
+      animation: none;
+    }
   }
 
   @media (min-width: 50em) {


### PR DESCRIPTION
Added smooth hardware-accelerated image scaling (`transform: scale(1.04)`) to `PortfolioPreview.astro` on hover and focus-visible states, backed by comprehensive prefers-reduced-motion accessibility rules and documented in `.jules/kinetic.md`.

---
*PR created automatically by Jules for task [12537630505161650392](https://jules.google.com/task/12537630505161650392) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added image zoom effects when hovering over or focusing on portfolio cards.
  * Improved accessibility by respecting reduced-motion preferences and disabling animations when requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->