### PR TITLE
Janitor: Typo & Terminology Alignment

### DIFF
--- a/.Janitor/hygiene.md
+++ b/.Janitor/hygiene.md
@@ -6,6 +6,7 @@
 | 2025-03-24 | worker-configuration.d.ts         | Removed 'the the' typos from documentation comments                                      | Validated   |
 | 2025-03-24 | context/author-linkedin.md        | Normalized Swedish terms (Produktchef, Produktledning) and removed duplicate text blocks | Validated   |
 | 2025-03-24 | src/content/work/master-thesis.md | Improved grammatical phrasing in the concluding paragraph                                | Validated   |
+| 2026-04-06 | worker-configuration.d.ts         | Corrected 'the The' double-word typo in documentation comments                           | Validated   |
 
 ## Spelling Exceptions
 

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -1506,7 +1506,7 @@ interface ErrorEventErrorEventInit {
 declare class MessageEvent extends Event {
   constructor(type: string, initializer: MessageEventInit);
   /**
-   * The **`data`** read-only property of the The data sent by the message emitter; this can be any data type, depending on what originated this event.
+   * The **`data`** read-only property of the data sent by the message emitter; this can be any data type, depending on what originated this event.
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/data)
    */


### PR DESCRIPTION
Fixed a double-word typographical error ('the The' -> 'the') in JSDoc comments inside worker-configuration.d.ts and logged the correction in .Janitor/hygiene.md. All linting, formatting, tests, and build checks passed.

---
*PR created automatically by Jules for task [14509129753838209838](https://jules.google.com/task/14509129753838209838) started by @alehar9320*