### PR TITLE
Janitor: Typo & Terminology Alignment

### DIFF
--- a/.Jules/Janitor/hygiene.md
+++ b/.Jules/Janitor/hygiene.md
@@ -7,6 +7,7 @@
 | 2025-03-24 | context/author-linkedin.md        | Normalized Swedish terms (Produktchef, Produktledning) and removed duplicate text blocks | Validated   |
 | 2025-03-24 | src/content/work/master-thesis.md | Improved grammatical phrasing in the concluding paragraph                                | Validated   |
 | 2025-03-30 | src/components/Chat.astro, src/utils/chat-logic.ts | Normalized 'IFS design system' to 'IFS Design System' title case for repository-wide terminology alignment | Validated   |
+| 2026-04-18 | worker-configuration.d.ts         | Removed redundant 'the' from MessageEvent.data docstring                                 | Validated   |
 
 ## Spelling Exceptions
 

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -1506,7 +1506,7 @@ interface ErrorEventErrorEventInit {
 declare class MessageEvent extends Event {
   constructor(type: string, initializer: MessageEventInit);
   /**
-   * The **`data`** read-only property of the The data sent by the message emitter; this can be any data type, depending on what originated this event.
+   * The **`data`** read-only property of the data sent by the message emitter; this can be any data type, depending on what originated this event.
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MessageEvent/data)
    */


### PR DESCRIPTION
Fix typographical error ('the The') in MessageEvent.data JSDoc comment in worker-configuration.d.ts and record update in .Jules/Janitor/hygiene.md.

---
*PR created automatically by Jules for task [15310810571376835518](https://jules.google.com/task/15310810571376835518) started by @alehar9320*