### PR TITLE
⚙️ Engine: Single-Pass Edge Visitor Changelog Formatting

### DIFF
--- a/.Jules/engine.md
+++ b/.Jules/engine.md
@@ -17,3 +17,9 @@
 - **Performance & Edge Memory:** Refactored `processBufferedText` in `src/utils/chat-stream.ts` to use pointer-based `indexOf('\n', startPos)` traversal instead of `combined.split('\n')`.
 - **Allocation Reduction:** Eliminates dynamic string array allocations on incoming SSE response stream chunks in Cloudflare Workers V8 runtime while retaining complete handling for multi-line data lines, CRLF endings, and trailing partial lines.
 - **Verification:** Added Vitest unit test cases for single-character streaming, multi-line SSE payloads across chunks, and empty pushes.
+
+## 2025-06-04 - Single-Pass Edge Visitor Changelog Formatting
+
+- **Performance & Edge Memory:** Refactored `toVisitorReleaseBody` in `src/utils/visitor-changelog.ts` from a multi-stage array pipeline (`.split().map().filter().map().filter()`) into a single-pass `for...of` loop over lines.
+- **Allocation Reduction:** Hoisted static regular expressions (`LIST_ITEM_PREFIX`, `MULTI_SPACE`) to module scope, avoiding re-instantiation and dynamic intermediate array allocations during edge rendering of `/api/releases` and `/whats-new`.
+- **Verification & Test Coverage:** Created a dedicated Vitest test suite (`src/utils/visitor-changelog.test.ts`) covering `stripChangelogChrome`, `toVisitorChangelogTitle`, `toVisitorReleaseBody`, and `toVisitorRelease` with 14 unit test cases.

--- a/src/utils/visitor-changelog.test.ts
+++ b/src/utils/visitor-changelog.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import {
+  stripChangelogChrome,
+  toVisitorChangelogTitle,
+  toVisitorRelease,
+  toVisitorReleaseBody,
+} from './visitor-changelog';
+
+describe('visitor-changelog utils', () => {
+  describe('stripChangelogChrome', () => {
+    it('strips commit hash prefixes', () => {
+      expect(stripChangelogChrome('41fe7ae rewrite What’s New')).toBe('rewrite What’s New');
+      expect(
+        stripChangelogChrome('a1b2c3d4e5f6789012345678901234567890a1b2 rewrite What’s New')
+      ).toBe('rewrite What’s New');
+    });
+
+    it('strips conventional commit prefixes', () => {
+      expect(stripChangelogChrome('feat: add RSS feed')).toBe('add RSS feed');
+      expect(stripChangelogChrome('fix(sitemap): drop 404 links')).toBe('drop 404 links');
+      expect(stripChangelogChrome('chore: update dependencies')).toBe('update dependencies');
+    });
+
+    it('strips PR number suffix', () => {
+      expect(stripChangelogChrome('add RSS feed (#520)')).toBe('add RSS feed');
+    });
+
+    it('strips combination of SHA, conventional commit prefix, and PR suffix', () => {
+      expect(stripChangelogChrome('515bbf9 feat: add a live RSS feed for the work (#520)')).toBe(
+        'add a live RSS feed for the work'
+      );
+    });
+
+    it('collapses internal extra spaces', () => {
+      expect(stripChangelogChrome('feat:   add   a   live   sitemap   ')).toBe(
+        'add a live sitemap'
+      );
+    });
+  });
+
+  describe('toVisitorChangelogTitle', () => {
+    it('maps known PR numbers to human visitor titles', () => {
+      expect(toVisitorChangelogTitle('515bbf9 feat: add a live RSS feed for the work (#520)')).toBe(
+        'RSS feed of the work'
+      );
+      expect(toVisitorChangelogTitle('41fe7ae feat: rewrite /experimental/now/ (#523)')).toBe(
+        'Now page rewritten for visitors'
+      );
+    });
+
+    it('maps known subjects when PR suffix is absent', () => {
+      expect(toVisitorChangelogTitle('feat: add a live RSS feed for the work')).toBe(
+        'RSS feed of the work'
+      );
+    });
+
+    it('title-cases sanitized unknown commit messages', () => {
+      expect(toVisitorChangelogTitle('feat: optimize edge rendering pipeline')).toBe(
+        'Optimize edge rendering pipeline'
+      );
+    });
+
+    it('returns empty string for empty input', () => {
+      expect(toVisitorChangelogTitle('')).toBe('');
+      expect(toVisitorChangelogTitle('   ')).toBe('');
+    });
+  });
+
+  describe('toVisitorReleaseBody', () => {
+    it('formats multi-line list release bodies into visitor titles', () => {
+      const rawBody = `
+- 515bbf9 feat: add a live RSS feed for the work (#520)
+- 62dd4d6 fix: drop sitemap URLs that 404 (#521)
+* 41fe7ae feat: rewrite /experimental/now/ for visitors (#523)
+`;
+      const result = toVisitorReleaseBody(rawBody);
+      expect(result).toBe(
+        `- RSS feed of the work\n- Sitemap no longer lists pages that 404\n- Now page rewritten for visitors`
+      );
+    });
+
+    it('filters out internal agent/changelog items', () => {
+      const rawBody = `
+- 515bbf9 feat: add a live RSS feed for the work (#520)
+- e1f2g3h chore: jules refactored parser logic
+- 41fe7ae feat: rewrite /experimental/now/ for visitors (#523)
+- a1b2c3d fix: agent-farm performance tweak
+`;
+      const result = toVisitorReleaseBody(rawBody);
+      expect(result).toBe(`- RSS feed of the work\n- Now page rewritten for visitors`);
+    });
+
+    it('falls back to single visitor title for non-list release body', () => {
+      expect(toVisitorReleaseBody('2026.08.16.2111')).toBe('2026.08.16.2111');
+      expect(toVisitorReleaseBody('feat: add a live RSS feed for the work (#520)')).toBe(
+        'RSS feed of the work'
+      );
+    });
+
+    it('returns empty string for empty input', () => {
+      expect(toVisitorReleaseBody('')).toBe('');
+    });
+  });
+
+  describe('toVisitorRelease', () => {
+    it('preserves release attributes while formatting body', () => {
+      const release = {
+        version: '2026.08.16.2111',
+        title: 'Release 2026.08.16.2111',
+        publishedAt: '2026-08-16T21:12:02Z',
+        url: 'https://github.com/alehar9320/astro-cloudflare-personal-website/releases/tag/2026.08.16.2111',
+        body: '- 515bbf9 feat: add a live RSS feed for the work (#520)',
+        extraProp: 123,
+      };
+
+      const result = toVisitorRelease(release);
+      expect(result).toEqual({
+        version: '2026.08.16.2111',
+        title: 'Release 2026.08.16.2111',
+        publishedAt: '2026-08-16T21:12:02Z',
+        url: 'https://github.com/alehar9320/astro-cloudflare-personal-website/releases/tag/2026.08.16.2111',
+        body: '- RSS feed of the work',
+        extraProp: 123,
+      });
+    });
+  });
+});

--- a/src/utils/visitor-changelog.ts
+++ b/src/utils/visitor-changelog.ts
@@ -178,6 +178,8 @@ const SHA_PREFIX = /^[a-f0-9]{7,40}\s+/i;
 const CONVENTIONAL_PREFIX =
   /^(feat|fix|chore|docs|refactor|test|style|perf|build|ci)(\([^)]+\))?:\s*/i;
 const PR_SUFFIX = /\s*\(#(\d+)\)\s*$/;
+const MULTI_SPACE = /\s{2,}/g;
+const LIST_ITEM_PREFIX = /^[-*+]\s+/;
 
 /**
  * Strip SHA, conventional-commit type, and trailing (#123) from a changelog line.
@@ -188,7 +190,7 @@ export function stripChangelogChrome(raw: string): string {
     .replace(SHA_PREFIX, '')
     .replace(CONVENTIONAL_PREFIX, '')
     .replace(PR_SUFFIX, '')
-    .replace(/\s{2,}/g, ' ')
+    .replace(MULTI_SPACE, ' ')
     .trim();
 }
 
@@ -225,21 +227,28 @@ export function toVisitorChangelogTitle(raw: string): string {
 
 /**
  * Rewrite a GitHub release body so list items are visitor copy, not SHA + feat + (#PR).
+ * Single-pass implementation to eliminate intermediate array and string allocations on Edge runtimes.
  */
 export function toVisitorReleaseBody(body: string): string {
-  const items = body
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => /^[-*+]\s+/.test(line))
-    .map((line) => line.replace(/^[-*+]\s+/, ''))
-    .filter((message) => !INTERNAL_CHANGELOG_ITEM.test(message));
+  const lines = body.split('\n');
+  const items: string[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!LIST_ITEM_PREFIX.test(trimmed)) continue;
+
+    const message = trimmed.replace(LIST_ITEM_PREFIX, '');
+    if (INTERNAL_CHANGELOG_ITEM.test(message)) continue;
+
+    items.push(`- ${toVisitorChangelogTitle(message)}`);
+  }
 
   if (items.length === 0) {
     const trimmed = body.trim();
     return trimmed ? toVisitorChangelogTitle(trimmed) : '';
   }
 
-  return items.map((message) => `- ${toVisitorChangelogTitle(message)}`).join('\n');
+  return items.join('\n');
 }
 
 /**


### PR DESCRIPTION
Refactored toVisitorReleaseBody in src/utils/visitor-changelog.ts to use a single-pass loop, hoisted static RegExp instances to module scope, added unit test suite src/utils/visitor-changelog.test.ts, and updated Engine journal.

---
*PR created automatically by Jules for task [723413822062440377](https://jules.google.com/task/723413822062440377) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the efficiency and consistency of release changelog formatting.
  - Preserved existing handling of list items, internal entries, whitespace, and visitor-friendly titles.

- **Tests**
  - Added comprehensive automated coverage for changelog cleanup, title generation, release body formatting, and preservation of release details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->