### PR TITLE
Apex: hard-abort farmed experimental stack/uses pages

### DIFF
--- a/.Jules/apex.md
+++ b/.Jules/apex.md
@@ -3,6 +3,7 @@
 Read this before scouting. If the idea is one of these, ABORT the cycle. Do not downscope into a sibling route with the same job. Do not open a PR.
 
 Do NOT recreate:
+
 - `/experimental/dx-stack`
 - `/experimental/uses`
 - `/experimental/stack`

--- a/.Jules/apex.md
+++ b/.Jules/apex.md
@@ -1,3 +1,21 @@
+# HARD ABORT — farmed experimental stack/uses pages
+
+Read this before scouting. If the idea is one of these, ABORT the cycle. Do not downscope into a sibling route with the same job. Do not open a PR.
+
+Do NOT recreate:
+- `/experimental/dx-stack`
+- `/experimental/uses`
+- `/experimental/stack`
+- any noindex experimental stack/uses page
+
+Already closed as farm: #768, #732, #718, #702.
+
+Prefer visitor-facing craft on live surfaces (Home, Work, Biography, Contact, and other shipped pages). Hire path is LinkedIn only. Do not invent a public email or CV.
+
+---
+
+## 2026-08-29 - Farm abort | Signal: closed #768/#732/#718/#702 | Lean Implementation: HARD ABORT dx-stack/uses/stack experimental routes; prefer live visitor surfaces
+
 ## 2026-05-25 - Strategic Pulse | Signal: "/now" page trend | Lean Implementation: Flagged experimental route, < 50 lines total delta.
 
 ## 2026-05-26 - Product Manifesto | Signal: Product Leadership "Guiding Principles" trend | Lean Implementation: Isolated experimental route, uses Hero/Icon primitives, ~45 lines delta.


### PR DESCRIPTION
Apex scheduled prompt cannot be edited via the Jules REST API (no scheduled-task resource; edit/pause is web UI only). Apex is required to read `.Jules/apex.md` before each cycle, so this puts a HARD ABORT there:

- Do not recreate `/experimental/dx-stack`, `/experimental/uses`, `/experimental/stack`, or any noindex experimental stack/uses page
- Closed as farm: #768, #732, #718, #702
- Prefer visitor-facing craft on live surfaces
- Hire path LinkedIn only

Does not touch #766 or #765. Stay draft until Nick dual PASS.

Overlay 69ca717. Hire LinkedIn.