### PR TITLE
Kinetic: hard-abort CallToAction glass farm

### DIFF
--- a/.jules/kinetic.md
+++ b/.jules/kinetic.md
@@ -1,4 +1,16 @@
+# HARD ABORT — CallToAction glass farm
+
+Read this before scouting. If the idea is more glassmorphism, backdrop-filter, glow tokens, sheen, translateY hover, or micro-states on `CallToAction.astro` or the hire CTA, ABORT the cycle. Do not downscope into a sibling glass pass on the same button. Do not open a PR.
+
+Closed as farm: #772, #667.
+
+Prefer distinct motion craft on a live visitor surface that is not CTA glass. Hire path is LinkedIn only. Do not invent a public email or CV.
+
+---
+
 # Kinetic Journal ⚡
+
+## 2026-08-29 - CTA glass abort | Signal: closed #772/#667 | Lean Implementation: HARD ABORT CallToAction glassmorphism and micro-states
 
 ## 2025-05-15 - Interactive Glassmorphism for Skills Section
 


### PR DESCRIPTION
Kinetic scheduled prompt cannot be edited via the Jules REST API (no scheduled-task resource; edit/pause is web UI only). Kinetic is required to read `.jules/kinetic.md` before each cycle, so this puts a HARD ABORT in the existing journal:

- If the idea is more glassmorphism, backdrop-filter, glow tokens, sheen, translateY hover, or micro-states on `CallToAction.astro` or the hire CTA, ABORT the cycle
- Do not downscope into a sibling glass pass on the same button. Do not open a PR
- Closed as farm: #772, #667
- Prefer distinct motion craft on a live visitor surface that is not CTA glass
- Hire path LinkedIn only. Do not invent a public email or CV

Does not restack #772 or #667. Does not touch `CallToAction.astro`. Stay draft until Nick dual PASS.

Overlay 69ca717. Hire LinkedIn.