### PR TITLE
⚡ Bolt: lazy load below-the-fold case study image

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -9,3 +9,7 @@ Action: Commented out unused icons in src/components/IconPaths.ts and updated re
 2026-08-29 - In-Viewport Decoding & Icon Pruning
 Learning: Docked composer avatars on first paint sit in-viewport inside the bottom chat bar. Using loading="lazy" on in-viewport images can cause blank flashes; using decoding="async" offloads image decoding from the main thread without deferring fetch. Unused SVG icon paths in IconPaths.ts can be safely commented out to prune bundle size.
 Action: Retained decoding="async" on the chat avatar image in src/components/Chat.astro (omitting loading="lazy") and commented out unused instagram-logo and facebook-logo paths in src/components/IconPaths.ts.
+
+2026-08-30 - Lazy Loading Below-the-Fold Case Study Image
+Learning: Case study hero/proof images positioned at the bottom of the page (below the fold) consume network bandwidth and decoding resources during initial page paint if un-lazy. Adding loading="lazy" defers fetching and decoding until scrolled into view.
+Action: Added loading="lazy" to the below-the-fold IFS Design System image in src/pages/work/[...slug].astro.

--- a/src/pages/work/[...slug].astro
+++ b/src/pages/work/[...slug].astro
@@ -167,7 +167,13 @@ const robots = entry?.id === 'lidkoping-stenhuggeri' ? 'noindex' : undefined;
                 {Content && <Content />}
               </div>
               {entry.data.img && entry.id === 'ifs-design-system' && (
-                <img src={entry.data.img} alt={entry.data.img_alt || ''} decoding="async" />
+                /* Optimization (⚡ Bolt): Below-the-fold case study image is lazy loaded to defer payload fetching and offload main-thread decoding on initial load. */
+                <img
+                  src={entry.data.img}
+                  alt={entry.data.img_alt || ''}
+                  loading="lazy"
+                  decoding="async"
+                />
               )}
             </div>
           </main>


### PR DESCRIPTION
### What
Added `loading="lazy"` attribute to the below-the-fold case study image rendered in `src/pages/work/[...slug].astro`.

### Why
The image for the `ifs-design-system` case study sits at the bottom of the page content, well below the fold on initial load. Un-lazy image loading forces the browser to fetch and decode this asset during initial page paint, consuming unnecessary network bandwidth and main-thread processing.

### Impact
Defers fetching and decoding of the case study image until the user scrolls into view, reducing initial payload network load and main-thread CPU work.

### How to verify
1. Run `npm run test`
2. Run `npm run format:check && npm run lint`
3. Run `npm run build`

---
*PR created automatically by Jules for task [5546847613452822940](https://jules.google.com/task/5546847613452822940) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved page loading by deferring loading of the below-the-fold case-study image until it approaches the viewport.
  * Retained asynchronous image decoding for smoother rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->