### PR TITLE
🏛️ Archie: Architecture Decision Records and Tech Radar Governance

### DIFF
--- a/.Jules/archie.md
+++ b/.Jules/archie.md
@@ -1,0 +1,5 @@
+# Archie Journal
+
+## 2026-03-30 - Architecture Decision Records & Repository Tech Radar Initial Setup
+Learning: Architectural context and unwritten repository patterns (such as Zod feature flag isolation and Cloudflare Workers production boundaries) were scattered across AGENTS.md, config files, and code. Lacking a centralized ADR directory and Tech Radar created potential context gaps and risk of AI agent drift.
+Action: Established formal ADR governance structure with sequential ADRs (`docs/adr/0001-...` and `docs/adr/0002-...`), master index (`docs/adr/README.md`), and comprehensive Tech Radar (`docs/tech-radar.md`) with explicit AI Agent Directives to enforce repository guardrails.

--- a/docs/adr/0001-cloudflare-production-render-jules.md
+++ b/docs/adr/0001-cloudflare-production-render-jules.md
@@ -1,18 +1,26 @@
-# ADR 0001: Cloudflare as production, Render as Jules test env
+# 0001. Cloudflare as Production, Render as Jules Test Environment
 
-- Status: Accepted
-- Date: 2026-08-24
+- **Status:** Accepted
+- **Date:** 2026-08-24
+- **Deciders:** Autonomous Architect (Archie) / Repository Analysis
 
 ## Context
 
-The site can build two ways: Cloudflare Workers (static + `@astrojs/cloudflare`) or a Node standalone server when `RENDER=true` (`@astrojs/node`). Prod already runs at https://me.alehar.workers.dev/. We need a clear split so Google Jules can debug against a Node environment without treating that path as a second production or failover.
+The site can build in two ways: Cloudflare Workers (static + `@astrojs/cloudflare`) or a Node standalone server when `RENDER=true` (`@astrojs/node`). Production is deployed at https://me.alehar.workers.dev/. A clear operational boundary is required so AI agents (e.g., Google Jules) can run and test against a Node environment without treating that environment as a secondary production target or failover cluster.
 
 ## Decision
 
-Production is Cloudflare Workers only. Render is a test environment for Google Jules (Node server via `render.yaml`). It is not a second prod and not a failover.
+Production hosting is strictly Cloudflare Workers + Assets (`wrangler.jsonc`). Render is designated exclusively as a test environment for Google Jules running a Node standalone server (`render.yaml`). Render is not a secondary production host or a failover site.
 
-## Consequences
+## Consequences & Tradeoffs
 
-- Ship and operate prod on the Cloudflare Worker (`wrangler.jsonc`, `src/cloudflare-worker.ts`).
-- Keep the Render Node path for Jules debugging only; expect AI/KV and other Workers bindings to be absent or stubbed there (`src/env/cloudflare-workers.node.ts`).
-- Docs and ops language should call Cloudflare production and Render the Jules test env.
+- **Positive:** Eliminates deployment ambiguity, maintains Workers-First performance on Cloudflare, and provides a sandbox for Node runtime testing.
+- **Negative / Risks:** Expect Workers bindings (e.g., KV, AI) to be absent or stubbed in the Render Node fallback environment (`src/env/cloudflare-workers.node.ts`).
+- **Adoption Readiness:** Already implemented and operational in build scripts (`astro.config.mjs`) and deployment blueprints (`render.yaml`).
+
+## Directives for AI Agents
+
+- **Do:** Direct all production configuration, edge bindings, and release workflows exclusively toward Cloudflare Workers + Assets (`wrangler.jsonc`).
+- **Do:** Use `src/env/cloudflare-workers.node.ts` to stub Workers bindings when testing in Node runtime environments.
+- **Don't:** Do not treat Render as a secondary production site or introduce dual-deploy production pipelines.
+- **Don't:** Do not modify `wrangler.jsonc` or `render.yaml` deployment configs without explicit architecture review.

--- a/docs/adr/0002-feature-flag-isolation-and-content-collections.md
+++ b/docs/adr/0002-feature-flag-isolation-and-content-collections.md
@@ -1,0 +1,30 @@
+# 0002. Feature Flag Isolation and Type-Safe Content Collections
+
+- **Status:** Accepted
+- **Date:** 2026-03-30
+- **Deciders:** Autonomous Architect (Archie) / Repository Analysis
+
+## Context
+
+The Personal Portfolio repository is evolved by multiple autonomous AI agents (Apex, Jules, Kinetic, Palette, Aurora, Vantage) and human contributors. To prevent regressions, breaking schema changes, or accidental global layout disruptions during rapid iteration, the codebase requires strict structural guardrails for micro-features, content schemas, and runtime isolation.
+
+## Decision
+
+All experimental or incremental feature toggles must be defined in `src/content/flags/config.json` and validated by Zod schema definitions in `src/content.config.ts`. Additionally:
+
+1. Every new feature flag added to `src/content/flags/config.json` must be declared in the `flags` collection schema in `src/content.config.ts` (e.g., `enable_feature_name: z.boolean().default(false)`).
+2. Content collections (such as `work` and `flags`) must use strict Zod schemas for compile-time and runtime type safety.
+3. Features or experimental routes must be isolated within `src/pages/experimental/` or guarded by a feature flag check rather than modifying core global layouts (`Layout.astro` or worker logic).
+
+## Consequences & Tradeoffs
+
+- **Positive:** Guarantees zero-runtime-type errors on content/flags, ensures reversible feature rollouts, and provides predictable boundary isolation for autonomous agent contributions.
+- **Negative / Risks:** Modifying flags requires synchronizing `src/content/flags/config.json` with `src/content.config.ts` to maintain schema validation tests.
+- **Adoption Readiness:** Already in active use across autonomous agent tracks (`Jules`, `Apex`, `Palette`, `Aurora`) and verified via `src/__tests__/` Vitest suites.
+
+## Directives for AI Agents
+
+- **Do:** Synchronize any new flag added in `src/content/flags/config.json` with the Zod schema in `src/content.config.ts`.
+- **Do:** Isolate experimental or WIP features in `src/pages/experimental/` or behind feature flag conditionals.
+- **Don't:** Do not introduce third-party feature flagging libraries or external remote config services; use the local Zod-backed content collection flags.
+- **Don't:** Do not bypass Zod type checking or use `@ts-ignore` / `any` when handling content collection data.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,23 @@
+# Architecture Decision Records (ADRs)
+
+This directory contains Architecture Decision Records (ADRs) for the Personal Portfolio repository.
+
+## Index
+
+| ADR                                                            | Title                                                      | Status   | Date       |
+| :------------------------------------------------------------- | :--------------------------------------------------------- | :------- | :--------- |
+| [0001](0001-cloudflare-production-render-jules.md)             | Cloudflare as Production, Render as Jules Test Environment | Accepted | 2026-08-24 |
+| [0002](0002-feature-flag-isolation-and-content-collections.md) | Feature Flag Isolation and Type-Safe Content Collections   | Accepted | 2026-03-30 |
+
+## ADR Creation Guidelines
+
+When creating a new ADR:
+
+1. File names follow sequential zero-padded numbering: `NNNN-[kebab-case-title].md`.
+2. Every ADR must include:
+   - Header metadata (`Status`, `Date`, `Deciders`).
+   - `Context`
+   - `Decision`
+   - `Consequences & Tradeoffs`
+   - `Directives for AI Agents` (mandatory `Do` and `Don't` guidelines).
+3. Always update this `README.md` master index in the same pull request.

--- a/docs/tech-radar.md
+++ b/docs/tech-radar.md
@@ -1,0 +1,75 @@
+# Repository Tech Radar
+
+The Tech Radar documents technology choices, structural patterns, and tool trajectories for the Personal Portfolio repository. It provides explicit ground-truth context for human developers and autonomous AI agents.
+
+## Quadrants & Rings Overview
+
+### Rings
+
+- **Adopt:** High confidence, production-proven in this repository. Default choice for all new work.
+- **Trial:** High potential with low risk. Ready for isolated usage in experimental routes, minor features, or scripts.
+- **Assess:** Worth tracking and evaluating trade-offs; not yet recommended for active production code.
+- **Hold:** Phasing out, banned, or proven problematic in our setup. Do not use for new work.
+
+---
+
+## 1. Frameworks & Runtimes
+
+- **Adopt:**
+  - **Astro (v4+ / v7):** Primary web framework for static-first, content-focused architecture.
+  - **TypeScript (Strict Mode):** Mandatory type system across all application code, utilities, and tests.
+  - **Node.js (>=22.12.0):** Baseline local development and build runtime.
+- **Trial:**
+  - **`@astrojs/node` Standalone Adapter:** Used exclusively for the Render Jules test environment (`RENDER=true`).
+- **Assess:**
+  - **WebAssembly (Wasm):** Edge compute compilation target for potential high-performance data processing.
+- **Hold:**
+  - **Client-Side Framework Hydration (`client:load`, `client:only` with React/Vue/Svelte):** Avoid client JS overhead; prefer static HTML/CSS and minimal vanilla JS islands.
+
+---
+
+## 2. Infrastructure & Cloud
+
+- **Adopt:**
+  - **Cloudflare Workers + Assets:** Production deployment model (`wrangler.jsonc`).
+  - **Sentry Astro / Cloudflare Integrations:** Telemetry, error logging, and performance monitoring.
+- **Trial:**
+  - **Render Web Service Blueprint:** Dedicated sandbox environment for AI agent testing.
+- **Assess:**
+  - **Cloudflare Workers AI / Vectorize:** Edge LLM execution and vector database capabilities.
+- **Hold:**
+  - **Legacy Cloudflare Pages:** Superseded by the unified Cloudflare Workers + Assets binding model.
+
+---
+
+## 3. Tooling & AI Workflows
+
+- **Adopt:**
+  - **Vitest:** Primary testing framework for unit, parser, and schema validation tests.
+  - **Prettier + Prettier Plugin Astro:** Mandatory repository formatting engine.
+  - **ESLint (Flat Config):** Strict code linting and style enforcement.
+  - **Autonomous AI Agent Ecosystem:** Autonomous feature, performance, quality, design, and architecture agents operating via `.Jules/` journals and feature flag isolation.
+- **Trial:**
+  - **Codecov Vite Plugin:** Bundle analysis and test coverage tracking.
+- **Assess:**
+  - **Model Context Protocol (MCP) Servers:** Standardized documentation and context retrieval (`mcp_config.json`).
+- **Hold:**
+  - **Manual CI Production Deployments:** Production releases are handled exclusively by Cloudflare's Git integration on `main`.
+
+---
+
+## 4. Patterns & Architecture
+
+- **Adopt:**
+  - **Static Pre-Rendering (`output: 'static'`):** High-performance static HTML generation.
+  - **Zero-Dependency Vanilla CSS:** 'Northern Lights' design system with custom properties and frosted-glass effects.
+  - **Type-Safe Zod Schemas:** Compile-time and runtime validation for content collections and feature flags (`src/content.config.ts`).
+  - **Feature Flag & Experimental Route Isolation:** Guarding WIP changes via `src/content/flags/config.json` and `src/pages/experimental/`.
+  - **Zero-Allocation SSE Stream Parsing:** Pointer-based string traversal for Cloudflare Worker stream processing (`src/utils/chat-stream.ts`).
+- **Trial:**
+  - **High Contrast / Forced-Colors Support:** `@media (forced-colors: active)` system color fallbacks.
+- **Assess:**
+  - **Canvas & WebGL Animation Loops:** Interactive visuals bound to Astro lifecycle teardown (`astro:before-swap`).
+- **Hold:**
+  - **Tailwind CSS & Utility Frameworks:** Prohibited; maintain strict Vanilla CSS adherence.
+  - **Bypassing Type Safety (`@ts-ignore` / `any`):** Strictly forbidden across all code and tests.


### PR DESCRIPTION
### What
Established central architecture decision records (`docs/adr/0001-...` and `docs/adr/0002-...`), master index (`docs/adr/README.md`), and repository Tech Radar (`docs/tech-radar.md`) alongside Archie agent journal initialization (`.Jules/archie.md`).

### Why & Horizon
Codified implicit codebase patterns (Zod feature flag validation, Cloudflare Workers deployment boundaries) and established explicit ground-truth technology status across 4 rings (Adopt, Trial, Assess, Hold) and 4 operational quadrants to guide human developers and autonomous AI agents.

### Tradeoff Analysis
- **Benefits:** Eliminates architectural drift, provides explicit `Do` and `Don't` directives for AI agents, and enforces structured governance for future evolution.
- **Costs/Risks:** Requires updating the ADR README index table whenever new ADRs are introduced.

### Human & AI Impact
Future developers and AI agents must follow mandatory Directives for AI Agents in ADRs and adhere to ring assignments in `docs/tech-radar.md`.

### Files added/updated
- `docs/adr/0001-cloudflare-production-render-jules.md`
- `docs/adr/0002-feature-flag-isolation-and-content-collections.md`
- `docs/adr/README.md`
- `docs/tech-radar.md`
- `.Jules/archie.md`

---
*PR created automatically by Jules for task [558676657950032658](https://jules.google.com/task/558676657950032658) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an Architecture Decision Record index with guidelines for creating and maintaining future records.
  - Documented production and testing environment decisions, feature-flag isolation, and type-safe content collection practices.
  - Added a technology radar covering adopted, trial, assessed, and held technologies.
  - Added an Archie Journal entry documenting repository governance and architectural context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->