### PR TITLE
🎨 Palette: Theme Toggle Touch Target Ergonomics & Focus Containment

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,5 +1,11 @@
 # Palette 🎨 - UX & Accessibility Journal
 
+## 2026-05-25 - Theme Toggle Touch Target Ergonomics & Focus Containment
+
+**Learning:** Compact pill controls located within constrained header/navigation layouts (such as `ThemeToggle.astro` in `Nav.astro`) require explicit minimum dimensions (`min-width: 44px; min-height: 44px; align-items: center; justify-content: center;`) to satisfy WCAG 2.1 AA touch target standards on mobile viewports. Furthermore, switching from positive `outline-offset: 2px` to negative inset focus containment (`outline-offset: -2px`) prevents the focus ring from overflowing outer header borders or clipping against adjacent layout elements during keyboard navigation.
+
+**Action:** Enforced `min-width: 44px; min-height: 44px; display: flex; align-items: center; justify-content: center;` and `outline-offset: -2px` for `button:focus-visible` in `src/components/ThemeToggle.astro`.
+
 ## 2026-05-24 - Focus-Visible Standardization & Mobile Touch Target Ergonomics
 
 **Learning:** Replacing raw `:focus` pseudo-classes with `:focus-visible` across footer version links (`.version-link`) and accessibility skip links (`.sr-only.focus-visible`) prevents sticky, persistent focus rings during mouse click interactions while preserving essential keyboard focus indicators. Furthermore, declaring explicit `min-height: 44px; display: inline-flex; align-items: center;` on interactive colophon triggers (`.visit-trigger`) ensures mobile touch targets comply with WCAG 2.1 AA requirements on touch viewports without causing layout shift.

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -16,6 +16,10 @@ const isTactileEnabled = flagsEntry?.data.enable_theme_toggle_tactile_v1 ?? fals
 <style>
   button {
     display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 44px;
+    min-height: 44px;
     border: 0;
     border-radius: 999rem;
     padding: 0;
@@ -38,7 +42,7 @@ const isTactileEnabled = flagsEntry?.data.enable_theme_toggle_tactile_v1 ?? fals
 
   button:focus-visible {
     outline: 2px solid var(--accent-regular);
-    outline-offset: 2px;
+    outline-offset: -2px;
   }
 
   .icon {


### PR DESCRIPTION
Implements WCAG 2.1 AA minimum 44x44px touch target dimensions on the theme toggle button and applies inset focus ring containment (`outline-offset: -2px`) to prevent outline overflow in constrained header layouts.

---
*PR created automatically by Jules for task [1100458224330873313](https://jules.google.com/task/1100458224330873313) started by @alehar9320*