### PR TITLE
⚡ Kinetic: Portfolio Card Image Scale Micro-Interaction

### DIFF
--- a/.Jules/kinetic.md
+++ b/.Jules/kinetic.md
@@ -10,6 +10,15 @@ Prefer distinct motion craft on a live visitor surface that is not CTA glass. Hi
 
 # Kinetic Journal ⚡
 
+## 2026-08-30 - Portfolio Preview Card Image Zoom
+
+- **Signal:** Portfolio preview cards lacked internal spatial depth during hover and focus interactions.
+- **Action:**
+  - Added hardware-accelerated image zoom transition (`transform: scale(1.05)`) with smooth `cubic-bezier(0.22, 1, 0.36, 1)` timing on `.card:hover img` and `.card:focus-visible img` in `PortfolioPreview.astro`.
+  - Enforced WCAG 2.1 AA `prefers-reduced-motion` compliance by explicitly setting `transition: none` and `transform: none` on reduced motion preferences.
+- **Tokens/Snippets Added:**
+  - Card Image Zoom: `scale(1.05)` with `transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1)`
+
 ## 2026-08-29 - CTA glass abort | Signal: closed #772/#667 | Lean Implementation: HARD ABORT CallToAction glassmorphism and micro-states
 
 ## 2025-05-15 - Interactive Glassmorphism for Skills Section

--- a/src/components/PortfolioPreview.astro
+++ b/src/components/PortfolioPreview.astro
@@ -130,6 +130,24 @@ const isShimmerEnabled = flagsEntry?.data.portfolio_shimmer_v1 ?? false;
     width: 100%;
     height: 100%;
     object-fit: cover;
+    transition: transform 0.5s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .card:hover img,
+  .card:focus-visible img {
+    transform: scale(1.05);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .card,
+    img {
+      transition: none;
+    }
+
+    .card:hover img,
+    .card:focus-visible img {
+      transform: none;
+    }
   }
 
   @media (min-width: 50em) {


### PR DESCRIPTION
Elevates the micro-interaction of portfolio preview cards (`PortfolioPreview.astro`) by adding a smooth, hardware-accelerated image zoom (`scale(1.05)`) on hover and focus-visible states. Includes explicit `prefers-reduced-motion` overrides for WCAG 2.1 AA compliance and documents the reusable CSS snippet in `.Jules/kinetic.md`.

---
*PR created automatically by Jules for task [16944523548619317541](https://jules.google.com/task/16944523548619317541) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Portfolio preview images now smoothly zoom when users hover over or keyboard-focus a card.
  * Added reduced-motion support to keep images static and disable transitions for users who prefer less animation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->