### PR TITLE
Janitor: Typo & Terminology Alignment

### DIFF
--- a/.Jules/Janitor/hygiene.md
+++ b/.Jules/Janitor/hygiene.md
@@ -7,6 +7,7 @@
 | 2025-03-24 | context/author-linkedin.md        | Normalized Swedish terms (Produktchef, Produktledning) and removed duplicate text blocks | Validated   |
 | 2025-03-24 | src/content/work/master-thesis.md | Improved grammatical phrasing in the concluding paragraph                                | Validated   |
 | 2025-03-30 | src/components/Chat.astro, src/utils/chat-logic.ts | Normalized 'IFS design system' to 'IFS Design System' title case for repository-wide terminology alignment | Validated   |
+| 2026-08-24 | worker-configuration.d.ts         | Corrected double articles and phrasing in JSDoc comments                                 | Validated   |
 
 ## Spelling Exceptions
 

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -35,7 +35,7 @@ declare var onmessage: never;
 declare class DOMException extends Error {
   constructor(message?: string, name?: string);
   /**
-   * The **`message`** read-only property of the a message or description associated with the given error name.
+   * The **`message`** read-only property of a message or description associated with the given error name.
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/DOMException/message)
    */
@@ -1506,7 +1506,7 @@ interface ErrorEventErrorEventInit {
 declare class MessageEvent extends Event {
   constructor(type: string, initializer: MessageEventInit);
   /**
-   * The **`data`** read-only property of the The data sent by the message emitter; this can be any data type, depending on what originated this event.
+   * The **`data`** read-only property of the data sent by the message emitter; this can be any data type, depending on what originated this event.
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/data)
    */
@@ -1524,7 +1524,7 @@ declare class MessageEvent extends Event {
    */
   readonly lastEventId: string;
   /**
-   * The **`source`** read-only property of the a WindowProxy, MessagePort, or a `MessageEventSource` (which can be a WindowProxy, message emitter.
+   * The **`source`** read-only property of a WindowProxy, MessagePort, or a `MessageEventSource` (which can be a WindowProxy, message emitter.
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/source)
    */


### PR DESCRIPTION
This PR corrects JSDoc comment typos in worker-configuration.d.ts ("property of the a message" -> "property of a message", "property of the The data" -> "property of the data", "property of the a WindowProxy" -> "property of a WindowProxy") and records the update in .Jules/Janitor/hygiene.md.

---
*PR created automatically by Jules for task [16690679574926181877](https://jules.google.com/task/16690679574926181877) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected grammatical errors in API reference comments for exception messages and message event properties.
  - No functional, type, or API behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->