### PR TITLE
🎨 Palette: Navigation Touch Target Ergonomics

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,5 +1,11 @@
 # Palette 🎨 - UX & Accessibility Journal
 
+## 2026-05-27 - Navigation Link Touch Target Ergonomics
+
+**Learning:** Main menu text links (`.link`) and header social icons (`.social`) in `Nav.astro` can fail WCAG 2.1 AA 44x44px minimum touch target requirements when rendered on mobile devices. Standardizing `.link` with `display: inline-flex; align-items: center; min-height: 44px;` and `.social` with `min-width: 44px; min-height: 44px; display: flex; align-items: center; justify-content: center;` prevents mis-taps on touch devices while preserving desktop layout alignment.
+
+**Action:** Added `display: inline-flex; align-items: center; min-height: 44px;` to `.link` and `min-width: 44px; min-height: 44px; align-items: center; justify-content: center;` to `.social` in `src/components/Nav.astro`.
+
 ## 2026-05-26 - Page Link Touch Target Ergonomics
 
 **Learning:** Section list links (such as `.earlier a` in `work.astro`) and standalone page action links (such as `.history-link` in `whats-new.astro` and `.hire-cta a`) often render as compact inline links on mobile viewports, failing WCAG 2.1 AA 44x44px minimum touch target requirements and risking mis-taps. Setting `display: inline-flex; align-items: center; min-height: 44px;` expands the interactive tap area without disrupting surrounding line rhythm.

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -343,7 +343,9 @@ const isCurrentPage = (href: string) => {
   }
 
   .link {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
     color: var(--gray-300);
     text-decoration: none;
     transition: transform var(--theme-transition);
@@ -433,6 +435,10 @@ const isCurrentPage = (href: string) => {
 
   .social {
     display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 44px;
+    min-height: 44px;
     padding: var(--icon-padding);
     text-decoration: none;
     color: var(--accent-dark);


### PR DESCRIPTION
Enhances main navigation text links and social icons in `Nav.astro` to satisfy WCAG 2.1 AA minimum 44x44px touch target guidelines on mobile viewports.

---
*PR created automatically by Jules for task [2767339480939162853](https://jules.google.com/task/2767339480939162853) started by @alehar9320*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved navigation link and social icon touch targets on mobile devices.
  * Added consistent centering and minimum 44×44px dimensions for easier tapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->