### PR TITLE
🎨 Palette: Page Link Touch Target Ergonomics

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,5 +1,11 @@
 # Palette 🎨 - UX & Accessibility Journal
 
+## 2026-05-26 - Page Link Touch Target Ergonomics
+
+**Learning:** Section list links (such as `.earlier a` in `work.astro`) and standalone page action links (such as `.history-link` in `whats-new.astro` and `.hire-cta a`) often render as compact inline links on mobile viewports, failing WCAG 2.1 AA 44x44px minimum touch target requirements and risking mis-taps. Setting `display: inline-flex; align-items: center; min-height: 44px;` expands the interactive tap area without disrupting surrounding line rhythm.
+
+**Action:** Added `display: inline-flex; align-items: center; min-height: 44px;` to `:global(.history-link)` in `whats-new.astro` and `.earlier a` / `.hire-cta a` in `work.astro`.
+
 ## 2026-05-25 - Theme Toggle Touch Target Ergonomics & Focus Containment
 
 **Learning:** Compact pill controls located within constrained header/navigation layouts (such as `ThemeToggle.astro` in `Nav.astro`) require explicit minimum dimensions (`min-width: 44px; min-height: 44px; align-items: center; justify-content: center;`) to satisfy WCAG 2.1 AA touch target standards on mobile viewports. Furthermore, switching from positive `outline-offset: 2px` to negative inset focus containment (`outline-offset: -2px`) prevents the focus ring from overflowing outer header borders or clipping against adjacent layout elements during keyboard navigation.

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -139,7 +139,7 @@ const currentYear = new Date().getFullYear();
             return;
           }
           openedByHover = false;
-          setOpen(panel.hidden);
+          setOpen(Boolean(panel.hidden));
         });
 
         trigger.addEventListener('focus', () => {

--- a/src/pages/whats-new.astro
+++ b/src/pages/whats-new.astro
@@ -224,6 +224,9 @@ const schema = {
   }
 
   :global(.history-link) {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
     color: var(--link-color);
     text-decoration: 1px solid underline transparent;
     text-underline-offset: 0.25em;

--- a/src/pages/work.astro
+++ b/src/pages/work.astro
@@ -218,6 +218,9 @@ const schema = {
   }
 
   .earlier a {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
     color: var(--gray-200);
     text-decoration: 1px solid underline transparent;
     text-underline-offset: 0.25em;
@@ -248,6 +251,9 @@ const schema = {
   }
 
   .hire-cta a {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
     color: var(--gray-200);
     text-decoration: 1px solid underline transparent;
     text-underline-offset: 0.25em;


### PR DESCRIPTION
Enforces WCAG 2.1 AA 44x44px minimum touch target sizing (`min-height: 44px; display: inline-flex; align-items: center;`) on section list links in `src/pages/work.astro` (`.earlier a`, `.hire-cta a`) and standalone page action links in `src/pages/whats-new.astro` (`:global(.history-link)`). Fixes DOM `hidden` parameter type safety in `src/components/Footer.astro` and documents learnings in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [4718229596103459657](https://jules.google.com/task/4718229596103459657) started by @alehar9320*