### PR TITLE
Jules: Skills Card Focus-Within Enhancement

### DIFF
--- a/.Jules/jules.md
+++ b/.Jules/jules.md
@@ -15,3 +15,9 @@
 - [Insight 1: Adding instant hardware-accelerated press feedback (`transform: translateY(2px) scale(0.98)`) on CTA buttons eliminates perceived press latency.]
 - [Insight 2: Scoping tactile feedback behind feature flags (`enable_cta_tactile_v1`) allows isolated deployment without global layout risk.]
 - [Delta: 12 lines. Guardrails: All passed autonomously.]
+
+## 2026-06-09 - Skills Card Focus-Within | Signal: Competitive/Technical | Lean Implementation: Flagged CSS :focus-within
+
+- [Insight 1: Keyboard users tabbing through links nested inside Skills card components benefit from card elevation and border highlight feedback.]
+- [Insight 2: Scoping card focus-within states behind feature flags (`enable_skills_card_focus`) prevents global layout risks and allows isolated verification.]
+- [Delta: 15 lines. Guardrails: All passed autonomously.]

--- a/src/components/Skills.astro
+++ b/src/components/Skills.astro
@@ -2,9 +2,12 @@
 import Icon from './Icon.astro';
 import { getEntry } from 'astro:content';
 const flagsEntry = await getEntry('flags', 'config');
+const isCardFocusEnabled = flagsEntry?.data.enable_skills_card_focus ?? false;
 ---
 
-<section class={`box skills ${flagsEntry?.data.enable_skills_pulse_v1 ? 'pulse-enabled' : ''}`}>
+<section
+  class={`box skills ${flagsEntry?.data.enable_skills_pulse_v1 ? 'pulse-enabled' : ''} ${isCardFocusEnabled ? 'card-focus-enabled' : ''}`}
+>
   <div class="stack gap-2 lg:gap-4">
     <Icon icon="rocket-launch" color="var(--accent-regular)" size="2.5rem" gradient />
     <h2>Driving Growth & ROI</h2>
@@ -55,7 +58,8 @@ const flagsEntry = await getEntry('flags', 'config');
       border-color var(--theme-transition);
   }
 
-  .box:hover {
+  .box:hover,
+  .box.card-focus-enabled:focus-within {
     transform: translateY(-4px);
     border-color: var(--accent-regular);
     box-shadow:
@@ -67,7 +71,8 @@ const flagsEntry = await getEntry('flags', 'config');
     .box {
       transition: none;
     }
-    .box:hover {
+    .box:hover,
+    .box.card-focus-enabled:focus-within {
       transform: none;
     }
   }

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -26,6 +26,7 @@ export const collections = {
       enable_reading_list: z.boolean().default(false),
       enable_logo_wobble_v1: z.boolean().default(false),
       enable_cta_tactile_v1: z.boolean().default(false),
+      enable_skills_card_focus: z.boolean().default(false),
     }),
   }),
 };

--- a/src/content/flags/config.json
+++ b/src/content/flags/config.json
@@ -6,5 +6,6 @@
   "enable_skills_pulse_v1": true,
   "enable_reading_list": true,
   "enable_logo_wobble_v1": true,
-  "enable_cta_tactile_v1": true
+  "enable_cta_tactile_v1": true,
+  "enable_skills_card_focus": true
 }


### PR DESCRIPTION
Enhanced keyboard navigation spatial feedback in Skills.astro by applying :focus-within styling to .box containers when nested links are focused. Flagged behind enable_skills_card_focus in src/content/flags/config.json with Zod schema validation in src/content.config.ts. Recorded insights in .Jules/jules.md. Total line delta: 21 lines (<50 limit). All tests, linter, formatting, build, and visual verification checks passed.

---
*PR created automatically by Jules for task [13933337720531464854](https://jules.google.com/task/13933337720531464854) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard focus feedback to Skills cards, including elevation and border highlighting when navigating links with the keyboard.
  * The experience respects reduced-motion preferences.

* **Bug Fixes**
  * Scoped the new focus styling behind a feature flag, allowing it to be enabled safely without affecting other layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->