### PR TITLE
🎨 Palette: Enhance focus-within state on Skills card component

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -47,3 +47,9 @@
 **Learning:** To optimize Largest Contentful Paint (LCP) in Astro projects, primary visual assets (like hero images) and the first items in repeated galleries should be prioritised by the browser. Applying `loading="eager"` and `fetchpriority="high"` to these elements prevents the browser from delaying their loading, ensuring a faster perceived performance for users.
 
 **Action:** Enhanced the `PortfolioPreview` component to support dynamic `loading` and `fetchpriority` props. Updated `index.astro` and `work.astro` to prioritise the first project in their respective galleries. Explicitly added `loading="eager"` to the primary portrait image on the home page.
+
+## 2026-05-20 - Synchronizing Focus-Within Spatial Feedback on Card Containers
+
+**Learning:** When interactive elements (such as external links or buttons) are embedded inside card containers or section boxes (e.g., `Skills.astro`), hover effects alone leave keyboard users without container-level spatial feedback when tabbing through content. Adding `:focus-within` selectors alongside `:hover` ensures card elevation, border highlights, and micro-interactions (like icon pulsing) activate seamlessly during keyboard navigation.
+
+**Action:** Updated `.box` container and `.pulse-enabled .stack` in `src/components/Skills.astro` to include `:focus-within` states alongside `:hover`, matching reduced-motion accessibility rules.

--- a/src/components/Skills.astro
+++ b/src/components/Skills.astro
@@ -55,7 +55,8 @@ const flagsEntry = await getEntry('flags', 'config');
       border-color var(--theme-transition);
   }
 
-  .box:hover {
+  .box:hover,
+  .box:focus-within {
     transform: translateY(-4px);
     border-color: var(--accent-regular);
     box-shadow:
@@ -67,7 +68,8 @@ const flagsEntry = await getEntry('flags', 'config');
     .box {
       transition: none;
     }
-    .box:hover {
+    .box:hover,
+    .box:focus-within {
       transform: none;
     }
   }
@@ -86,7 +88,8 @@ const flagsEntry = await getEntry('flags', 'config');
     color: var(--gray-400);
   }
   @media (prefers-reduced-motion: no-preference) {
-    .pulse-enabled .stack:hover :global(svg) {
+    .pulse-enabled .stack:hover :global(svg),
+    .pulse-enabled .stack:focus-within :global(svg) {
       animation: pulse 0.6s ease;
     }
   }


### PR DESCRIPTION
Adds :focus-within styling to .box containers and pulse-enabled icon wrappers in src/components/Skills.astro. This provides keyboard users with spatial elevation and micro-interaction visual feedback consistent with mouse hover states.

---
*PR created automatically by Jules for task [1513770020186707667](https://jules.google.com/task/1513770020186707667) started by @alehar9320*