### PR TITLE
🎨 Palette: Card focus-within spatial feedback for skills

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,5 +1,11 @@
 # Palette 🎨 - UX & Accessibility Journal
 
+## 2026-05-20 - Card Focus-Within Spatial Feedback
+
+**Learning:** When interactive links are nested within container cards (e.g., `Skills.astro`), applying `:focus-within` alongside `:hover` ensures keyboard users tabbing through inner links receive identical spatial feedback (elevation, border color, and glassmorphic shadow) as mouse hover states, providing a consistent visual mental model across input methods.
+
+**Action:** Added `:focus-within` selector to `.box` in `Skills.astro` and gated `transform` under `prefers-reduced-motion` to maintain full accessibility parity between mouse and keyboard interaction modes.
+
 ## 2026-05-17 - Enhancing Content Selection and Standardizing Focus Spatiality
 
 **Learning:** Using `user-select: none` on informational badges (like `Pill`) creates unnecessary friction for users trying to copy text for reference. Additionally, consistent `outline-offset: 4px` across all interactive elements (including theme toggles and cards) reinforces a predictable spatial model for keyboard users. Adding `target="_blank"` with `rel="noopener noreferrer"` to external informational links (like the Astro framework link in the footer) ensures a non-disruptive navigation experience that preserves the user's session.

--- a/src/components/Skills.astro
+++ b/src/components/Skills.astro
@@ -55,7 +55,8 @@ const flagsEntry = await getEntry('flags', 'config');
       border-color var(--theme-transition);
   }
 
-  .box:hover {
+  .box:hover,
+  .box:focus-within {
     transform: translateY(-4px);
     border-color: var(--accent-regular);
     box-shadow:
@@ -67,7 +68,8 @@ const flagsEntry = await getEntry('flags', 'config');
     .box {
       transition: none;
     }
-    .box:hover {
+    .box:hover,
+    .box:focus-within {
       transform: none;
     }
   }


### PR DESCRIPTION
Applied `:focus-within` spatial feedback to the glassmorphism card container in `Skills.astro` so keyboard users tabbing through nested links receive the same elevation, border highlight, and glassmorphic shadow as mouse hover states. Documented in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [9439237292602365086](https://jules.google.com/task/9439237292602365086) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added matching visual feedback for keyboard-focused cards, including elevation, border, and shadow styling.
  * Respects reduced-motion preferences by disabling focus-related movement when requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->