### PR TITLE
Fix biography IFS Design System proof link hit target and mobile dock clearance

### DIFF
--- a/src/pages/biography.astro
+++ b/src/pages/biography.astro
@@ -147,6 +147,22 @@ const schema = {
     gap: 2rem;
   }
 
+  .timeline a[href='/work/ifs-design-system/'] {
+    display: inline-block;
+    min-height: 44px;
+    min-width: 44px;
+  }
+
+  @media (max-width: 30em) {
+    .about {
+      gap: 2rem;
+    }
+
+    .timeline {
+      gap: 1rem;
+    }
+  }
+
   .timeline h3 {
     margin: 0.15rem 0;
     font-size: var(--text-lg);


### PR DESCRIPTION
Enforce minimum 44x44px touch target on IFS Design System proof link and improve mobile dock clearance to >= 8px on 375px viewports.

---
*PR created automatically by Jules for task [5848580872242448036](https://jules.google.com/task/5848580872242448036) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the design system link’s tap area for easier interaction.
  * Reduced spacing on the biography page for better readability on small screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->