### PR TITLE
Navigate to OKR page when clicking site stats in footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -127,19 +127,8 @@ const currentYear = new Date().getFullYear();
           if (open) place();
         };
 
-        let openedByHover = false;
-
-        trigger.addEventListener('click', (event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          // DevTools 375 still reports hover:hover. pointerenter then click would
-          // toggle the panel shut. A tap should leave it open.
-          if (openedByHover && !panel.hidden) {
-            openedByHover = false;
-            return;
-          }
-          openedByHover = false;
-          setOpen(Boolean(panel.hidden));
+        trigger.addEventListener('click', () => {
+          window.location.assign('/okr/');
         });
 
         trigger.addEventListener('focus', () => {
@@ -152,18 +141,15 @@ const currentYear = new Date().getFullYear();
         });
         trigger.addEventListener('pointerenter', (event) => {
           if (event.pointerType !== 'mouse') return;
-          openedByHover = true;
           setOpen(true);
         });
         trigger.addEventListener('pointerleave', (event) => {
           if (event.pointerType !== 'mouse') return;
           if (event.relatedTarget instanceof Node && panel.contains(event.relatedTarget)) return;
-          openedByHover = false;
           setOpen(false);
         });
         panel.addEventListener('pointerleave', (event) => {
           if (event.pointerType !== 'mouse') return;
-          openedByHover = false;
           setOpen(false);
         });
 
@@ -175,7 +161,6 @@ const currentYear = new Date().getFullYear();
           const target = event.target;
           if (!(target instanceof Node)) return;
           if (trigger.contains(target) || panel.contains(target)) return;
-          openedByHover = false;
           setOpen(false);
         });
         window.addEventListener('resize', () => {


### PR DESCRIPTION
## Summary

Clicking the site-stat visit-count trigger in the footer now navigates to the OKR ("Site success") page at `/okr/` instead of toggling the popup visit panel at that location.

The visit-count popup panel is still shown on hover/focus, but a click (tap or mouse) now takes the user straight to the OKR page, where the site success metrics are explained. The opportunistic click-navigation means the panel no longer needs the click-toggle logic — `openedByHover` tracking was removed accordingly.

## Changes
- `src/components/Footer.astro`: replace click-toggle behavior with `window.location.assign('/okr/')` and remove now-unused `openedByHover` state.

## Validation
- `npm run test`: 368 tests passing
- `npm run lint`: clean
- `npm run format`: clean
- `npm run astro check`: no new errors (pre-existing error in `Footer.astro` at line 113 remains on `main` too)

This PR was created by an AI agent (OpenHands) on behalf of the repository owner.

@alehar9320 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a09d04a9-7295-446e-97c8-befe60c13f28)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Clicking the visit-count control now takes you to the OKR page.
  - Hovering over the control continues to open and close the visit overview as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->