### PR TITLE
Tighten visitor readability of twin chat follow-up suggestion chips

### DIFF
--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -293,22 +293,41 @@
   }
 
   .chat-suggestion {
-    background: var(--gray-900);
-    border: 1px solid var(--gray-700);
-    color: var(--gray-100);
-    padding: 0.375rem 0.625rem;
-    border-radius: 0.375rem;
-    font-size: 0.75rem;
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    background: var(--gray-999);
+    border: 1px solid var(--gray-300);
+    color: var(--gray-0);
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.5rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
     font-family: inherit;
+    line-height: 1.35;
     text-align: left;
     cursor: pointer;
     transition:
       background-color 0.15s ease,
-      border-color 0.15s ease;
+      border-color 0.15s ease,
+      color 0.15s ease;
+  }
+
+  :root.theme-dark .chat-suggestion {
+    background: var(--gray-900);
+    border-color: var(--gray-700);
+    color: var(--gray-100);
   }
 
   .chat-suggestion:hover,
   .chat-suggestion:focus-visible {
+    background: var(--gray-900);
+    border-color: var(--accent-regular);
+    color: var(--gray-0);
+  }
+
+  :root.theme-dark .chat-suggestion:hover,
+  :root.theme-dark .chat-suggestion:focus-visible {
     background: var(--gray-800);
     border-color: var(--accent-regular);
     color: var(--gray-0);


### PR DESCRIPTION
Tightened visitor readability and tap targets of twin chat suggestion chips on home (`src/components/Chat.astro`):
- Established min 44px height and flex alignment for touch targets on narrow viewports (@375).
- Improved light and dark mode background/border/text contrast for suggestion chips.
- Preserved existing chat dock behavior and all prompt constraints.

---
*PR created automatically by Jules for task [16663367392967926747](https://jules.google.com/task/16663367392967926747) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved chat suggestion buttons with larger touch targets, clearer spacing, and updated typography.
  * Refined borders, colors, and hover/focus states for better usability.
  * Added styling optimized for both light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->