### PR TITLE
Wrap IFS case tags on 375 — no page side-scroll (#754)

### DIFF
--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -189,11 +189,17 @@ const robots = entry?.id === 'lidkoping-stenhuggeri' ? 'noindex' : undefined;
     gap: 1.5rem;
     justify-content: space-between;
     align-items: center;
+    max-width: 100%;
+    box-sizing: border-box;
   }
 
   .tags {
     display: flex;
+    flex-wrap: wrap;
     gap: 0.5rem;
+    justify-content: center;
+    max-width: 100%;
+    box-sizing: border-box;
   }
 
   .description {


### PR DESCRIPTION
## Summary
- 375 `/work/ifs-design-system/`: `div.tags` wraps so Design System, Product Experience, Scaling stay fully readable
- No ellipsis-as-solution; no invented shorter labels
- Case-local CSS in `src/pages/work/[...slug].astro` only
- Keep #710 + #740 + #741. Overlay `69ca717`. Hire LinkedIn.

## Test plan
- [ ] 375: all three tags fully readable
- [ ] No horizontal page scroll (`scrollWidth` ≤ `clientWidth` + 1px)
- [ ] 1280 optional: tags may stay one row if they fit

Stay draft until Nick freeze + Johan+Vera.
