### PR TITLE
Janitor: Typo & Terminology Alignment

### DIFF
--- a/.Janitor/hygiene.md
+++ b/.Janitor/hygiene.md
@@ -3,7 +3,7 @@
 | Date       | Corrected File                    | Correction                                                                               | Status      |
 | :--------- | :-------------------------------- | :--------------------------------------------------------------------------------------- | :---------- |
 | 2025-03-24 | N/A                               | Initialized Journal                                                                      | Initialized |
-| 2025-03-24 | worker-configuration.d.ts         | Removed 'the the' typos from documentation comments                                      | Validated   |
+| 2025-03-24 | worker-configuration.d.ts         | Removed duplicate 'The' from MessageEvent.data JSDoc documentation comment               | Validated   |
 | 2025-03-24 | context/author-linkedin.md        | Normalized Swedish terms (Produktchef, Produktledning) and removed duplicate text blocks | Validated   |
 | 2025-03-24 | src/content/work/master-thesis.md | Improved grammatical phrasing in the concluding paragraph                                | Validated   |
 

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -1506,7 +1506,7 @@ interface ErrorEventErrorEventInit {
 declare class MessageEvent extends Event {
   constructor(type: string, initializer: MessageEventInit);
   /**
-   * The **`data`** read-only property of the The data sent by the message emitter; this can be any data type, depending on what originated this event.
+   * The **`data`** read-only property of the data sent by the message emitter; this can be any data type, depending on what originated this event.
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/data)
    */


### PR DESCRIPTION
🧹 Janitor run: Fixed duplicate 'The' typo in MessageEvent.data JSDoc comment in worker-configuration.d.ts and updated .Janitor/hygiene.md. All linting, formatting, type checking, unit tests, and production build checks passed.

---
*PR created automatically by Jules for task [3046919035362893476](https://jules.google.com/task/3046919035362893476) started by @alehar9320*