### PR TITLE
🎨 Palette: Add focus-within feedback to Skills cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -42,6 +42,12 @@
 
 **Action:** Standardized `outline-offset: 4px` and tactile scaling across `Nav.astro`, `Footer.astro`, and global link styles. Refined `global.css` to gate smooth scrolling behind `prefers-reduced-motion: no-preference`. Ensured site-wide "Skip to Content" functionality by adding `id="main-content"` to all primary page layouts and components.
 
+## 2026-05-20 - Container Focus-Within Feedback for Card-Nested Links
+
+**Learning:** When interactive links (such as Wikipedia reference links) are nested inside card or section containers (e.g., `Skills.astro`), keyboard users tabbing through those links should receive container-level spatial feedback. Applying `:focus-within` styles alongside `:hover` ensures the outer container elevates (`translateY(-4px)`) and displays accent border highlights, aligning the keyboard experience with the mouse hover state.
+
+**Action:** Added `.box:focus-within` styling to `Skills.astro` alongside `.box:hover`, and ensured `@media (prefers-reduced-motion: reduce)` safely disables `transform` during focus-within interactions.
+
 ## 2026-05-19 - Optimizing LCP for Portfolio Galleries and Hero Assets
 
 **Learning:** To optimize Largest Contentful Paint (LCP) in Astro projects, primary visual assets (like hero images) and the first items in repeated galleries should be prioritised by the browser. Applying `loading="eager"` and `fetchpriority="high"` to these elements prevents the browser from delaying their loading, ensuring a faster perceived performance for users.

--- a/src/components/Skills.astro
+++ b/src/components/Skills.astro
@@ -55,7 +55,8 @@ const flagsEntry = await getEntry('flags', 'config');
       border-color var(--theme-transition);
   }
 
-  .box:hover {
+  .box:hover,
+  .box:focus-within {
     transform: translateY(-4px);
     border-color: var(--accent-regular);
     box-shadow:
@@ -67,7 +68,8 @@ const flagsEntry = await getEntry('flags', 'config');
     .box {
       transition: none;
     }
-    .box:hover {
+    .box:hover,
+    .box:focus-within {
       transform: none;
     }
   }


### PR DESCRIPTION
Added `:focus-within` styling to `.box` skill card containers in `Skills.astro` to ensure keyboard users tabbing through nested links receive container spatial feedback and accent border highlights. Documented learning in `.Jules/palette.md` and verified code quality and accessibility standards across tests, lint, astro check, build, and visual verification.

---
*PR created automatically by Jules for task [16350607714791831423](https://jules.google.com/task/16350607714791831423) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Skills cards now provide visual feedback when links receive keyboard focus, matching the existing hover behavior.
  * Motion effects are disabled for focused cards when reduced-motion preferences are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->