### PR TITLE
Janitor: Typo & Terminology Alignment

### DIFF
--- a/.Jules/Janitor/hygiene.md
+++ b/.Jules/Janitor/hygiene.md
@@ -7,6 +7,7 @@
 | 2025-03-24 | context/author-linkedin.md        | Normalized Swedish terms (Produktchef, Produktledning) and removed duplicate text blocks | Validated   |
 | 2025-03-24 | src/content/work/master-thesis.md | Improved grammatical phrasing in the concluding paragraph                                | Validated   |
 | 2025-03-30 | src/components/Chat.astro, src/utils/chat-logic.ts | Normalized 'IFS design system' to 'IFS Design System' title case for repository-wide terminology alignment | Validated   |
+| 2026-05-18 | worker-configuration.d.ts         | Removed repeated word 'the The' in JSDoc comment for MessageEvent.data                     | Validated   |
 
 ## Spelling Exceptions
 

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -1506,7 +1506,7 @@ interface ErrorEventErrorEventInit {
 declare class MessageEvent extends Event {
   constructor(type: string, initializer: MessageEventInit);
   /**
-   * The **`data`** read-only property of the The data sent by the message emitter; this can be any data type, depending on what originated this event.
+   * The **`data`** read-only property of the data sent by the message emitter; this can be any data type, depending on what originated this event.
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/data)
    */


### PR DESCRIPTION
Corrected a repeated word typo ('the The' -> 'the') in JSDoc comments inside worker-configuration.d.ts and recorded the correction in .Jules/Janitor/hygiene.md.

---
*PR created automatically by Jules for task [17540318213046472437](https://jules.google.com/task/17540318213046472437) started by @alehar9320*