### PR TITLE
Janitor: Typo & Terminology Alignment

### DIFF
--- a/.Jules/Janitor/hygiene.md
+++ b/.Jules/Janitor/hygiene.md
@@ -6,6 +6,7 @@
 | 2025-03-24 | worker-configuration.d.ts         | Removed 'the the' typos from documentation comments                                      | Validated   |
 | 2025-03-24 | context/author-linkedin.md        | Normalized Swedish terms (Produktchef, Produktledning) and removed duplicate text blocks | Validated   |
 | 2025-03-24 | src/content/work/master-thesis.md | Improved grammatical phrasing in the concluding paragraph                                | Validated   |
+| 2025-03-30 | src/components/Chat.astro, src/utils/chat-logic.ts | Normalized 'IFS design system' to 'IFS Design System' title case for repository-wide terminology alignment | Validated   |
 
 ## Spelling Exceptions
 

--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -779,7 +779,7 @@ describe('identity copy', () => {
     expect(chat).toContain('id="chat-clear"');
     expect(chat).toContain('chat-followups');
     expect(chat).toContain('How do I get in touch on LinkedIn?');
-    expect(chat).toContain('What did the IFS design system change?');
+    expect(chat).toContain('What did the IFS Design System change?');
     expect(chat).toContain("I'm an AI with his context.");
     expect(chat).not.toContain('Ask about the work');
     expect(chat).toContain('prefers-reduced-motion: reduce');
@@ -901,7 +901,7 @@ describe('identity copy', () => {
     expect(chat).toContain('id="chat-clear"');
     expect(chat).toContain('chat-followups');
     expect(chat).toContain('How do I get in touch on LinkedIn?');
-    expect(chat).toContain('What did the IFS design system change?');
+    expect(chat).toContain('What did the IFS Design System change?');
     expect(chat).toContain("I'm an AI with his context.");
     expect(nav).toContain('hsla(var(--gray-999-basis), 0.9)');
     expect(nav).toContain('backdrop-filter: blur(40px) saturate(140%)');
@@ -1051,7 +1051,7 @@ describe('identity copy', () => {
     expect(chat).toContain('id="chat-clear"');
     expect(chat).toContain('chat-followups');
     expect(chat).toContain('How do I get in touch on LinkedIn?');
-    expect(chat).toContain('What did the IFS design system change?');
+    expect(chat).toContain('What did the IFS Design System change?');
     expect(chat).toContain("I'm an AI with his context.");
     expect(nav).toContain('hsla(var(--gray-999-basis), 0.9)');
     expect(nav).toContain('backdrop-filter: blur(40px) saturate(140%)');

--- a/src/components/Chat.astro
+++ b/src/components/Chat.astro
@@ -70,7 +70,7 @@
       </section>
       <div id="chat-suggestions" class="chat-suggestions">
         <button type="button" class="chat-suggestion">
-          What did the IFS design system change?
+          What did the IFS Design System change?
         </button>
         <button type="button" class="chat-suggestion">How do you work as a PM?</button>
         <button type="button" class="chat-suggestion">What's the Industrial AI bet?</button>
@@ -888,7 +888,7 @@
 
   const FOLD_DISMISSED_KEY = 'chat-fold-dismissed';
   const FOLLOW_UP_PROMPTS = [
-    'What did the IFS design system change?',
+    'What did the IFS Design System change?',
     'How do you work as a PM?',
     "What's the Industrial AI bet?",
     'How do I get in touch on LinkedIn?',

--- a/src/utils/chat-logic.ts
+++ b/src/utils/chat-logic.ts
@@ -52,7 +52,7 @@ export function pruneMessages(messages: ChatMessage[]): ChatMessage[] {
   return start > 0 ? windowed.slice(start) : windowed;
 }
 
-export const DESIGN_SYSTEM_CHIP = 'What did the IFS design system change?';
+export const DESIGN_SYSTEM_CHIP = 'What did the IFS Design System change?';
 
 export const DESIGN_SYSTEM_PROOF =
   'The IFS Design System delivered up to 2x faster delivery and up to 30x ROI, and was a Zeroheight runner-up.';


### PR DESCRIPTION
Aligns internal terminology by normalizing 'IFS design system' to proper title case 'IFS Design System' across prompt chips, default suggestions, and unit tests, and records the update in the Janitor hygiene journal.

---
*PR created automatically by Jules for task [5849113606233849257](https://jules.google.com/task/5849113606233849257) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized the product name to “IFS Design System” across chat suggestions, follow-up prompts, and quick-action text.
* **Tests**
  * Updated chat expectation checks to reflect the standardized product name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->