### PR TITLE
⚙️ Engine: Optimize chat history pruning and GitHub release changelog parser

### DIFF
--- a/.jules/engine.md
+++ b/.jules/engine.md
@@ -6,3 +6,8 @@
 - **New Utility:** Established `pruneMessages` which implements a sliding window algorithm to maintain conversation history within Cloudflare Workers AI limits (10 messages, 3000 total characters).
 - **TypeScript & Validation:** Leveraged Zod for strict schema validation of chat requests and messages, ensuring runtime safety and defensive error handling.
 - **Performance:** Pruning happens on the edge to minimize payload size sent to the AI model, improving response latency and reliability.
+
+## 2025-05-21 - Pointer-Based Context Pruning & Single-Pass Changelog Parsing
+
+- **Performance & Edge Memory:** Refactored `pruneMessages` sliding-window logic in `src/utils/chat-logic.ts` to use pointer bounds slicing instead of repeated `.shift()` calls, eliminating $O(N^2)$ array re-indexing overhead during context window trimming.
+- **Changelog Parsing:** Updated `parseReleaseItem` commit hash regex in `src/utils/github-releases.ts` to support 7 to 40-character hex commit SHAs. Refactored `splitReleaseBody` from a multi-stage array chain into a single-pass `for...of` loop to eliminate intermediate array allocations on Cloudflare Workers edge runtimes.

--- a/src/__tests__/github-releases.test.ts
+++ b/src/__tests__/github-releases.test.ts
@@ -161,9 +161,9 @@ describe('github releases utility', () => {
     );
   });
 
-  it('parses commit hashes from release items with various markers', () => {
+  it('parses commit hashes from release items with various markers and variable hash lengths', () => {
     const body =
-      '* 8acc628 ✍️ Scribe: Strategic Copy Optimization\n+ 1234567 fix: some issue\n- plain message';
+      '* 8acc628 ✍️ Scribe: Strategic Copy Optimization\n+ 12345678 fix: 8-char hash issue\n- 40481fa790b8d54d7e2c040d1a49826354fb2206 feat: 40-char full sha\n- plain message';
     const items = splitReleaseBody(body);
 
     expect(items).toEqual([
@@ -173,9 +173,14 @@ describe('github releases utility', () => {
         url: 'https://github.com/alehar9320/astro-cloudflare-personal-website/commit/8acc628',
       },
       {
-        hash: '1234567',
-        message: 'fix: some issue',
-        url: 'https://github.com/alehar9320/astro-cloudflare-personal-website/commit/1234567',
+        hash: '12345678',
+        message: 'fix: 8-char hash issue',
+        url: 'https://github.com/alehar9320/astro-cloudflare-personal-website/commit/12345678',
+      },
+      {
+        hash: '40481fa790b8d54d7e2c040d1a49826354fb2206',
+        message: 'feat: 40-char full sha',
+        url: 'https://github.com/alehar9320/astro-cloudflare-personal-website/commit/40481fa790b8d54d7e2c040d1a49826354fb2206',
       },
       {
         message: 'plain message',

--- a/src/utils/chat-logic.ts
+++ b/src/utils/chat-logic.ts
@@ -33,20 +33,23 @@ export const ChatRequestSchema = z.object({
  * @returns A pruned array of messages that satisfies all constraints.
  */
 export function pruneMessages(messages: ChatMessage[]): ChatMessage[] {
-  const pruned = messages.slice(-MAX_MESSAGES);
-  let totalLength = pruned.reduce((acc, msg) => acc + msg.content.length, 0);
+  const windowed = messages.slice(-MAX_MESSAGES);
+  if (windowed.length <= 1) return windowed;
 
-  while (pruned.length > 1 && totalLength > MAX_TOTAL_CONTENT_LENGTH) {
-    // biome-ignore lint/style/noNonNullAssertion: loop guard ensures shift() returns an element
-    totalLength -= pruned.shift()!.content.length;
+  let start = 0;
+  let totalLength = windowed.reduce((acc, msg) => acc + msg.content.length, 0);
+
+  while (start < windowed.length - 1 && totalLength > MAX_TOTAL_CONTENT_LENGTH) {
+    totalLength -= windowed[start].content.length;
+    start += 1;
   }
 
-  while (pruned.length > 1 && pruned[0].role === 'assistant') {
-    // biome-ignore lint/style/noNonNullAssertion: loop guard ensures shift() returns an element
-    totalLength -= pruned.shift()!.content.length;
+  while (start < windowed.length - 1 && windowed[start].role === 'assistant') {
+    totalLength -= windowed[start].content.length;
+    start += 1;
   }
 
-  return pruned;
+  return start > 0 ? windowed.slice(start) : windowed;
 }
 
 export const DESIGN_SYSTEM_CHIP = 'What did the IFS design system change?';

--- a/src/utils/github-releases.ts
+++ b/src/utils/github-releases.ts
@@ -186,8 +186,8 @@ export function formatReleaseDate(dateString: string | null): string {
  */
 export function parseReleaseItem(line: string): ReleaseItem {
   const cleaned = line.trim();
-  // Matches a 7-character hex hash at the beginning
-  const hashMatch = cleaned.match(/^([a-f0-9]{7})\s+(.*)/);
+  // Matches a 7 to 40-character hex hash at the beginning
+  const hashMatch = cleaned.match(/^([a-f0-9]{7,40})\s+(.*)/i);
 
   if (hashMatch) {
     const hash = hashMatch[1];
@@ -213,17 +213,26 @@ export function isPublicChangelogItem(item: ReleaseItem): boolean {
  * Splits a release body into individual, formatted ReleaseItem objects.
  * Filters for lines starting with list markers (-, *, +).
  * Drops Jules, agent-farm, and Johan-nits internals from the public list.
+ * Single-pass implementation to minimize allocations on edge runtimes.
  * @param {string} body - The full Markdown body of a GitHub release.
  * @returns {ReleaseItem[]} An array of parsed release items.
  */
 export function splitReleaseBody(body: string): ReleaseItem[] {
-  return body
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => /^[-*+]\s+/.test(line))
-    .map((line) => line.replace(/^[-*+]\s+/, ''))
-    .map(parseReleaseItem)
-    .filter(isPublicChangelogItem);
+  const lines = body.split('\n');
+  const items: ReleaseItem[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!/^[-*+]\s+/.test(trimmed)) continue;
+
+    const rawMessage = trimmed.replace(/^[-*+]\s+/, '');
+    const item = parseReleaseItem(rawMessage);
+    if (isPublicChangelogItem(item)) {
+      items.push(item);
+    }
+  }
+
+  return items;
 }
 
 export { RELEASES_PAGE_URL };


### PR DESCRIPTION
Refactors context window message pruning to use pointer index slicing instead of repeated array shift operations. Expands commit hash parsing to support 7-40 character hex SHAs and converts changelog bullet extraction to a single-pass loop for lower allocation overhead on Cloudflare Workers edge runtime.

---
*PR created automatically by Jules for task [6314991711352021678](https://jules.google.com/task/6314991711352021678) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release parsing to recognize commit hashes ranging from 7 to 40 characters.
  * Preserved release-note filtering while improving handling of formatted entries.

* **Performance**
  * Improved chat-history pruning efficiency for large message collections.
  * Reduced unnecessary processing when parsing release content.

* **Tests**
  * Added coverage for short and full-length commit hashes in release parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->