### PR TITLE
Content: Award Terminology Alignment for src/pages/experimental/now.astro

### DIFF
--- a/.Jules/content.md
+++ b/.Jules/content.md
@@ -10,3 +10,4 @@ Stay inside published facts. Hire path is LinkedIn only. Do not invent a public 
 
 ## 2026-08-29 - Invented outcome abort | Signal: closed #769/#731/#703/#654 | Lean Update: HARD ABORT invented ROI/metrics; stay on published facts
 ## 2026-09-03 - Evergreen Title Alignment | Signal: Stale | Lean Update: Aligned fallback title in MainHead.astro with exact company title ('Product Manager, Developer Experience at IFS')
+## 2026-09-10 - Award Terminology Alignment | Signal: Inconsistent | Lean Update: Aligned Zeroheight award phrasing in now.astro with published 'Zeroheight Design System Awards runner-up'

--- a/src/pages/experimental/now.astro
+++ b/src/pages/experimental/now.astro
@@ -20,7 +20,7 @@ const linkedinHref = 'https://www.linkedin.com/in/alehar/';
       <p class="lede">Design systems, DevEx, and Industrial AI.</p>
       <p class="proof">
         The <a href="/work/ifs-design-system/">IFS Design System</a>: up to 2x faster delivery,{' '}
-        up to 30x ROI, Zeroheight runner-up.
+        up to 30x ROI, Zeroheight Design System Awards runner-up.
       </p>
       <div class="actions">
         <CallToAction


### PR DESCRIPTION
Addressed inconsistent award terminology on src/pages/experimental/now.astro. Updated 'Zeroheight runner-up' to 'Zeroheight Design System Awards runner-up' to match static copy across index.astro, biography.astro, roadmap.astro, and ifs-design-system.md. Character delta is +21 characters (< 2.1% file delta). All autonomous verification checks and guardrails passed cleanly.

---
*PR created automatically by Jules for task [16709190297004245527](https://jules.google.com/task/16709190297004245527) started by @alehar9320*