### PR TITLE
🎨 Palette: Standardize focus-visible states and touch targets in Footer and BaseLayout

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,5 +1,11 @@
 # Palette 🎨 - UX & Accessibility Journal
 
+## 2026-05-24 - Focus-Visible Standardization & Mobile Touch Target Ergonomics
+
+**Learning:** Replacing raw `:focus` pseudo-classes with `:focus-visible` across footer version links (`.version-link`) and accessibility skip links (`.sr-only.focus-visible`) prevents sticky, persistent focus rings during mouse click interactions while preserving essential keyboard focus indicators. Furthermore, declaring explicit `min-height: 44px; display: inline-flex; align-items: center;` on interactive colophon triggers (`.visit-trigger`) ensures mobile touch targets comply with WCAG 2.1 AA requirements on touch viewports without causing layout shift.
+
+**Action:** Updated `.version-link` in `Footer.astro` and `.sr-only.focus-visible` in `BaseLayout.astro` to use `:focus-visible`. Added `min-height: 44px; display: inline-flex; align-items: center;` to `.visit-trigger` in `Footer.astro`.
+
 ## 2026-05-23 - Compact Overlay Control Focus Containment & Touch Target Standard
 
 **Learning:** Compact overlay controls inside constrained components (such as `.chat-clear`, `.chat-close`, and suggestion chips in `Chat.astro`) require tight focus ring containment (`outline-offset: 2px`) to prevent focus outlines from overflowing overlay bounds or clipping against scroll container edges. Furthermore, ensuring all action controls maintain WCAG touch target dimensions (`min-height: 44px; min-width: 44px`) with `display: inline-flex; align-items: center; justify-content: center;` and gated tactile feedback (`transform: scale(0.96)`) under `@media (prefers-reduced-motion: no-preference)` delivers an accessible, highly responsive experience across touch and keyboard interactions.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -241,7 +241,7 @@ const currentYear = new Date().getFullYear();
   }
 
   .version-link:hover,
-  .version-link:focus {
+  .version-link:focus-visible {
     color: var(--gray-200);
   }
 
@@ -274,7 +274,9 @@ const currentYear = new Date().getFullYear();
   }
 
   .visit-trigger {
-    display: inline;
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
     appearance: none;
     -webkit-appearance: none;
     margin: 0;

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -255,7 +255,7 @@ const { title, description, ogTitle, shareUrl, canonicalUrl, robots } = Astro.pr
         white-space: nowrap;
       }
 
-      .sr-only.focus-visible:focus {
+      .sr-only.focus-visible:focus-visible {
         clip: auto;
         height: auto;
         margin: auto;


### PR DESCRIPTION
Standardizes focus-visible states across Footer.astro and BaseLayout.astro while ensuring mobile touch target compliance for colophon visit triggers.

---
*PR created automatically by Jules for task [5221320373550552568](https://jules.google.com/task/5221320373550552568) started by @alehar9320*