### PR TITLE
Impressive home first-view — Eden copy + calm wash (#761)

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -13,7 +13,10 @@ const files = [
 ];
 
 describe('identity copy', () => {
-  const sources = files.map((path) => ({ path, text: readFileSync(path, 'utf8') }));
+  const sources = files.map((path) => ({
+    path,
+    text: readFileSync(path, 'utf8'),
+  }));
 
   it('does not use Strategic Product Leader in about, biography, meta, llms.txt, or the twin prompt', () => {
     for (const { path, text } of sources) {
@@ -77,7 +80,8 @@ describe('identity copy', () => {
     expect(home).toContain('justify-content: flex-start');
     expect(home).toContain('https://www.linkedin.com/in/alehar/');
     expect(home).toContain('Get in touch');
-    expect(home).toContain('class="cta-hint">LinkedIn</p>');
+    expect(home).toContain('class="cta-hint"');
+    expect(home).toContain('>LinkedIn</p>');
     expect(home).not.toContain('LinkedIn · replies from me');
     expect(home).toContain('class="hero-copy"');
     expect(home).toContain('proof-card');
@@ -99,7 +103,7 @@ describe('identity copy', () => {
     expect(home).toContain('Hero title="Product Manager, Developer Experience at IFS"');
     expect(home).toContain('class="hero-dek"');
     expect(home).toContain('developer platforms');
-    expect(home).toContain('design systems');
+    expect(home).toContain('Design systems');
     expect(home).toContain('Industrial AI copilots');
     expect(home).not.toContain('not only DevEx');
     expect(home).toContain('Chalmers software engineering');
@@ -650,7 +654,8 @@ describe('identity copy', () => {
     expect(chat).not.toContain('layoutProminentPhone');
     expect(home).toContain('cta-hint');
     expect(home).toContain('Get in touch');
-    expect(home).toContain('class="cta-hint">LinkedIn</p>');
+    expect(home).toContain('class="cta-hint"');
+    expect(home).toContain('>LinkedIn</p>');
     expect(home).not.toContain('LinkedIn · replies from me');
     expect(home).toContain('body.has-prominent-chat');
     expect(home).toContain('padding-bottom: 36dvh');
@@ -728,16 +733,15 @@ describe('identity copy', () => {
     expect(home).toContain('Hero title="Product Manager, Developer Experience at IFS"');
     expect(home).toContain('class="hero-dek"');
     expect((home.match(/class="hero-dek"/g) || []).length).toBe(1);
-    expect(home).toContain(
-      'Design systems, developer platforms, and Industrial AI copilots.'
-    );
+    expect(home).toContain('Design systems, developer platforms, and Industrial AI copilots.');
     expect(home).not.toContain('Also hireable');
     expect(home).not.toContain('not only DevEx');
     expect(home).toContain('class="hero-bridge"');
-    expect(home.replace(/\s+/g, ' ')).toContain('eight years at IFS');
+    expect(home).toContain('Eight years at IFS');
     expect(home).toContain('Chalmers software engineering');
     expect(home).toContain('Get in touch');
-    expect(home).toContain('class="cta-hint">LinkedIn</p>');
+    expect(home).toContain('class="cta-hint"');
+    expect(home).toContain('>LinkedIn</p>');
     expect(home).not.toContain('LinkedIn · replies from me');
     expect(home).toContain('https://www.linkedin.com/in/alehar/');
     expect(home).toContain('proof-card');

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -77,10 +77,11 @@ describe('identity copy', () => {
     expect(home).toContain('justify-content: flex-start');
     expect(home).toContain('https://www.linkedin.com/in/alehar/');
     expect(home).toContain('Get in touch');
-    expect(home).toContain('LinkedIn · replies from me');
+    expect(home).toContain('class="cta-hint">LinkedIn</p>');
+    expect(home).not.toContain('LinkedIn · replies from me');
     expect(home).toContain('class="hero-copy"');
     expect(home).toContain('proof-card');
-    expect(home).toContain('From the first version to IFS Cloud.');
+    expect(home).toContain('Took the design system from first version to IFS Cloud.');
     expect(home).not.toContain('inception');
     expect(home).not.toContain('mailto:');
     expect((home.match(/<Hero/g) || []).length).toBe(1);
@@ -100,12 +101,12 @@ describe('identity copy', () => {
     expect(home).toContain('developer platforms');
     expect(home).toContain('design systems');
     expect(home).toContain('Industrial AI copilots');
-    expect(home).toContain('not only DevEx');
+    expect(home).not.toContain('not only DevEx');
     expect(home).toContain('Chalmers software engineering');
-    expect(home).toContain('MEI');
-    expect(home.replace(/\s+/g, ' ')).toContain('eight years at IFS');
+    expect(home).not.toContain('MEI');
+    expect(home).toContain('Eight years at IFS');
     expect(home).toContain('IFS Design System');
-    expect(home).toContain('copilots, analytics, and thesis');
+    expect(home).toContain('Design system, copilots, and analytics.');
     expect(home).toContain('https://www.linkedin.com/in/alehar/');
     expect(home).toContain('Get in touch');
     expect(home).not.toContain('mailto:');
@@ -649,7 +650,8 @@ describe('identity copy', () => {
     expect(chat).not.toContain('layoutProminentPhone');
     expect(home).toContain('cta-hint');
     expect(home).toContain('Get in touch');
-    expect(home).toContain('LinkedIn · replies from me');
+    expect(home).toContain('class="cta-hint">LinkedIn</p>');
+    expect(home).not.toContain('LinkedIn · replies from me');
     expect(home).toContain('body.has-prominent-chat');
     expect(home).toContain('padding-bottom: 36dvh');
     expect(home).not.toContain('padding-right: min(34rem, 48vw)');
@@ -727,17 +729,19 @@ describe('identity copy', () => {
     expect(home).toContain('class="hero-dek"');
     expect((home.match(/class="hero-dek"/g) || []).length).toBe(1);
     expect(home).toContain(
-      'Also hireable for product work across developer platforms, design systems, and'
+      'Design systems, developer platforms, and Industrial AI copilots.'
     );
-    expect(home).toContain('Industrial AI copilots, not only DevEx.');
+    expect(home).not.toContain('Also hireable');
+    expect(home).not.toContain('not only DevEx');
     expect(home).toContain('class="hero-bridge"');
     expect(home.replace(/\s+/g, ' ')).toContain('eight years at IFS');
     expect(home).toContain('Chalmers software engineering');
     expect(home).toContain('Get in touch');
-    expect(home).toContain('LinkedIn · replies from me');
+    expect(home).toContain('class="cta-hint">LinkedIn</p>');
+    expect(home).not.toContain('LinkedIn · replies from me');
     expect(home).toContain('https://www.linkedin.com/in/alehar/');
     expect(home).toContain('proof-card');
-    expect(home).toContain('Zeroheight runner-up');
+    expect(home).toContain('Zeroheight Design System Awards, runner-up');
     expect(home).not.toContain('mailto:');
     expect(home).not.toMatch(/\bVP\b/);
     expect(hero).toContain('font-size: var(--text-xl)');

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -13,10 +13,7 @@ const files = [
 ];
 
 describe('identity copy', () => {
-  const sources = files.map((path) => ({
-    path,
-    text: readFileSync(path, 'utf8'),
-  }));
+  const sources = files.map((path) => ({ path, text: readFileSync(path, 'utf8') }));
 
   it('does not use Strategic Product Leader in about, biography, meta, llms.txt, or the twin prompt', () => {
     for (const { path, text } of sources) {
@@ -80,8 +77,7 @@ describe('identity copy', () => {
     expect(home).toContain('justify-content: flex-start');
     expect(home).toContain('https://www.linkedin.com/in/alehar/');
     expect(home).toContain('Get in touch');
-    expect(home).toContain('class="cta-hint"');
-    expect(home).toContain('>LinkedIn</p>');
+    expect(home).toContain('class="cta-hint">LinkedIn</p>');
     expect(home).not.toContain('LinkedIn · replies from me');
     expect(home).toContain('class="hero-copy"');
     expect(home).toContain('proof-card');
@@ -654,8 +650,7 @@ describe('identity copy', () => {
     expect(chat).not.toContain('layoutProminentPhone');
     expect(home).toContain('cta-hint');
     expect(home).toContain('Get in touch');
-    expect(home).toContain('class="cta-hint"');
-    expect(home).toContain('>LinkedIn</p>');
+    expect(home).toContain('class="cta-hint">LinkedIn</p>');
     expect(home).not.toContain('LinkedIn · replies from me');
     expect(home).toContain('body.has-prominent-chat');
     expect(home).toContain('padding-bottom: 36dvh');
@@ -737,11 +732,10 @@ describe('identity copy', () => {
     expect(home).not.toContain('Also hireable');
     expect(home).not.toContain('not only DevEx');
     expect(home).toContain('class="hero-bridge"');
-    expect(home).toContain('Eight years at IFS');
+    expect(home.replace(/\s+/g, ' ')).toContain('Eight years at IFS');
     expect(home).toContain('Chalmers software engineering');
     expect(home).toContain('Get in touch');
-    expect(home).toContain('class="cta-hint"');
-    expect(home).toContain('>LinkedIn</p>');
+    expect(home).toContain('class="cta-hint">LinkedIn</p>');
     expect(home).not.toContain('LinkedIn · replies from me');
     expect(home).toContain('https://www.linkedin.com/in/alehar/');
     expect(home).toContain('proof-card');

--- a/src/components/CallToAction.astro
+++ b/src/components/CallToAction.astro
@@ -42,15 +42,13 @@ const {
     line-height: 1.1;
     border-radius: 999rem;
     overflow: hidden;
-    background-image: var(--gradient-accent-orange);
-    background-size: 300% 300%;
-    background-position: 0% 50%;
-    box-shadow: var(--shadow-md);
+    background-color: var(--accent-regular);
+    background-image: none;
+    box-shadow: var(--shadow-sm);
     white-space: nowrap;
     transition:
-      background-position 0.6s cubic-bezier(0.22, 1, 0.36, 1),
-      transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1),
-      box-shadow 0.3s ease;
+      background-color 0.2s ease,
+      box-shadow 0.2s ease;
   }
 
   @media (min-width: 20em) {
@@ -61,11 +59,8 @@ const {
 
   a:hover,
   a:focus-visible {
-    background-position: 100% 50%;
-    transform: translateY(-3px) scale(1.02);
-    box-shadow:
-      0 12px 30px -5px hsla(210, 100%, 50%, 0.6),
-      var(--shadow-md);
+    background-color: var(--accent-dark);
+    box-shadow: var(--shadow-md);
   }
 
   a:focus-visible {
@@ -74,8 +69,7 @@ const {
   }
 
   a:active {
-    background-position: 50% 50%;
-    transform: translateY(0) scale(0.97);
+    background-color: var(--accent-dark);
     box-shadow: var(--shadow-sm);
   }
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -148,28 +148,28 @@ const { title, description, ogTitle, shareUrl, canonicalUrl, robots } = Astro.pr
 
       .aurora-wash-a {
         background: radial-gradient(
-          ellipse 55% 45% at 28% 22%,
+          ellipse 48% 36% at 26% 18%,
           var(--accent-light),
-          transparent 70%
+          transparent 72%
         );
-        opacity: 0.28;
+        opacity: 0.14;
       }
 
       .aurora-wash-b {
         background: radial-gradient(
-          ellipse 50% 55% at 78% 38%,
+          ellipse 42% 40% at 80% 32%,
           var(--accent-regular),
-          transparent 68%
+          transparent 70%
         );
-        opacity: 0.22;
+        opacity: 0.1;
       }
 
       :root.theme-dark .aurora-wash-a {
-        opacity: 0.55;
+        opacity: 0.28;
       }
 
       :root.theme-dark .aurora-wash-b {
-        opacity: 0.45;
+        opacity: 0.22;
       }
 
       @media (prefers-reduced-motion: no-preference) {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -73,8 +73,7 @@ const schema = {
       <div class="hero-copy">
         <Hero title="Product Manager, Developer Experience at IFS" align="start">
           <p class="hero-dek">
-            Also hireable for product work across developer platforms, design systems, and
-            Industrial AI copilots, not only DevEx.
+            Design systems, developer platforms, and Industrial AI copilots.
           </p>
           <div class="hero-actions">
             <CallToAction
@@ -86,26 +85,25 @@ const schema = {
             >
               Get in touch
             </CallToAction>
-            <p class="cta-hint">LinkedIn · replies from me</p>
+            <p class="cta-hint">LinkedIn</p>
           </div>
         </Hero>
         <section class="proof" aria-label="Proof">
           <a class="proof-card" href="/work/ifs-design-system/">
             <p class="proof-eyebrow">IFS Design System</p>
-            <p class="proof-outcome">From the first version to IFS Cloud.</p>
+            <p class="proof-outcome">Took the design system from first version to IFS Cloud.</p>
             <p class="proof-chips">
               <span>Up to 2x faster delivery</span>
               <span aria-hidden="true">·</span>
               <span>Up to 30x ROI</span>
               <span aria-hidden="true">·</span>
-              <span>Zeroheight runner-up</span>
+              <span>Zeroheight Design System Awards, runner-up</span>
             </p>
             <p class="proof-affordance">Read the case</p>
           </a>
         </section>
         <p class="hero-bridge">
-          Chalmers software engineering and MEI, eight years at IFS, the IFS Design System, plus
-          copilots, analytics, and thesis work.
+          Chalmers software engineering. Eight years at IFS. Design system, copilots, and analytics.
         </p>
       </div>
     </header>
@@ -118,8 +116,8 @@ const schema = {
     min-height: 100svh;
     min-height: 100dvh;
     justify-content: flex-start;
-    gap: 1.5rem;
-    padding-block: 1rem var(--chat-fab-clearance);
+    gap: 1rem;
+    padding-block: 0.75rem var(--chat-fab-clearance);
     box-sizing: border-box;
   }
 
@@ -127,14 +125,14 @@ const schema = {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 1.25rem;
+    gap: 0.85rem;
     padding-bottom: 0;
   }
 
   .hero-copy {
     display: flex;
     flex-direction: column;
-    gap: 1.25rem;
+    gap: 0.85rem;
     width: 100%;
   }
 
@@ -157,7 +155,7 @@ const schema = {
   }
 
   .hero-actions {
-    margin-top: 0.75rem;
+    margin-top: 0.5rem;
     display: flex;
     flex-direction: column;
     flex-wrap: wrap;
@@ -194,15 +192,18 @@ const schema = {
   .proof-eyebrow {
     margin: 0;
     font-size: var(--text-sm);
-    color: var(--gray-300);
-    letter-spacing: 0.04em;
+    font-weight: 600;
+    color: var(--gray-200);
+    letter-spacing: 0.06em;
     text-transform: uppercase;
   }
 
   .proof-outcome {
     margin: 0;
     font-size: var(--text-xl);
+    font-weight: 650;
     color: var(--gray-0);
+    letter-spacing: -0.01em;
   }
 
   .proof-chips {
@@ -229,7 +230,7 @@ const schema = {
 
     .hero {
       padding-inline: 2.5rem;
-      gap: 3.75rem;
+      gap: 1.75rem;
       padding-bottom: 0;
     }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -199,7 +199,7 @@ const schema = {
   .proof-outcome {
     margin: 0;
     font-size: var(--text-xl);
-    font-weight: 600;
+    font-weight: 650;
     color: var(--gray-0);
     letter-spacing: -0.01em;
   }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -72,9 +72,7 @@ const schema = {
     <header class="hero">
       <div class="hero-copy">
         <Hero title="Product Manager, Developer Experience at IFS" align="start">
-          <p class="hero-dek">
-            Design systems, developer platforms, and Industrial AI copilots.
-          </p>
+          <p class="hero-dek">Design systems, developer platforms, and Industrial AI copilots.</p>
           <div class="hero-actions">
             <CallToAction
               href={linkedinHref}
@@ -117,7 +115,7 @@ const schema = {
     min-height: 100dvh;
     justify-content: flex-start;
     gap: 1rem;
-    padding-block: 0.75rem var(--chat-fab-clearance);
+    padding-block: 1rem var(--chat-fab-clearance);
     box-sizing: border-box;
   }
 
@@ -201,7 +199,7 @@ const schema = {
   .proof-outcome {
     margin: 0;
     font-size: var(--text-xl);
-    font-weight: 650;
+    font-weight: 600;
     color: var(--gray-0);
     letter-spacing: -0.01em;
   }


### PR DESCRIPTION
## Summary
Closes #761.

Soft → assertive home first-view (separate from #760):
- **Eden locked copy:** dek, quiet `LinkedIn`, case headline, Zeroheight award line, bio bridge
- **Calm aurora wash** (secondary, not candy hero)
- **Solid accent** `Get in touch` (no cyan gradient / no scale)
- Tighter fold density + clearer proof hierarchy

### Keep
H1 `Product Manager, Developer Experience at IFS`. CTA Get in touch → LinkedIn. Read the case. Up to 2x / up to 30x. Overlay `69ca717`. #710+#740+#741. Ericsson stays in README.

## Test plan
- [ ] 375 + 1280: wash secondary; fold not pastel-soft
- [ ] CTA solid accent; quiet line is `LinkedIn` only
- [ ] Eden strings exact; no twin-mouth me; “up to” stays
- [ ] #710 docked first paint; #740/#741 not regressed

Stay draft until Nick freeze + hashed `*-me.alehar.workers.dev`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Content Updates**
  - Refreshed homepage messaging to highlight design systems, developer platforms, and Industrial AI copilots.
  - Simplified the LinkedIn call-to-action hint.
  - Expanded project proof points and updated award wording.

- **Visual Improvements**
  - Reduced hero-section spacing for a more compact layout.
  - Improved proof-card typography.
  - Refined background gradients for subtler light and dark themes.
  - Simplified call-to-action hover, focus, and active states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->