### PR TITLE
Content: hard-abort invented outcomes, ROI, and metrics

### DIFF
--- a/.Jules/content.md
+++ b/.Jules/content.md
@@ -1,0 +1,11 @@
+# HARD ABORT: invented outcomes, ROI, and metrics
+
+Read this before scouting. If the edit would invent or inflate an outcome, ROI, percentage, productivity claim, or metric not already published on the live site, ABORT. Do not clarify vague copy by adding numbers.
+
+Closed as farm for this class: #769, #731, #703, #654.
+
+Stay inside published facts. Hire path is LinkedIn only. Do not invent a public email or CV.
+
+---
+
+## 2026-08-29 - Invented outcome abort | Signal: closed #769/#731/#703/#654 | Lean Update: HARD ABORT invented ROI/metrics; stay on published facts


### PR DESCRIPTION
Content scheduled prompt cannot be edited via the Jules REST API (no scheduled-task resource; edit/pause is web UI only). Content is required to read `.Jules/content.md` before each cycle, and that file was missing on main. This adds it with a HARD ABORT:

- Do not invent or inflate outcomes, ROI, percentages, productivity claims, or metrics not already published on the live site
- Do not clarify vague copy by adding numbers
- Closed as farm: #769, #731, #703, #654
- Stay inside published facts
- Hire path LinkedIn only

Does not restack those copilots outcome PRs. Stay draft until Nick dual PASS.

Needed before Sunday Content ~05:18 CEST.

Overlay 69ca717. Hire LinkedIn.