### PR TITLE
feat: add GitHub DORA metrics section to /okr/ (#883)

### DIFF
--- a/src/__tests__/identity.test.ts
+++ b/src/__tests__/identity.test.ts
@@ -2807,4 +2807,31 @@ describe('identity copy', () => {
     expect(contact).toContain('min-height: 44px');
     expect(contact).toContain('min-width: 44px');
   });
+
+  it('shows How shipping holds up DORA metrics on /okr/ (#883)', () => {
+    const data = readFileSync('src/data/okr-h2-2026.ts', 'utf8');
+    const page = readFileSync('src/pages/okr.astro', 'utf8');
+    expect(data).toContain('export const DORA_METRICS');
+    expect(data).toContain("id: 'dora-deploy'");
+    expect(data).toContain("id: 'dora-lead'");
+    expect(data).toContain("id: 'dora-cfr'");
+    expect(data).toContain("id: 'dora-restore'");
+    expect(data).toContain("label: 'Ships to production (deployment frequency)'");
+    expect(data).toContain("label: 'Time from PR open to merge (lead time for changes)'");
+    expect(data).toContain(
+      "label: 'Failed production CI / production ships (change failure rate)'"
+    );
+    expect(data).toContain(
+      "label: 'Time from failed main CI to next green main CI (time to restore)'"
+    );
+    expect(data).toContain("targetLabel: '—'");
+    expect(data).toContain("direction: 'none'");
+    expect(data).not.toContain("currentLabel: 'TODO'");
+    expect(data).not.toContain("baselineLabel: 'TODO'");
+    expect(data).toContain("currentLabel: '48'");
+    expect(page).toContain('DORA_METRICS');
+    expect(page).toContain('aria-labelledby="dora"');
+    expect(page).toContain('<h2 id="dora">How shipping holds up</h2>');
+    expect(page).not.toContain('mailto:');
+  });
 });

--- a/src/data/okr-h2-2026.ts
+++ b/src/data/okr-h2-2026.ts
@@ -10,6 +10,13 @@
  *   No localhost / *-me.alehar.workers.dev preview hosts.
  * - Contact-card: $autocapture with element href containing linkedin.com OR element text
  *   containing "Get in touch", same host + Linux-exclude. Unique persons.
+ *
+ * GitHub DORA recipes (production only, repo alehar9320/astro-cloudflare-personal-website, last 7 days window):
+ * - Ships to production: count of PRs state=MERGED base=main with mergedAt in last 7 days.
+ * - Lead time: median hours of (mergedAt − createdAt) for that same 7-day merged-to-main set.
+ * - Change failure rate: failed CI workflow runs (.github/workflows/ci.yml) event=push head_branch=main in last 7 days,
+ *   divided by total CI runs on push/main in window. Revert PRs count as fails if CI stayed green.
+ * - Time to restore: median hours from failed push/main CI run to next green push/main CI run. If 0 fails, Current is '0 fails'.
  */
 
 export type ProgressDirection = 'up' | 'down' | 'none';
@@ -107,6 +114,57 @@ export const OBJECTIVES: readonly Objective[] = [
       },
     ],
     supporting: ['At least half of weekly merges visitor-facing, for 8 weeks before year-end'],
+  },
+];
+
+export const DORA_METRICS: readonly KeyResult[] = [
+  {
+    id: 'dora-deploy',
+    label: 'Ships to production (deployment frequency)',
+    window: '7 days',
+    baselineLabel: '33',
+    currentLabel: '29',
+    targetLabel: '—',
+    baseline: 33,
+    current: 29,
+    target: 0,
+    direction: 'none',
+  },
+  {
+    id: 'dora-lead',
+    label: 'Time from PR open to merge (lead time for changes)',
+    window: '7 days',
+    baselineLabel: '0.2h',
+    currentLabel: '0.2h',
+    targetLabel: '—',
+    baseline: 0.2,
+    current: 0.2,
+    target: 0,
+    direction: 'none',
+  },
+  {
+    id: 'dora-cfr',
+    label: 'Failed production CI / production ships (change failure rate)',
+    window: '7 days',
+    baselineLabel: '0%',
+    currentLabel: '0%',
+    targetLabel: '—',
+    baseline: 0,
+    current: 0,
+    target: 0,
+    direction: 'none',
+  },
+  {
+    id: 'dora-restore',
+    label: 'Time from failed main CI to next green main CI (time to restore)',
+    window: '7 days',
+    baselineLabel: '0 fails',
+    currentLabel: '0 fails',
+    targetLabel: '—',
+    baseline: 0,
+    current: 0,
+    target: 0,
+    direction: 'none',
   },
 ];
 

--- a/src/pages/okr.astro
+++ b/src/pages/okr.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import ContactCTA from '../components/ContactCTA.astro';
 import Hero from '../components/Hero.astro';
-import { OBJECTIVES, progressTowardTarget } from '../data/okr-h2-2026';
+import { DORA_METRICS, OBJECTIVES, progressTowardTarget } from '../data/okr-h2-2026';
 
 const pageTitle = 'Site success | Product Manager, Developer Experience at IFS';
 const dek = 'How this site is measured through the end of 2026. Progress against real baselines.';
@@ -64,6 +64,49 @@ const meta = 'H2 2026 · baselines frozen 29 Aug 2026 · current refreshed weekl
           </section>
         ))
       }
+      <section class="objective" aria-labelledby="dora">
+        <h2 id="dora">How shipping holds up</h2>
+        {
+          DORA_METRICS.map((kr) => {
+            const pct = progressTowardTarget(kr);
+            return (
+              <article class="kr" aria-labelledby={`${kr.id}-label`}>
+                <p class="kr-head">
+                  <span id={`${kr.id}-label`}>{kr.label}</span>
+                  <span class="kr-window">{kr.window}</span>
+                </p>
+                <dl class="kr-cols">
+                  <div>
+                    <dt>Baseline</dt>
+                    <dd>{kr.baselineLabel}</dd>
+                  </div>
+                  <div>
+                    <dt>Current</dt>
+                    <dd>{kr.currentLabel}</dd>
+                  </div>
+                  <div>
+                    <dt>Target</dt>
+                    <dd>{kr.targetLabel}</dd>
+                  </div>
+                </dl>
+                {pct !== null && (
+                  <div
+                    class="kr-bar"
+                    role="progressbar"
+                    aria-valuemin="0"
+                    aria-valuemax="100"
+                    aria-valuenow={Math.round(pct)}
+                    aria-label={`${kr.label} progress`}
+                  >
+                    <span class="kr-bar-fill" style={`width: ${Math.min(100, pct)}%`} />
+                  </div>
+                )}
+                {kr.note && <p class="kr-note">{kr.note}</p>}
+              </article>
+            );
+          })
+        }
+      </section>
     </main>
     <ContactCTA />
   </div>


### PR DESCRIPTION
Implement GitHub issue #883: Visitors on /okr/ can read GitHub DORA metrics: deployment frequency, lead time, change failure rate, and time to restore. Adds DORA_METRICS export to src/data/okr-h2-2026.ts, renders section in src/pages/okr.astro, and adds corresponding unit test in src/__tests__/identity.test.ts.

---
*PR created automatically by Jules for task [15732472506545007292](https://jules.google.com/task/15732472506545007292) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “How shipping holds up” section to the OKR page.
  - Displays four delivery performance metrics: deployment frequency, lead time, change failure rate, and time to restore.
  - Includes current values, measurement windows, targets, progress indicators where available, and supporting notes.

- **Tests**
  - Added coverage verifying the new metrics and OKR page section render correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->