### PR TITLE
🎨 Palette: High contrast progress bars & proof card touch targets

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,5 +1,11 @@
 # Palette 🎨 - UX & Accessibility Journal
 
+## 2026-05-22 - Forced-Colors Mode High Contrast Progress Bars & Proof Card Affordances
+
+**Learning:** When using custom progress bars or metric fill elements (such as `.kr-bar` and `.kr-bar-fill` in `okr.astro`), translucent or gradient backgrounds disappear or become invisible in Windows High Contrast Mode / forced-colors active mode. Adding explicit system color fallbacks (`border: 1px solid CanvasText;` and `background-color: Highlight;`) inside `@media (forced-colors: active)` ensures data visualization components remain fully readable. Additionally, standardizing interactive card affordances (such as `.proof-affordance`) with WCAG touch target dimensions (`min-height: 44px; min-width: 44px;`) and clear hover/focus-visible color feedback (`color: var(--gray-0)`) ensures accessible touch and keyboard interactions.
+
+**Action:** Added `@media (forced-colors: active)` support for `.kr-bar` and `.kr-bar-fill` in `src/pages/okr.astro`. Enhanced `.proof-card` in `src/pages/roadmap.astro` and `src/pages/index.astro` with hover and `:focus-visible` color transitions on `.proof-affordance`, and enforced minimum 44x44px touch targets.
+
 ## 2026-05-21 - Standardizing Focus-Visible Indicators & Card Radius Alignment
 
 **Learning:** Scoped link selectors inside markdown content containers (such as `.content :global(a)`) and list sections (`.earlier a`) must use `:focus-visible` with site-standard outline indicators (`outline: 2px solid var(--accent-regular)`, `outline-offset: 4px`, `border-radius: 0.25rem`) rather than raw `:focus` text-decoration properties. Replacing raw `:focus` prevents sticky focus underlines on mouse clicks, while adding explicit `:focus-visible` outlines and rounded corner alignment ensures a high-visibility, visually clean experience for keyboard navigation.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -188,6 +188,11 @@ const schema = {
     border-radius: 0.25rem;
   }
 
+  .proof-card:hover .proof-affordance,
+  .proof-card:focus-visible .proof-affordance {
+    color: var(--gray-0);
+  }
+
   .proof-eyebrow {
     margin: 0;
     font-size: var(--text-sm);
@@ -225,6 +230,7 @@ const schema = {
     min-height: 44px;
     min-width: 44px;
     box-sizing: border-box;
+    transition: color var(--theme-transition);
   }
 
   @media (min-width: 50em) {

--- a/src/pages/okr.astro
+++ b/src/pages/okr.astro
@@ -159,6 +159,15 @@ const meta = 'H2 2026 · baselines frozen 29 Aug 2026 · current refreshed weekl
     border-radius: 0.25rem;
   }
 
+  @media (forced-colors: active) {
+    .kr-bar {
+      border: 1px solid CanvasText;
+    }
+    .kr-bar-fill {
+      background-color: Highlight;
+    }
+  }
+
   .kr-note,
   .kr-support {
     margin: 0;

--- a/src/pages/roadmap.astro
+++ b/src/pages/roadmap.astro
@@ -124,6 +124,11 @@ const schema = {
     border-radius: 0.25rem;
   }
 
+  .proof-card:hover .proof-affordance,
+  .proof-card:focus-visible .proof-affordance {
+    color: var(--gray-0);
+  }
+
   .proof-eyebrow {
     margin: 0;
     font-size: var(--text-sm);
@@ -156,6 +161,12 @@ const schema = {
     color: var(--gray-300);
     text-decoration: underline;
     text-underline-offset: 0.2em;
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    min-width: 44px;
+    box-sizing: border-box;
+    transition: color var(--theme-transition);
   }
 
   @media (min-width: 50em) {


### PR DESCRIPTION
Adds @media (forced-colors: active) support for progress bars in okr.astro and standardizes WCAG touch targets (44x44px) and hover/focus feedback for proof card affordances in roadmap.astro and index.astro.

---
*PR created automatically by Jules for task [12473551130092312523](https://jules.google.com/task/12473551130092312523) started by @alehar9320*