### PR TITLE
🎨 Palette: Standardize Chat Overlay Control Touch Targets and Focus States

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,5 +1,11 @@
 # Palette 🎨 - UX & Accessibility Journal
 
+## 2026-05-23 - Compact Overlay Control Focus Containment & Touch Target Standard
+
+**Learning:** Compact overlay controls inside constrained components (such as `.chat-clear`, `.chat-close`, and suggestion chips in `Chat.astro`) require tight focus ring containment (`outline-offset: 2px`) to prevent focus outlines from overflowing overlay bounds or clipping against scroll container edges. Furthermore, ensuring all action controls maintain WCAG touch target dimensions (`min-height: 44px; min-width: 44px`) with `display: inline-flex; align-items: center; justify-content: center;` and gated tactile feedback (`transform: scale(0.96)`) under `@media (prefers-reduced-motion: no-preference)` delivers an accessible, highly responsive experience across touch and keyboard interactions.
+
+**Action:** Updated `.chat-clear`, `.chat-close`, `.chat-suggestion`, and explore card links in `src/components/Chat.astro` to enforce 44x44px minimum touch targets and contained `outline-offset: 2px` focus outlines with tactile `:active` scaling.
+
 ## 2026-05-22 - Forced-Colors Mode High Contrast Progress Bars & Proof Card Affordances
 
 **Learning:** When using custom progress bars or metric fill elements (such as `.kr-bar` and `.kr-bar-fill` in `okr.astro`), translucent or gradient backgrounds disappear or become invisible in Windows High Contrast Mode / forced-colors active mode. Adding explicit system color fallbacks (`border: 1px solid CanvasText;` and `background-color: Highlight;`) inside `@media (forced-colors: active)` ensures data visualization components remain fully readable. Additionally, standardizing interactive card affordances (such as `.proof-affordance`) with WCAG touch target dimensions (`min-height: 44px; min-width: 44px;`) and clear hover/focus-visible color feedback (`color: var(--gray-0)`) ensures accessible touch and keyboard interactions.

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -335,7 +335,7 @@
 
   .chat-suggestion:focus-visible {
     outline: 2px solid var(--accent-regular);
-    outline-offset: 4px;
+    outline-offset: 2px;
   }
 
   .chat-window {
@@ -490,10 +490,20 @@
     border: none;
     color: var(--gray-400);
     cursor: pointer;
-    padding: 0.25rem 0.4rem;
+    padding: 0.25rem 0.5rem;
     font: inherit;
     font-size: 0.75rem;
     font-weight: 500;
+    min-height: 44px;
+    min-width: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.375rem;
+    box-sizing: border-box;
+    transition:
+      color var(--theme-transition),
+      transform var(--theme-transition);
   }
 
   .chat-clear:hover,
@@ -506,7 +516,14 @@
   .chat-clear:focus-visible,
   .chat-close:focus-visible {
     outline: 2px solid var(--accent-regular);
-    outline-offset: 4px;
+    outline-offset: 2px;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .chat-clear:active,
+    .chat-close:active {
+      transform: scale(0.96);
+    }
   }
 
   .chat-close {
@@ -515,6 +532,16 @@
     color: var(--gray-400);
     cursor: pointer;
     padding: 0.25rem;
+    min-height: 44px;
+    min-width: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.375rem;
+    box-sizing: border-box;
+    transition:
+      color var(--theme-transition),
+      transform var(--theme-transition);
   }
 
   .chat-messages {
@@ -616,13 +643,14 @@
   .chat-explore-card-open:hover,
   .chat-explore-card-open:focus-visible {
     outline: 2px solid var(--accent-regular);
-    outline-offset: 4px;
+    outline-offset: 2px;
   }
 
   .chat-explore-card-primary {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    min-height: 44px;
     margin-top: 0.15rem;
     padding: 0.5rem 0.9rem;
     border-radius: 0.5rem;
@@ -638,7 +666,7 @@
   .chat-explore-card-primary:hover,
   .chat-explore-card-primary:focus-visible {
     outline: 2px solid var(--accent-regular);
-    outline-offset: 4px;
+    outline-offset: 2px;
   }
 
   @media (prefers-reduced-motion: no-preference) {


### PR DESCRIPTION
Enforced WCAG 44x44px minimum touch targets and contained 2px focus outlines for compact chat overlay controls in `src/components/Chat.astro`. Added gated `:active` scale transitions (`transform: scale(0.96)`) under `prefers-reduced-motion: no-preference`. Documented accessibility learnings in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [12507365901066106237](https://jules.google.com/task/12507365901066106237) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved keyboard focus visibility for chat suggestions, controls, and explore card actions with more contained outlines.
  - Increased chat control and explore card action touch targets to 44px.
  - Improved alignment, rounded styling, and interaction feedback for chat controls.
  - Added press animation that respects reduced-motion preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->