### PR TITLE
Content: Fallback Title Alignment for src/components/MainHead.astro

### DIFF
--- a/.Jules/content.md
+++ b/.Jules/content.md
@@ -9,3 +9,4 @@ Stay inside published facts. Hire path is LinkedIn only. Do not invent a public 
 ---
 
 ## 2026-08-29 - Invented outcome abort | Signal: closed #769/#731/#703/#654 | Lean Update: HARD ABORT invented ROI/metrics; stay on published facts
+## 2026-09-03 - Evergreen Title Alignment | Signal: Stale | Lean Update: Aligned fallback title in MainHead.astro with exact company title ('Product Manager, Developer Experience at IFS')

--- a/src/components/MainHead.astro
+++ b/src/components/MainHead.astro
@@ -12,7 +12,7 @@ interface Props {
 }
 
 const {
-  title = 'Alexander Härenstam | Product Manager, Developer Experience',
+  title = 'Alexander Härenstam | Product Manager, Developer Experience at IFS',
   description = 'Product Manager, Developer Experience at IFS.',
   ogTitle,
   shareUrl: shareUrlProp,


### PR DESCRIPTION
Addressed stale title fallback signal in MainHead.astro by ensuring the default title prop matches the full title format 'Alexander Härenstam | Product Manager, Developer Experience at IFS'. Character/line delta is <1% of the file, with all autonomous guardrails and automated verification checks passing.

---
*PR created automatically by Jules for task [1144444240676739678](https://jules.google.com/task/1144444240676739678) started by @alehar9320*