### PR TITLE
Stop twin-mouth me on LinkedIn hire replies

### DIFF
--- a/src/__tests__/chat-api.test.ts
+++ b/src/__tests__/chat-api.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 
 import { env as workerEnv } from 'cloudflare:workers';
 import { POST, type ChatEnv } from '../pages/api/chat';
-import { DESIGN_SYSTEM_CHIP, DESIGN_SYSTEM_PROOF } from '../utils/chat-logic';
+import { DESIGN_SYSTEM_CHIP, DESIGN_SYSTEM_PROOF, LINKEDIN_HIRE_REPLY } from '../utils/chat-logic';
 
 const endpoint = 'https://example.com/api/chat';
 
@@ -92,7 +92,7 @@ describe('chat API', () => {
   it('includes grounded system prompt directives in AI execution call', async () => {
     const ai = createAi();
 
-    await postChat({ messages: [{ role: 'user', content: 'How do I get in touch?' }] }, ai);
+    await postChat({ messages: [{ role: 'user', content: 'How do you work as a PM?' }] }, ai);
 
     const callArgs = ai.run.mock.calls[0];
     const systemMessage = callArgs[1].messages[0];
@@ -100,6 +100,7 @@ describe('chat API', () => {
     expect(systemMessage.content).toContain('Product Manager, Developer Experience');
     expect(systemMessage.content).toContain('linkedin.com/in/alehar');
     expect(systemMessage.content).toContain('Hire path is LinkedIn only');
+    expect(systemMessage.content).toContain('no first-person me/my/I');
     expect(systemMessage.content).toContain('Chalmers B.Sc. Software Engineering');
     expect(systemMessage.content).toContain(
       'Chalmers M.Sc. Management and Economics of Innovation'
@@ -130,6 +131,21 @@ describe('chat API', () => {
     expect(body).toContain('up to 30x ROI');
     expect(body).toContain('Zeroheight runner-up');
     expect(body).toContain(DESIGN_SYSTEM_PROOF);
+  });
+
+  it('returns a visitor-facing LinkedIn hire line without calling the model', async () => {
+    const ai = createAi();
+    const response = await postChat(
+      { messages: [{ role: 'user', content: 'How do I get in touch on LinkedIn?' }] },
+      ai
+    );
+
+    expect(response.status).toBe(200);
+    expect(ai.run).not.toHaveBeenCalled();
+    const body = await response.text();
+    expect(body).toContain(LINKEDIN_HIRE_REPLY);
+    expect(body.toLowerCase()).not.toMatch(/\bfind me\b/);
+    expect(body.toLowerCase()).not.toContain('from me');
   });
 
   it('returns the exact 2x/30x proof for any IFS design-system question', async () => {

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -2,7 +2,7 @@ import type { APIRoute } from 'astro';
 import { env } from 'cloudflare:workers';
 import {
   ChatRequestSchema,
-  groundedDesignSystemAnswer,
+  groundedCannedAnswer,
   pruneMessages,
   sseTextStream,
   type ChatMessage,
@@ -96,6 +96,7 @@ When asked about the IFS Design System, answer with this exact proof: up to 2x f
 Write the digits 2 and 30. Say up to twice as fast (up to 2x) and up to thirty times ROI (up to 30x). Never say "x faster" or "x ROI". Do not mint new ROI.
 AI coding copilots is current DevEx work. Do not invent copilots metrics.
 Hire path is LinkedIn only: https://www.linkedin.com/in/alehar/. Do not invent email, a résumé, or availability. Do not tell the UI to add a Get in touch button.
+When the visitor asks about hire, contact, LinkedIn, or getting in touch: answer in visitor-facing voice with no first-person me/my/I. Prefer exactly: Continue on LinkedIn: https://www.linkedin.com/in/alehar/. Do not say find me, from me, my LinkedIn, or I. The UI may show a LinkedIn confirm card.
 Recruiter keywords (not a fake title): Product Management, Developer Experience, DevEx, AI coding copilots, design systems, Industrial AI, IFS Cloud, platform, product strategy.
 Keep answers brief (2-3 sentences). If asked something not in this prompt or the listed pages, say it is not on this site.
 
@@ -174,7 +175,7 @@ export const POST: APIRoute = async ({ request }) => {
 
   const prunedMessages = pruneMessages(result.data.messages as ChatMessage[]);
   const lastUser = [...prunedMessages].reverse().find((message) => message.role === 'user');
-  const canned = lastUser ? groundedDesignSystemAnswer(lastUser.content) : null;
+  const canned = lastUser ? groundedCannedAnswer(lastUser.content) : null;
 
   try {
     const stream = canned

--- a/src/utils/chat-logic.test.ts
+++ b/src/utils/chat-logic.test.ts
@@ -3,6 +3,12 @@ import {
   pruneMessages,
   MAX_MESSAGES,
   MAX_TOTAL_CONTENT_LENGTH,
+  DESIGN_SYSTEM_CHIP,
+  DESIGN_SYSTEM_PROOF,
+  LINKEDIN_HIRE_REPLY,
+  groundedCannedAnswer,
+  groundedDesignSystemAnswer,
+  groundedLinkedInHireAnswer,
   type ChatMessage,
 } from './chat-logic';
 
@@ -112,6 +118,24 @@ describe('chat logic utilities', () => {
       const pruned = pruneMessages(messages);
       expect(pruned[0].role).toBe('user');
       expect(pruned[0].content).toBe('Final user question');
+    });
+  });
+
+  describe('grounded canned answers', () => {
+    it('returns the design-system proof for the live chip', () => {
+      expect(groundedDesignSystemAnswer(DESIGN_SYSTEM_CHIP)).toBe(DESIGN_SYSTEM_PROOF);
+      expect(groundedCannedAnswer(DESIGN_SYSTEM_CHIP)).toBe(DESIGN_SYSTEM_PROOF);
+    });
+
+    it('returns a visitor-facing LinkedIn hire line with no twin-mouth me/my/I', () => {
+      expect(groundedLinkedInHireAnswer('How do I get in touch on LinkedIn?')).toBe(
+        LINKEDIN_HIRE_REPLY
+      );
+      expect(groundedCannedAnswer('How do I get in touch?')).toBe(LINKEDIN_HIRE_REPLY);
+      expect(LINKEDIN_HIRE_REPLY).toBe('Continue on LinkedIn: https://www.linkedin.com/in/alehar/');
+      expect(LINKEDIN_HIRE_REPLY.toLowerCase()).not.toMatch(/\b(me|my|i)\b/);
+      expect(groundedLinkedInHireAnswer('What is your email?')).toBeNull();
+      expect(groundedLinkedInHireAnswer('Can I download a CV?')).toBeNull();
     });
   });
 });

--- a/src/utils/chat-logic.ts
+++ b/src/utils/chat-logic.ts
@@ -66,6 +66,36 @@ export function groundedDesignSystemAnswer(lastUserMessage: string): string | nu
   return null;
 }
 
+/** Visitor-facing hire line — no twin-mouth me/my/I. Card still carries the primary. */
+export const LINKEDIN_HIRE_REPLY = 'Continue on LinkedIn: https://www.linkedin.com/in/alehar/';
+
+export function groundedLinkedInHireAnswer(lastUserMessage: string): string | null {
+  const question = lastUserMessage.trim().toLowerCase();
+  if (!question) return null;
+  // Email / CV stay off the twin — no public email, no placeholder CV.
+  if (
+    question.includes('email') ||
+    question.includes('cv') ||
+    question.includes('résumé') ||
+    question.includes('resume')
+  ) {
+    return null;
+  }
+  if (
+    question.includes('linkedin') ||
+    question.includes('get in touch') ||
+    question.includes('hire') ||
+    /\bcontact\b/.test(question)
+  ) {
+    return LINKEDIN_HIRE_REPLY;
+  }
+  return null;
+}
+
+export function groundedCannedAnswer(lastUserMessage: string): string | null {
+  return groundedDesignSystemAnswer(lastUserMessage) ?? groundedLinkedInHireAnswer(lastUserMessage);
+}
+
 export function sseTextStream(text: string): ReadableStream<Uint8Array> {
   const body = `data: ${JSON.stringify({ response: text })}\n\ndata: [DONE]\n\n`;
   return new ReadableStream({


### PR DESCRIPTION
## Summary
- Live FAIL after #743: assistant said `You can find me on LinkedIn…` (twin-mouth me)
- Canned hire reply: `Continue on LinkedIn: https://www.linkedin.com/in/alehar/` (no me/my/I)
- System prompt guard for residual model answers on hire/contact/LinkedIn
- Confirm card still carries the one primary

## Test plan
- [ ] Ask "How do I get in touch on LinkedIn?" → canned visitor-facing line, no find me / from me
- [ ] LinkedIn confirm card still in-stream with one primary
- [ ] #710 + #740 hold; Overlay 69ca717; Hire LinkedIn

Stay draft until Nick freeze + Johan+Vera.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visitor-facing responses for hiring, contact, and LinkedIn inquiries.
  * Responses include a direct LinkedIn continuation link and may display a confirmation card.
  * Added consistent design-system responses for supported questions.

* **Bug Fixes**
  * Prevented first-person wording in visitor-facing replies.
  * Unrelated email and résumé requests no longer trigger LinkedIn responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->